### PR TITLE
Implement composite mode in GrayToColor

### DIFF
--- a/cellprofiler/modules/graytocolor.py
+++ b/cellprofiler/modules/graytocolor.py
@@ -35,19 +35,30 @@ OFF_RED_ADJUSTMENT_FACTOR = 4
 OFF_GREEN_ADJUSTMENT_FACTOR = 5
 OFF_BLUE_ADJUSTMENT_FACTOR = 6
 
+OFF_STACK_CHANNELS_V2 = 16
+OFF_STACK_CHANNEL_COUNT_V3 = 16
+OFF_STACK_CHANNEL_COUNT = 16
+
 SCHEME_RGB = "RGB"
 SCHEME_CMYK = "CMYK"
 SCHEME_STACK = "Stack"
+SCHEME_COMPOSITE = "Composite"
 LEAVE_THIS_BLACK = "Leave this black"
+
+DEFAULT_COLORS = [
+    "#%02x%02x%02x" % color for color in
+    (255, 0, 0), (0, 255, 0), (0, 0, 255),
+    (128, 128, 0), (128, 0, 128), (0, 128, 128)]
 
 class GrayToColor(cpm.CPModule):
     module_name = 'GrayToColor'
-    variable_revision_number = 2
+    variable_revision_number = 3
     category = "Image Processing"
     def create_settings(self):
         self.scheme_choice = cps.Choice(
             "Select a color scheme",
-            [SCHEME_RGB, SCHEME_CMYK, SCHEME_STACK],doc="""
+            [SCHEME_RGB, SCHEME_CMYK, SCHEME_STACK, SCHEME_COMPOSITE],
+            doc="""
             This module can use one of two color schemes to combine images:<br/>
             <ul><li><i>%(SCHEME_RGB)s</i>: Each input image determines the intensity of
             one of the color channels: red, green, and blue.</li>
@@ -58,6 +69,11 @@ class GrayToColor(cpm.CPModule):
             image adds equally to the red and green intensities.</li>
             <li><i>%(SCHEME_STACK)s</i>: The channels are stacked in order. An arbitrary number of 
             channels is allowed.</li>
+            <li><i>%(SCHEME_COMPOSITE)s</i>: A color is assigned to each grayscale
+            image. Each grayscale image is converted to color by multiplying
+            the intensity by the color and the resulting color images are
+            added together. An arbitrary number of channels can be composited
+            into a single color image.</li>
             </ul>"""%globals())
         
         # # # # # # # # # # # # # # # #
@@ -163,13 +179,19 @@ class GrayToColor(cpm.CPModule):
         # # # # # # # # # # # # # #
 
         self.stack_channels = []
+        self.stack_channel_count = cps.HiddenCount(self.stack_channels)
         self.add_stack_channel_cb(can_remove = False)
         self.add_stack_channel = cps.DoSomething("","Add another channel", self.add_stack_channel_cb)
 
     def add_stack_channel_cb(self, can_remove=True):
         group = cps.SettingsGroup()
+        default_color = DEFAULT_COLORS[
+            len(self.stack_channels) % len(DEFAULT_COLORS)]
         group.append("image_name", cps.ImageNameSubscriber(
             "Select the input image to add to the stacked image", cps.NONE))
+        group.append("color", cps.Color(
+            "Color", default_color,
+            doc = "The color to be assigned to the above image."))
         
         if can_remove:
             group.append("remover", cps.RemoveSettingButton("", "Remove this image", self.stack_channels, group))
@@ -205,12 +227,17 @@ class GrayToColor(cpm.CPModule):
                  self.cyan_image_name,self.magenta_image_name, 
                  self.yellow_image_name, self.gray_image_name,
                  self.cyan_adjustment_factor, self.magenta_adjustment_factor,
-                 self.yellow_adjustment_factor, self.gray_adjustment_factor]
-        result += [sc.image_name for sc in self.stack_channels]
+                 self.yellow_adjustment_factor, self.gray_adjustment_factor,
+                 self.stack_channel_count]
+        for stack_channel in self.stack_channels:
+            result += [stack_channel.image_name, stack_channel.color]
         return result
     
     def prepare_settings(self, setting_values):
-        num_stack_images = max(len(setting_values) - 16, 1)
+        try:
+            num_stack_images = int(setting_values[OFF_STACK_CHANNEL_COUNT])
+        except ValueError:
+            num_stack_images = 1
         del self.stack_channels[num_stack_images:]
         while len(self.stack_channels) < num_stack_images:
             self.add_stack_channel_cb()
@@ -223,9 +250,13 @@ class GrayToColor(cpm.CPModule):
         for color_scheme_setting in self.color_scheme_settings:
             if not color_scheme_setting.image_name.is_blank:
                 result.append(color_scheme_setting.adjustment_factor)
-        if self.scheme_choice == SCHEME_STACK:
+        if self.scheme_choice in (SCHEME_STACK, SCHEME_COMPOSITE):
             for sc_group in self.stack_channels:
-                result += sc_group.visible_settings()
+                result.append(sc_group.image_name)
+                if self.scheme_choice == SCHEME_COMPOSITE:
+                    result.append(sc_group.color)
+                if hasattr(sc_group, "remover"):
+                    result.append(sc_group.remover)
             result += [self.add_stack_channel]
         return result
     
@@ -234,7 +265,7 @@ class GrayToColor(cpm.CPModule):
         
         We need at least one image name to be filled in
         """
-        if self.scheme_choice != SCHEME_STACK:
+        if self.scheme_choice not in (SCHEME_STACK, SCHEME_COMPOSITE):
             if all([color_scheme_setting.image_name.is_blank
                     for color_scheme_setting in self.color_scheme_settings]):
                 raise cps.ValidationError(
@@ -247,7 +278,7 @@ class GrayToColor(cpm.CPModule):
         rgb_pixel_data = None
         input_image_names = []
         channel_names = []
-        if self.scheme_choice != SCHEME_STACK:
+        if self.scheme_choice not in (SCHEME_STACK, SCHEME_COMPOSITE):
             for color_scheme_setting in self.color_scheme_settings:
                 if color_scheme_setting.image_name.is_blank:
                     channel_names.append("Blank")
@@ -285,7 +316,18 @@ class GrayToColor(cpm.CPModule):
                                       self.stack_channels[idx].image_name.value,
                                       source_channels[0].shape,
                                       pd.pixel_data.shape))
