### PR TITLE
Fix for EnhanceEdges LoG boundary effect (Issue #407)

### DIFF
--- a/cellprofiler/modules/enhanceedges.py
+++ b/cellprofiler/modules/enhanceedges.py
@@ -160,7 +160,8 @@ class EnhanceEdges(cpm.CPModule):
         elif self.method == M_LOG:
             sigma = self.get_sigma()
             size = int(sigma * 4)+1
-            output_pixels = laplacian_of_gaussian(orig_pixels, mask, size, sigma)
+            edge_correction = laplacian_of_gaussian(np.ones(orig_pixels.shape, float) * np.mean(orig_pixels), mask, size, sigma)
+            output_pixels = laplacian_of_gaussian(orig_pixels, mask, size, sigma) - edge_correction
         elif self.method == M_PREWITT:
             if self.direction == E_ALL:
                 output_pixels = prewitt(orig_pixels)


### PR DESCRIPTION
This modification calculates the Laplacian of Gaussian (LoG) of a uniform array of the mean image value and subtracts that from the LoG of the image. Since the LoG of the uniform array is ~0 everywhere except the image edge, this removes the boundary effect without affecting the real image edges.

Addresses Issue #407
