### PR TITLE
Fix check for subprocess.check_output.

### DIFF
--- a/external_dependencies.py
+++ b/external_dependencies.py
@@ -37,8 +37,6 @@ def check_output(*popenargs, **kwargs):
     Python 2.6.2
 
     """
-    if 'check_output' in subprocess:
-        return subprocess.check_output(*popenargs, **kwargs)
     process = subprocess.Popen(stdout=subprocess.PIPE, *popenargs, **kwargs)
     output, unused_err = process.communicate()
     retcode = process.poll()


### PR DESCRIPTION
The check for the presence of subprocess.check_output should be

```
try:
    return getattr(subprocess, "check_output")(*args, **kwargs)
except AttributeError:
    ...
```

but one may as well always override the definition.
