### PR TITLE
SaveImages "Create Subdirectories" visibility

### DIFF
--- a/cellprofiler/modules/saveimages.py
+++ b/cellprofiler/modules/saveimages.py
@@ -409,7 +409,8 @@ class SaveImages(cpm.CPModule):
             if self.gray_or_color == GC_COLOR:
                 result.append(self.colormap)
         result.append(self.update_file_names)
-        result.append(self.create_subdirectories)
+        if self.file_name_method == FN_FROM_IMAGE:
+            result.append(self.create_subdirectories)
         return result
     
     @property


### PR DESCRIPTION
The "Create Subdirectories" option in SaveImages is only valid when the saved file name is based on one of the loaded images, otherwise an assertion error is generated when the module runs. I made it only become visible when the method for constructing file names is set to "From image filename".
