### PR TITLE
Fixes #1663 + some resizing to make the text fit

### DIFF
--- a/cellprofiler/gui/moduleview.py
+++ b/cellprofiler/gui/moduleview.py
@@ -813,7 +813,7 @@ class ModuleView:
                     d[None] = leaf_state
                     return leaf_state
                 get_state(d)
-                dlg = TreeCheckboxDialog(self.module_panel, d, size=(320,480))
+                dlg = TreeCheckboxDialog(self.module_panel, d, size=(480,480))
                 dlg.Title = "Select measurements"
                 if dlg.ShowModal() == wx.ID_OK:
                     def collect_state(object_name, prefix, d):

--- a/cellprofiler/gui/treecheckboxdialog.py
+++ b/cellprofiler/gui/treecheckboxdialog.py
@@ -64,7 +64,6 @@ class TreeCheckboxDialog(wx.Dialog):
         self.tree_ctrl.Bind(wx.EVT_LEFT_DOWN, self.on_left_down)
         self.tree_ctrl.Expand(root_id)
         table_sizer = wx.GridBagSizer()
-        table_sizer.AddGrowableCol(2)
         sizer.Add(table_sizer, 0, wx.EXPAND)
         table_sizer.Add(wx.StaticText(self, label='Key:'), (0, 0), flag=wx.LEFT | wx.RIGHT, border=3)
         for i, (bitmap, description) in enumerate((
@@ -75,6 +74,7 @@ class TreeCheckboxDialog(wx.Dialog):
             bitmap_ctrl.SetBitmap(bitmap)
             table_sizer.Add(bitmap_ctrl, (i, 1), flag=wx.RIGHT, border=5)
             table_sizer.Add(wx.StaticText(self, label=description), (i, 2))
+        table_sizer.AddGrowableCol(2)
         sizer.Add(self.CreateStdDialogButtonSizer(wx.CANCEL | wx.OK), 
                   flag=wx.CENTER)
         self.Layout()


### PR DESCRIPTION
These fixes are needed to fix #1663 (behavior change in wx 3.0) and to expand the dialog box size so it fits the text under 3.0.