### PR TITLE
Fixes #1656 - set matplotlib canvas initial size to 640 x 480

### DIFF
--- a/cellprofiler/gui/cpfigure.py
+++ b/cellprofiler/gui/cpfigure.py
@@ -319,7 +319,11 @@ class CPFigureFrame(wx.Frame):
             self.SetIcon(get_cp_icon())
         except:
             pass
-        self.Fit()
+        if size == wx.DefaultSize:
+            self.panel.SetInitialSize(wx.Size(640, 480))
+            self.Fit()
+        else:
+            self.Layout()
         self.Show()
         if sys.platform.lower().startswith("win"):
             try:


### PR DESCRIPTION
I am guessing that Matplotlib is not using SetInitialSize to set the canvas size, so the code that set the size to 640x480 fails to work in wx 3.0. I used SetInitialSize after creating the canvas and it works now.