-            rgb_pixel_data = np.dstack(source_channels)
+            if self.scheme_choice == SCHEME_STACK:
+                rgb_pixel_data = np.dstack(source_channels)
+            else:
+                colors = [ca[np.newaxis, np.newaxis, :] for ca in
+                    [np.array(c).astype(parent_image.pixel_data.dtype) / 255
+                     for c in
+                     [sc.color.to_rgb() for sc in self.stack_channels]]]
+                rgb_pixel_data = \
+                    parent_image.pixel_data[:, :, np.newaxis] * colors[0]
+                for image, color in zip(source_channels[1:], colors[1:]):
+                    rgb_pixel_data = rgb_pixel_data + \
+                        image[:, :, np.newaxis] * color
 
         ##############
         # Save image #
@@ -380,6 +422,19 @@ class GrayToColor(cpm.CPModule):
                 [ SCHEME_CMYK ] + setting_values + 
                 [cps.NONE] * 4 + [1] * 4)
             variable_revision_number = 2
+        if (not from_matlab) and variable_revision_number == 2:
+            #
+            # Added composite mode
+            #
+            n_stacked = len(setting_values) - OFF_STACK_CHANNELS_V2
+            new_setting_values = list(setting_values[:OFF_STACK_CHANNELS_V2])
+            new_setting_values.append(str(n_stacked))
+            for i, image_name in enumerate(
+                setting_values[OFF_STACK_CHANNELS_V2:]):
+                new_setting_values += \
+                    [image_name, DEFAULT_COLORS[i % len(DEFAULT_COLORS)]]
+            setting_values = new_setting_values
+            variable_revision_number = 3
         return setting_values, variable_revision_number, from_matlab
 
 class ColorSchemeSettings(object):

--- a/cellprofiler/modules/tests/test_graytocolor.py
+++ b/cellprofiler/modules/tests/test_graytocolor.py
@@ -24,9 +24,6 @@ from StringIO import StringIO
 import unittest
 import zlib
 
-from cellprofiler.preferences import set_headless
-set_headless()
-
 import cellprofiler.pipeline as cpp
 import cellprofiler.cpmodule as cpm
 import cellprofiler.cpimage as cpi
