### PR TITLE
Issues/1834

### DIFF
--- a/cellprofiler/modules/enhanceorsuppressfeatures.py
+++ b/cellprofiler/modules/enhanceorsuppressfeatures.py
@@ -262,7 +262,7 @@ class EnhanceOrSuppressFeatures(cpm.CPModule):
         pixel_data = image.pixel_data
         if self.method == ENHANCE:
             if self.enhance_method == E_SPECKLES:
-                if self.speckle_accuracy == S_SLOW:
+                if self.speckle_accuracy == S_SLOW or radius <= 3:
                     result = white_tophat(pixel_data, radius, mask)
                 else:
                     #

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,6 @@ matplotlib-backends =
 packages =
     cellprofiler,
     centrosome,
-    contrib,
     h5py,
     imagej,
     javabridge,


### PR DESCRIPTION
The median filter operates using an octagon and you need a reasonable kernel size in order to draw the octagon over the image (e.g. a 3x3 kernel is too small). Also, there's no point speeding it up since white_tophat runs just as fast or faster.