### PR TITLE
Update for wxWidgets 3.x 

### DIFF
--- a/cellprofiler/cellprofilerapp.py
+++ b/cellprofiler/cellprofilerapp.py
@@ -40,8 +40,6 @@ class CellProfilerApp(wx.App):
         # The wx.StandardPaths aren't available until this is set.
         from cellprofiler.utilities.version import dotted_version
         self.SetAppName('CellProfiler%s' % dotted_version)
-        
-        wx.InitAllImageHandlers()
 
         if self.show_splashbox:
             # If the splash image has alpha, it shows up transparently on

--- a/cellprofiler/cpmath/otsu.py
+++ b/cellprofiler/cpmath/otsu.py
@@ -302,7 +302,6 @@ if __name__=='__main__':
     M_LOG_TRANSFORM = wx.NewId()
     class MyApp(wx.App):
         def OnInit(self):
-            wx.InitAllImageHandlers()
             self.frame = F.CPFigureFrame(title="Otsu",subplots=(2,1))
             file_menu = self.frame.MenuBar.Menus[0][0]
             file_menu.Append(FILE_OPEN,"&Open")

--- a/cellprofiler/cpmath/zernike.py
+++ b/cellprofiler/cpmath/zernike.py
@@ -334,7 +334,6 @@ if __name__ == "__main__":
     
     class MyApp(wx.App):
         def OnInit(self):
-            wx.InitAllImageHandlers()
             self.frame = MyFrame()
             self.SetTopWindow(self.frame)
             self.frame.Show()

--- a/cellprofiler/gui/cpframe.py
+++ b/cellprofiler/gui/cpframe.py
@@ -922,8 +922,7 @@ class CPFrame(wx.Frame):
 
     def __on_preferences(self, event):
         dlg = cellprofiler.gui.preferencesdlg.PreferencesDlg()
-        dlg.show_modal()
-        dlg.Destroy()
+        dlg.Show()
 
     def __on_check_new_version(self, event):
         wx.GetApp().new_version_check(force=True)

--- a/cellprofiler/gui/cpgrid.py
+++ b/cellprofiler/gui/cpgrid.py
@@ -255,7 +255,6 @@ if __name__ == "__main__":
 
     class MyApp(wx.App):
         def OnInit(self):
-            wx.InitAllImageHandlers()
             self.frame = MyFrame()
             self.SetTopWindow(self.frame)
             self.frame.Show()

--- a/cellprofiler/gui/movieslider.py
+++ b/cellprofiler/gui/movieslider.py
@@ -467,7 +467,6 @@ if __name__ == "__main__":
 
     class MyApp(wx.App):
         def OnInit(self):
-            wx.InitAllImageHandlers()
             self.frame = MyFrame()
             self.SetTopWindow(self.frame)
             self.frame.Show()

--- a/cellprofiler/gui/preferencesdlg.py
+++ b/cellprofiler/gui/preferencesdlg.py
@@ -189,9 +189,8 @@ class PreferencesDlg(wx.Dialog):
         sizer.AddGrowableCol(3, 1)
 
         top_sizer.Add(wx.StaticLine(scrollpanel), 0, wx.EXPAND | wx.ALL, 2)
-        btnsizer = self.CreateButtonSizer(wx.OK | wx.CANCEL | wx.APPLY)
+        btnsizer = self.CreateButtonSizer(wx.OK | wx.CANCEL)
         self.Bind(wx.EVT_BUTTON, self.save_preferences, id=wx.ID_OK)
-        self.Bind(wx.EVT_BUTTON, self.save_preferences, id=wx.ID_APPLY)
 
         scrollpanel_sizer.Add(
             btnsizer, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.ALL, 5)

--- a/cellprofiler/gui/preferencesdlg.py
+++ b/cellprofiler/gui/preferencesdlg.py
@@ -388,10 +388,7 @@ class PreferencesDlg(wx.Dialog):
 if __name__=='__main__':
     class MyApp(wx.App):
         def OnInit(self):
-            wx.InitAllImageHandlers()
             dlg = PreferencesDlg()
             dlg.show_modal()
             return 1
     app = MyApp(0)
- 
-    

--- a/cellprofiler/gui/preferencesdlg.py
+++ b/cellprofiler/gui/preferencesdlg.py
@@ -87,8 +87,6 @@ class PreferencesDlg(wx.Dialog):
 
         sizer = wx.GridBagSizer(len(p),4)
         sizer.SetFlexibleDirection(wx.HORIZONTAL)