@@ -37,25 +34,36 @@ import cellprofiler.modules.graytocolor as G
 
 OUTPUT_IMAGE_NAME = 'outputimage'
 class TestGrayToColor(unittest.TestCase):
-    def make_workspace(self, scheme, images, adjustments):
+    def make_workspace(self, scheme, images, adjustments_or_colors):
         module = G.GrayToColor()
         module.scheme_choice.value = scheme
-        image_names = ["image%d"%i if images[i] is not None
-                       else G.LEAVE_THIS_BLACK
-                       for i in range(7)]
-        for image_name_setting, image_name, adjustment_setting, adjustment\
-            in zip((module.red_image_name, module.green_image_name, 
-                    module.blue_image_name,
-                    module.cyan_image_name, module.magenta_image_name,
-                    module.yellow_image_name, module.gray_image_name),
-                   image_names,
-                   (module.red_adjustment_factor, module.green_adjustment_factor,
-                    module.blue_adjustment_factor, module.cyan_adjustment_factor,
-                    module.magenta_adjustment_factor, module.yellow_adjustment_factor,
-                    module.gray_adjustment_factor),
-                   adjustments):
-            image_name_setting.value = image_name
-            adjustment_setting.value = adjustment
+        if scheme not in (G.SCHEME_COMPOSITE, G.SCHEME_STACK):
+            image_names = ["image%d"%i if images[i] is not None
+                           else G.LEAVE_THIS_BLACK
+                           for i in range(7)]
+            for image_name_setting, image_name, adjustment_setting, adjustment\
+                in zip((module.red_image_name, module.green_image_name, 
+                        module.blue_image_name,
+                        module.cyan_image_name, module.magenta_image_name,
+                        module.yellow_image_name, module.gray_image_name),
+                       image_names,
+                       (module.red_adjustment_factor, module.green_adjustment_factor,
+                        module.blue_adjustment_factor, module.cyan_adjustment_factor,
+                        module.magenta_adjustment_factor, module.yellow_adjustment_factor,
+                        module.gray_adjustment_factor),
+                       adjustments_or_colors):
+                image_name_setting.value = image_name
+                adjustment_setting.value = adjustment
+        else:
+            while len(module.stack_channels) < len(images):
+                module.add_stack_channel_cb()
+            image_names = []
+            for i, (image, color) in enumerate(zip(images, adjustments_or_colors)):
+                image_name = 'image%d' % (i+1)
+                image_names.append(image_name)
+                module.stack_channels[i].image_name.value = image_name
+                module.stack_channels[i].color.value = color
+                
         module.rgb_image_name.value = OUTPUT_IMAGE_NAME
         module.module_num = 1
         pipeline = cpp.Pipeline()
@@ -145,7 +153,73 @@ class TestGrayToColor(unittest.TestCase):
                                   module.green_adjustment_factor,
                                   module.blue_adjustment_factor):
             self.assertEqual(adjustment_factor.value, 1)
