### PR TITLE
`python -m cellprofiler` fix

### DIFF
--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -938,4 +938,6 @@ def run_pipeline_headless(options, args):
         fd.close()
     if measurements is not None:
         measurements.close()
-    
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
`if __name__ == "__main__"` is needed for expected `$ python -m cellprofiler` use