### PR TITLE
Fixes #1517 - BPBatch constructor's signature changed

### DIFF
--- a/BatchProfiler/GetPipeline.py
+++ b/BatchProfiler/GetPipeline.py
@@ -30,8 +30,7 @@ EXPERIMENT = "Experiment"
 
 with bputilities.CellProfilerContext():
     batch_id = BATCHPROFILER_DEFAULTS[BATCH_ID]
-    my_batch = RunBatch.BPBatch()
-    my_batch.select(batch_id)
+    my_batch = RunBatch.BPBatch.select(batch_id)
     path = RunBatch.batch_data_file_path(my_batch)
     h = HDF5Dict(path, mode="r")
     if M_USER_PIPELINE in h.second_level_names(EXPERIMENT):


### PR DESCRIPTION
GetPipeline was using an old initialization mechanism for fetching the batch and that's now updated. @dlogan, you can try the fixed version at http://imagewebrhel6/batchprofiler/cgi-bin/dev/ViewBatch.py?batch_id=15 and if that works, you can review the pull request, accept it and I'll update the official version (or you could leave it for @0x00B1 to check over) when I see that you've merged.