### PR TITLE
Fixes #1573 slf4j-simple excluded from POM

### DIFF
--- a/cpnose.py
+++ b/cpnose.py
@@ -29,7 +29,7 @@ from nose.util import resolve_name
 from nose.plugins.manager import PluginManager
 
 from cellprofiler.utilities.cpjvm import \
-     get_path_to_jars, get_jars, get_patcher_args
+     get_path_to_jars, get_jars, get_patcher_args, add_logback_xml_arg
 
 import numpy as np
 np.seterr(all='ignore')
@@ -58,6 +58,7 @@ class CPShutdownPlugin(nose.plugins.Plugin):
                 "-Djava.util.prefs.PreferencesFactory="+
                 "org.cellprofiler.headlesspreferences"+
                 ".HeadlessPreferencesFactory"]
+            add_logback_xml_arg(jvm_args)
             #
             # Find the ij1patcher
             #
@@ -87,6 +88,7 @@ class CPShutdownPlugin(nose.plugins.Plugin):
             self.temp_exampleimages = None
         else:
             self.temp_exampleimages = tempfile.mkdtemp(prefix="cpexampleimages")
+            os.environ["CP_EXAMPLEIMAGES"] = self.temp_exampleimages
 
         if "CP_TEMPIMAGES" in os.environ:
             self.temp_images = None

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -144,6 +144,10 @@
 	 			<artifactId>javassist</artifactId>
 	 			<groupId>javassist</groupId>
 	 		</exclusion>
+	 		<exclusion>
+	 			<artifactId>slf4j-simple</artifactId>
+	 			<groupId>org.slf4j</groupId>
+	 		</exclusion>
 	 	</exclusions>
  	</dependency>
  	<!-- 


### PR DESCRIPTION
@0x00B1 this gets rid of the SLF4J binding message and it uses the correct logger. In addition, I've added a more flexible way of specifying the location of the logging file "logback.xml". It looks in the following places (in this order):

./logback.xml
cellprofiler/utilities/logback.xml (relative to CellProfiler root dir)
java/src/main/resources/logback.xml

The error, `Warning:  org.apache.xerces.parsers.SAXParser: Property 'http://www.oracle.com/xml/jaxp/properties/entityExpansionLimit' is not recognized.` is not handled by Java logging. See http://bugs.java.com/view_bug.do?bug_id=8016153