### PR TITLE
issue #1639 neighbors can get unfairly excluded if there are missing objects

### DIFF
--- a/cellprofiler/modules/measureobjectneighbors.py
+++ b/cellprofiler/modules/measureobjectneighbors.py
@@ -217,7 +217,8 @@ class MeasureObjectNeighbors(cpm.CPModule):
         has_pixels = objects.areas > 0
         labels = objects.small_removed_segmented
         kept_labels = objects.segmented
-        neighbor_objects = workspace.object_set.get_objects(self.neighbors_name.value)
+        neighbor_objects = workspace.object_set.get_objects(
+            self.neighbors_name.value)
         assert isinstance(neighbor_objects, cpo.Objects)
         neighbor_labels = neighbor_objects.small_removed_segmented
         #
@@ -243,6 +244,8 @@ class MeasureObjectNeighbors(cpm.CPModule):
             neighbor_labels = neighbor_labels.copy().astype(np.int32)
             neighbor_labels[touching_border_mask] = touching_border_object_number[
                 unedited_segmented[touching_border_mask]]
+        
+        neighbor_has_pixels = np.bincount(neighbor_labels.ravel())[1:] > 0
         
         _, object_numbers = objects.relate_labels(labels, kept_labels)
         if self.neighbors_are_objects:
@@ -434,7 +437,7 @@ class MeasureObjectNeighbors(cpm.CPModule):
                       ncenters[neighbor_indexes[np.newaxis, :], 1])
                 distance_matrix = np.sqrt(di*di + dj*dj)
                 distance_matrix[~ has_pixels, :] = np.inf
-                distance_matrix[:, ~has_pixels] = np.inf
+                distance_matrix[:, ~neighbor_has_pixels] = np.inf
                 #
                 # order[:,0] should be arange(nobjects)
                 # order[:,1] should be the nearest neighbor

--- a/cellprofiler/modules/tests/test_measureobjectneighbors.py
+++ b/cellprofiler/modules/tests/test_measureobjectneighbors.py
@@ -785,3 +785,25 @@ MeasureObjectNeighbors:[module_num:1|svn_version:\'Unknown\'|variable_revision_n
               module.get_measurement_name(M.M_NUMBER_OF_NEIGHBORS), 1]
         self.assertEqual(len(v), 1)
         self.assertEqual(v[0], 2)
+        
+    def test_08_03_object_is_missing(self):
+        # regression test of #1639
+        #
+        # Object # 2 should match neighbor # 1, but because of
+        # an error in masking distances, neighbor #1 is masked out
+        #
+        olabels = np.zeros((20,10), int)
+        olabels[2, 2] = 2
+        nlabels = np.zeros((20,10), int)
+        nlabels[2, 3] = 1
+        nlabels[5, 2] = 2
+        workspace, module = self.make_workspace(
+            olabels, M.D_EXPAND, distance = 20, neighbors_labels = nlabels)
+        self.assertTrue(isinstance(module, M.MeasureObjectNeighbors))
+        module.run(workspace)
+        m = workspace.measurements
+        self.assertTrue(isinstance(m, cpmeas.Measurements))
+        ftr = module.get_measurement_name(M.M_FIRST_CLOSEST_OBJECT_NUMBER)
+        values = m[OBJECTS_NAME, ftr]
+        self.assertEqual(values[1], 1)
+        


### PR DESCRIPTION
Also prevents VisibleDeprecationWarning

Has test case that failed.