### PR TITLE
Fixes #1672 + tests. If objects are neighbors, distances don't include touching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ install:
   - pip install --upgrade wheel
   - pip install --upgrade cython
   - pip install -r requirements.txt
-  - pip install --editable git+https://github.com/h5py/h5py.git#egg=h5py       --upgrade
-  - pip install --editable git+https://github.com/CellH5/cellh5.git#egg=cellh5 --upgrade
+  - pip install --editable git+https://github.com/h5py/h5py.git#egg=h5py
+  - pip install --editable git+https://github.com/CellH5/cellh5.git#egg=cellh5
   - python external_dependencies.py
   - python CellProfiler.py --build-and-exit
 script:

--- a/cellprofiler/modules/measureobjectneighbors.py
+++ b/cellprofiler/modules/measureobjectneighbors.py
@@ -245,14 +245,15 @@ class MeasureObjectNeighbors(cpm.CPModule):
             neighbor_labels[touching_border_mask] = touching_border_object_number[
                 unedited_segmented[touching_border_mask]]
         
-        neighbor_has_pixels = np.bincount(neighbor_labels.ravel())[1:] > 0
         
         _, object_numbers = objects.relate_labels(labels, kept_labels)
         if self.neighbors_are_objects:
             neighbor_numbers = object_numbers
+            neighbor_has_pixels = has_pixels
         else:
             _, neighbor_numbers = neighbor_objects.relate_labels(
                 neighbor_labels, neighbor_objects.segmented)
+            neighbor_has_pixels = np.bincount(neighbor_labels.ravel())[1:] > 0
         neighbor_count = np.zeros((nobjects,))
         pixel_count = np.zeros((nobjects,))
         first_object_number = np.zeros((nobjects,),int)

--- a/cellprofiler/modules/tests/test_measureobjectneighbors.py
+++ b/cellprofiler/modules/tests/test_measureobjectneighbors.py
@@ -807,3 +807,26 @@ MeasureObjectNeighbors:[module_num:1|svn_version:\'Unknown\'|variable_revision_n
         values = m[OBJECTS_NAME, ftr]
         self.assertEqual(values[1], 1)
         
+    def test_08_04_small_removed_same(self):
+        # Regression test of issue #1672
+        #
+        # Objects with small removed failed.
+        #
+        objects = np.zeros((11, 13), int)
+        objects[5:7, 1:3] = 1
+        objects[6:8, 5:7] = 2
+        objects_unedited = objects.copy()
+        objects_unedited[0:2, 0:2] = 3
+        
+        workspace, module = self.make_workspace(
+            objects, M.D_EXPAND, distance = 1)
+        no = workspace.object_set.get_objects(OBJECTS_NAME)
+        no.unedited_segmented = objects_unedited
+        no.small_removed_segmented = objects
+        module.run(workspace)
+        m = workspace.measurements
+        v = m[OBJECTS_NAME, 
+              module.get_measurement_name(M.M_NUMBER_OF_NEIGHBORS), 1]
+        self.assertEqual(len(v), 2)
+        self.assertEqual(v[0], 1)
+        


### PR DESCRIPTION
I introduced a bug in 9a2b6a6dc9981ddc0b5d566109067238d12fa78b that shows up when you calculate distances to the nearest neighbor. The distance matrix is computed excluding the objects touching the image border, but the neighbor_has_pixels array was calculated using objects touching the border as well (and these have larger object numbers than the ones that don't). The array size was wrong and the code failed as indicated.

@0x00B1 - this pull should get a little priority since the reporter is an ASTP client.