+   
+    def test_01_03_load_v3(self):
+        data = r"""CellProfiler Pipeline: http://www.cellprofiler.org
+Version:3
+DateRevision:20151029194828
+GitHash:8379488
+ModuleCount:5
+HasImagePlaneDetails:False
+
+GrayToColor:[module_num:1|svn_version:\'Unknown\'|variable_revision_number:3|show_window:True|notes:\x5B\x5D|batch_state:array(\x5B\x5D, dtype=uint8)|enabled:True|wants_pause:False]
+    Select a color scheme:Composite
+    Select the image to be colored red:1
+    Select the image to be colored green:2
+    Select the image to be colored blue:3
+    Name the output image:myimage
+    Relative weight for the red image:2.1
+    Relative weight for the green image:2.2
+    Relative weight for the blue image:2.3
+    Select the image to be colored cyan:4
+    Select the image to be colored magenta:5
+    Select the image to be colored yellow:6
+    Select the image that determines brightness:7
+    Relative weight for the cyan image:1.1
+    Relative weight for the magenta image:1.2
+    Relative weight for the yellow image:1.3
+    Relative weight for the brightness image:1.4
+    Hidden:2
+    Select the input image to add to the stacked image:DNA
+    Color:#7F00FF
+    Select the input image to add to the stacked image:GFP
+    Color:#7FFF00
+"""
+        pipeline = cpp.Pipeline()
+        def callback(caller,event):
+            self.assertFalse(isinstance(event, cpp.LoadExceptionEvent))
+        pipeline.add_listener(callback)
+        pipeline.load(StringIO(data))
+        self.assertEqual(len(pipeline.modules()), 1)
+        module = pipeline.modules()[0]
+        self.assertTrue(isinstance(module, G.GrayToColor))
+        self.assertEqual(module.scheme_choice, G.SCHEME_COMPOSITE)
+        self.assertEqual(module.rgb_image_name, "myimage")
+        self.assertEqual(module.red_image_name, "1")
+        self.assertEqual(module.green_image_name, "2")
+        self.assertEqual(module.blue_image_name, "3")
+        self.assertEqual(module.cyan_image_name, "4")
+        self.assertEqual(module.magenta_image_name, "5")
+        self.assertEqual(module.yellow_image_name, "6")
+        self.assertEqual(module.gray_image_name, "7")
+        self.assertAlmostEqual(module.red_adjustment_factor, 2.1)
+        self.assertAlmostEqual(module.green_adjustment_factor, 2.2)
+        self.assertAlmostEqual(module.blue_adjustment_factor, 2.3)
+        self.assertAlmostEqual(module.cyan_adjustment_factor, 1.1)
+        self.assertAlmostEqual(module.magenta_adjustment_factor, 1.2)
+        self.assertAlmostEqual(module.yellow_adjustment_factor, 1.3)
+        self.assertAlmostEqual(module.gray_adjustment_factor, 1.4)
+        self.assertEqual(len(module.stack_channels), 2)
+        self.assertEqual(module.stack_channels[0].image_name, "DNA")
+        self.assertEqual(module.stack_channels[1].image_name, "GFP")
+        self.assertSequenceEqual(
+            module.stack_channels[0].color.to_rgb(), 
+            (127, 0, 255))
+        self.assertSequenceEqual(
+            module.stack_channels[1].color.to_rgb(), 
+            (127, 255, 0))
         
+
     def test_02_01_rgb(self):
         np.random.seed(0)
         for combination in ((True, True, True), (True, True, False),
@@ -194,4 +268,35 @@ class TestGrayToColor(unittest.TestCase):
                                   (images[6],(1,1,1), adjustments[6]))])
             expected = np.sum(expected, 0)
             self.assertTrue(np.all(np.abs(expected - pixel_data) <= .00001))
-        
+            
+    def test_04_01_stack(self):
+        r = np.random.RandomState()
+        r.seed(41)
+        images = [r.uniform(size=(11, 13)) for _ in range(5)]
+        workspace, module = self.make_workspace(
+            G.SCHEME_STACK, images, ["#000000"] * len(images))
+        module.run(workspace)
+        output = workspace.image_set.get_image(OUTPUT_IMAGE_NAME).pixel_data
+        self.assertSequenceEqual(output.shape[:2], images[0].shape)
+        self.assertEqual(output.shape[2], len(images))
+        for i, image in enumerate(images):
+            np.testing.assert_array_almost_equal(output[:, :, i], image)
+
+    def test_05_01_composite(self):
+        r = np.random.RandomState()
+        r.seed(41)
+        images = [r.uniform(size=(11, 13)) for _ in range(5)]
+        colors = [r.randint(0, 255, size=3) for _ in range(5)]
+        color_names = \
+            ["#%02x%02x%02x" % tuple(color.tolist()) for color in colors]
+        workspace, module = self.make_workspace(
+            G.SCHEME_COMPOSITE, images, color_names)
+        module.run(workspace)
+        output = workspace.image_set.get_image(OUTPUT_IMAGE_NAME).pixel_data
+        self.assertSequenceEqual(output.shape[:2], images[0].shape)
+        self.assertEqual(output.shape[2], 3)
+        for i in range(3):
+            channel = sum(
+                [image*float(color[i])/255 
+                 for image, color in zip(images, colors)])
+            np.testing.assert_array_almost_equal(output[:, :, i], channel)


### PR DESCRIPTION
This lets the user specify an arbitrary number of input images and colors for each. Each grayscale image is converted to its chosen color and then the set of color images are composited together by a simple addition.