### PR TITLE
fixes issue #1508. The icon was being loaded from the wrong place.

### DIFF
--- a/cellprofiler/icons/__init__.py
+++ b/cellprofiler/icons/__init__.py
@@ -22,7 +22,8 @@ if hasattr(sys, 'frozen'):
     path = os.path.split(os.path.abspath(sys.argv[0]))[0]
     path = os.path.join(path, 'artwork')
 else:
-    path = __path__[0]
+    path = os.path.join(os.path.dirname(os.path.dirname(__path__[0])),
+                        'artwork')
 
 image_cache = weakref.WeakValueDictionary()
 

--- a/cellprofiler/tests/test_analysisworker.py
+++ b/cellprofiler/tests/test_analysisworker.py
@@ -327,8 +327,10 @@ class TestAnalysisWorker(unittest.TestCase):
                                      "Channel1-01-A-01.tif")
         maybe_download_example_image(["ExampleHT29"],
                                      "AS_09125_050116030001_D03f00d0.tif")
-        input_dir = os.path.join(example_images_directory(), "ExampleSBSImages")
-        output_dir = os.path.join(example_images_directory(), "ExampleHT29")
+        input_dir = os.path.normcase(
+            os.path.join(example_images_directory(), "ExampleSBSImages"))
+        output_dir = os.path.normcase(
+            os.path.join(example_images_directory(), "ExampleHT29"))
         cpprefs.set_default_image_directory(input_dir)
         input_dir = cpprefs.get_default_image_directory()
         cpprefs.set_default_output_directory(output_dir)

--- a/cellprofiler/tests/test_analysisworker.py
+++ b/cellprofiler/tests/test_analysisworker.py
@@ -339,7 +339,6 @@ class TestAnalysisWorker(unittest.TestCase):
                        cpprefs.config_read(cpprefs.DEFAULT_IMAGE_DIRECTORY),
                        cpprefs.DEFAULT_OUTPUT_DIRECTORY:
                        cpprefs.config_read(cpprefs.DEFAULT_OUTPUT_DIRECTORY)}
-        
         cpprefs.set_default_image_directory(example_images_directory())
         cpprefs.set_default_output_directory(example_images_directory())
         rep = cpanalysis.Reply(

--- a/windows_setup.py
+++ b/windows_setup.py
@@ -471,9 +471,9 @@ if do_modify:
 else:
     opts['py2exe']['dll_excludes'] += ["msvcr90.dll", "msvcm90.dll", "msvcp90.dll"]
 
-data_files += [('cellprofiler\\artwork',
-               ['cellprofiler\\artwork\\%s'%(x)
-                for x in os.listdir('cellprofiler\\artwork')
+data_files += [('artwork',
+               ['artwork\\%s'%(x)
+                for x in os.listdir('artwork')
                 if x.endswith(".png") 
                 or x.endswith(".psd") or x.endswith(".txt")]),
               ('imagej\\jars', 


### PR DESCRIPTION
This isn't an ideal fix - it doesn't deal with a proper `pip install` and where the artwork goes in that case. But it restores CellProfiler to a working state.