### PR TITLE
Pull/1488

### DIFF
--- a/cellprofiler/gui/preferencesdlg.py
+++ b/cellprofiler/gui/preferencesdlg.py
@@ -204,11 +204,19 @@ class PreferencesDlg(wx.Dialog):
         for control, (text, getter, setter, ui_info, help_text) in \
             zip(self.controls, p):
             if ui_info == COLOR:
-                setter(control.BackgroundColour)
-            elif ui_info == FILEBROWSE and os.path.isfile(control.Value):
-                setter(control.Value)
+                value = control.BackgroundColour
+            elif ui_info == FILEBROWSE:
+                value = control.Value
+                if not os.path.isfile(value):
+                    continue
+            elif ui_info == DIRBROWSE:
+                value = control.Value
+                if not os.path.isdir(value):
+                    continue
             else:
-                setter(control.Value)
+                value = control.Value
+            if value != getter():
+                setter(value)
 
     def get_preferences(self):
         '''Get the list of preferences.

--- a/cellprofiler/preferences.py
+++ b/cellprofiler/preferences.py
@@ -1282,9 +1282,11 @@ def get_temporary_directory():
     if __temp_dir is not None:
         pass
     elif config_exists(TEMP_DIR):
-        __temp_dir = config_read(TEMP_DIR)
-    else:
-        __temp_dir = tempfile.gettempdir()
+        path = config_read(TEMP_DIR)
+        if os.path.isdir(path):
+            __temp_dir = path
+            return __temp_dir
+    __temp_dir = tempfile.gettempdir()
     return __temp_dir
 
 def set_temporary_directory(tempdir, globally=False):


### PR DESCRIPTION
Only save preferences in preferences dialog if they have changed in order to prevent saving default preferences (e.g. on mac, the default temp directory disappears after the program closes, so saving it will make CellProfiler use the old default (which no longer exists) rather than the new one.

(also testing Jenkins build of pull/*)