-        sizer.AddGrowableCol(1, 10)
-        sizer.AddGrowableCol(3, 1)
         top_sizer.Add(sizer,1, wx.EXPAND|wx.ALL, 5)
         index = 0
         controls = []
@@ -186,6 +184,10 @@ class PreferencesDlg(wx.Dialog):
             sizer.Add(button, (index, 3))
             self.Bind(wx.EVT_BUTTON, on_help, button)
             index += 1
+        
+        sizer.AddGrowableCol(1, 10)
+        sizer.AddGrowableCol(3, 1)
+        
         top_sizer.Add(wx.StaticLine(scrollpanel), 0, wx.EXPAND | wx.ALL, 2)
         btnsizer = wx.StdDialogButtonSizer()
         

--- a/cellprofiler/gui/preferencesdlg.py
+++ b/cellprofiler/gui/preferencesdlg.py
@@ -184,40 +184,33 @@ class PreferencesDlg(wx.Dialog):
             sizer.Add(button, (index, 3))
             self.Bind(wx.EVT_BUTTON, on_help, button)
             index += 1
-        
+
         sizer.AddGrowableCol(1, 10)
         sizer.AddGrowableCol(3, 1)
-        
+
         top_sizer.Add(wx.StaticLine(scrollpanel), 0, wx.EXPAND | wx.ALL, 2)
-        btnsizer = wx.StdDialogButtonSizer()
-        
-        btn = wx.Button(self, wx.ID_OK)
-        btn.SetDefault()
-        btnsizer.AddButton(btn)
+        btnsizer = self.CreateButtonSizer(wx.OK | wx.CANCEL | wx.APPLY)
+        self.Bind(wx.EVT_BUTTON, self.save_preferences, id=wx.ID_OK)
+        self.Bind(wx.EVT_BUTTON, self.save_preferences, id=wx.ID_APPLY)
 
-        btn = wx.Button(self, wx.ID_CANCEL)
-        btnsizer.AddButton(btn)
-        btnsizer.Realize()
-
-        self.Sizer.Add(btnsizer, 0, wx.ALIGN_CENTER_HORIZONTAL|wx.ALL, 5)
-        
-        scrollpanel.SetupScrolling(scrollToTop=False)        
+        scrollpanel_sizer.Add(
+            btnsizer, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.ALL, 5)
+        scrollpanel.SetupScrolling(scrollToTop=False)
         self.Fit()
         self.controls = controls
-    
-    
-    def show_modal(self):
-        if self.ShowModal() == wx.ID_OK:
-            p = self.get_preferences()
-            for control, (text, getter, setter, ui_info, help_text) in \
-                zip(self.controls, p):
-                if ui_info == COLOR:
-                    setter(control.BackgroundColour)
-                elif ui_info == FILEBROWSE and os.path.isfile(control.Value):
-                    setter(control.Value)
-                else:
-                    setter(control.Value)
-    
+
+    def save_preferences(self, event):
+        event.Skip()
+        p = self.get_preferences()
+        for control, (text, getter, setter, ui_info, help_text) in \
+            zip(self.controls, p):
+            if ui_info == COLOR:
+                setter(control.BackgroundColour)
+            elif ui_info == FILEBROWSE and os.path.isfile(control.Value):
+                setter(control.Value)
+            else:
+                setter(control.Value)
+
     def get_preferences(self):
         '''Get the list of preferences.
         

--- a/cellprofiler/gui/regexp_editor.py
+++ b/cellprofiler/gui/regexp_editor.py
@@ -627,9 +627,7 @@ if __name__== "__main__":
     import wx.lib.inspection
     class MyApp(wx.App):
         def OnInit(self):
-            wx.InitAllImageHandlers()
             return True
 
     app = MyApp(0)
     edit_regexp(None, "(?P<foo>foo)", "Where is the food?")
-


### PR DESCRIPTION
Hello! There are small changes for wxWidgets3.x compatibility and one bugfix for preferences dialog.

* Help window `cellprofiler.gui.htmldialog.HTMLDialog` available by click on *?* button in preferences dialog `cellprofiler.gui.preferencesdlg.PreferencesDlg` was inactive (impossible click *OK* or even just close window), because parent (`PreferencesDlg`) was modal.
    * Now `PreferencesDlg` is nonmodal with separate `save_preferences` slot called by both *OK* and *Apply* buttons.

Tested with Archlinux x64, Windows 7 x64 (Anaconda + [gohlke](http://www.lfd.uci.edu/~gohlke/pythonlibs/) libs).