### PR TITLE
Patched the cpmath and utilities setup.py files to fix broken compilation with Windows SDK

### DIFF
--- a/cellprofiler/cpmath/setup.py
+++ b/cellprofiler/cpmath/setup.py
@@ -16,6 +16,8 @@ __version__="$Revision$"
 
 from distutils.core import setup,Extension
 import os
+import sys
+is_win = sys.platform.startswith("win")
 try:
     from Cython.Distutils import build_ext
     from numpy import get_include
@@ -26,30 +28,42 @@ except ImportError:
     from numpy import get_include
 
 def configuration():
+    if is_win:
+        extra_compile_args = None
+        extra_link_args = ['/MANIFEST']
+    else:
+        extra_compile_args = ['-O3']
+        extra_link_args = None
     extensions = [Extension(name="_cpmorphology",
                             sources=["src/cpmorphology.c"],
                             include_dirs=['src']+[get_include()],
-                            extra_compile_args=['-O3']),
+                            extra_compile_args=extra_compile_args,
+                            extra_link_args=extra_link_args),
                   Extension(name="_cpmorphology2",
                             sources=["_cpmorphology2.pyx"],
                             include_dirs=[get_include()],
-                            extra_compile_args=['-O3']),
+                            extra_compile_args=extra_compile_args,
+                            extra_link_args=extra_link_args),
                   Extension(name="_watershed",
                             sources=["_watershed.pyx", "heap_watershed.pxi"],
                             include_dirs=['src']+[get_include()],
-                            extra_compile_args=['-O3']),
+                            extra_compile_args=extra_compile_args,
+                            extra_link_args=extra_link_args),
                   Extension(name="_propagate",
                             sources=["_propagate.pyx", "heap.pxi"],
                             include_dirs=['src']+[get_include()],
-                            extra_compile_args=['-O3']),
+                            extra_compile_args=extra_compile_args,
+                            extra_link_args=extra_link_args),
                   Extension(name="_filter",
                             sources=["_filter.pyx"],
                             include_dirs=['src']+[get_include()],
-                            extra_compile_args=['-O3']),
+                            extra_compile_args=extra_compile_args,
+                            extra_link_args=extra_link_args),
                   Extension(name="_lapjv",
                             sources=["_lapjv.pyx"],
                             include_dirs=['src']+[get_include()],
-                            extra_compile_args=['-O3'])
+                            extra_compile_args=extra_compile_args,
+                            extra_link_args=extra_link_args),
                   ]
     dict = { "name":"cpmath",
              "description":"algorithms for CellProfiler",

--- a/cellprofiler/utilities/setup.py
+++ b/cellprofiler/utilities/setup.py
@@ -41,11 +41,13 @@ if not hasattr(sys, 'frozen'):
 
     def configuration():
         extensions = []
+        extra_link_args = None
         if is_win:
+            extra_link_args = ['/MANIFEST']
             extensions += [Extension(name="_get_proper_case_filename",
                                      sources=["get_proper_case_filename.c"],
                                      libraries=["shlwapi", "shell32", "ole32"],
-                                     extra_compile_args=['-O3'])]
+                                     extra_link_args=extra_link_args)]
         try:
             #
             # Find JAVA_HOME, possibly from Windows registry
@@ -54,7 +56,6 @@ if not hasattr(sys, 'frozen'):
             jdk_home = find_jdk()
             logger.debug("Using jdk_home = %s"%jdk_home)
             include_dirs = [get_include()]
-            extra_link_args = None
             libraries = None
             library_dirs = None
             javabridge_sources = [ "javabridge.pyx" ]


### PR DESCRIPTION
Modified the compiler and linker command line arguments for better OS-specific behavior.

The -O3 compiler flag is invalid for the Microsoft Visual C compiler (Windows SDK versions 6.1-7.1). Though this flag is safely ignored by the compiler, it is better to be as specific as possible.
The Microsoft Visual C linker (same versions) does not automatically build the manifest file, even though the documentation suggests it does. Omitting this caused compilation to fail. Adding the "/MANIFEST" argument fixes this.
