### PR TITLE
FIX: Canny label strel now 8-connected for all architectures

### DIFF
--- a/cellprofiler/cpmath/filter.py
+++ b/cellprofiler/cpmath/filter.py
@@ -469,7 +469,7 @@ def canny(image, mask, sigma, low_threshold, high_threshold):
     # Segment the low-mask, then only keep low-segments that have
     # some high_mask component in them 
     #
-    labels,count = label(low_mask, np.ndarray((3,3),bool))
+    labels,count = label(low_mask, np.ones((3,3),bool))
     if count == 0:
         return low_mask
     


### PR DESCRIPTION
We found this bug in scikit-image a bit back, when testing the scipy.ndimage.label changes in 0.13dev. Turns out `np.ndarray((3, 3), bool)` does different things pseudo-randomly on different architectures, so it's a poor choice of a structuring element. This fix forces it to use an 8-connected neighborhood regardless of architecture.

For example, on my OSX Canopy install I get True in upper left and lower right, otherwise False... while on Win7 everything is True.

My suspicion is the original developer worked on a system where this reliably returned all True, but that just isn't the case generally. In any event, this fixes the problem.
