### PR TITLE
Fixes #1899 - remove drop file name text functionality

### DIFF
--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -3420,7 +3420,10 @@ class PipelineController:
         return self.__pipeline.Run(self.__frame)
 
 
-class FLDropTarget(wx.PyDropTarget):
+# TODO: wx 3.0 seems to have broken the composite drop target functionality
+#       so I am reverting to only allowing files, hence the commented-out code
+#
+class FLDropTarget(wx.FileDropTarget):
     """A generic drop target (for the path list)"""
 
     def __init__(self, file_callback_fn, text_callback_fn):
@@ -3432,7 +3435,7 @@ class FLDropTarget(wx.PyDropTarget):
         self.composite_data_object = wx.DataObjectComposite()
         self.composite_data_object.Add(self.file_data_object, True)
         self.composite_data_object.Add(self.text_data_object)
-        self.SetDataObject(self.composite_data_object)
+        #self.SetDataObject(self.composite_data_object)
 
     def OnDropFiles(self, x, y, filenames):
         self.file_callback_fn(x, y, filenames)
@@ -3440,24 +3443,22 @@ class FLDropTarget(wx.PyDropTarget):
     def OnDropText(self, x, y, text):
         self.text_callback_fn(x, y, text)
 
-    @staticmethod
-    def OnEnter(x, y, d):
+    def OnEnter(self, x, y, d):
         return wx.DragCopy
 
-    @staticmethod
-    def OnDragOver(x, y, d):
+    def OnDragOver(self, x, y, d):
         return wx.DragCopy
 
-    def OnData(self, x, y, d):
-        if self.GetData():
-            df = self.composite_data_object.GetReceivedFormat().GetType()
-            if df in (wx.DF_TEXT, wx.DF_UNICODETEXT):
-                self.OnDropText(x, y, self.text_data_object.GetText())
-            elif df == wx.DF_FILENAME:
-                self.OnDropFiles(x, y,
-                                 self.file_data_object.GetFilenames())
-        return wx.DragCopy
-
-    @staticmethod
-    def OnDrop(x, y):
-        return True
+    #def OnData(self, x, y, d):
+    #    if self.GetData():
+    #        df = self.composite_data_object.GetReceivedFormat().GetType()
+    #        if df in (wx.DF_TEXT, wx.DF_UNICODETEXT):
+    #            self.OnDropText(x, y, self.text_data_object.GetText())
+    #        elif df == wx.DF_FILENAME:
+    #            self.OnDropFiles(x, y,
+    #                             self.file_data_object.GetFilenames())
+    #    return wx.DragCopy
+    #
+    #@staticmethod
+    #def OnDrop(x, y):
+    #    return True


### PR DESCRIPTION
@dlogan - if you agree that it's worth not being able to select filenames as text from a Word document and drop them into the images module, please take this pull request if it passes the build.

Just hit the button.
Do it.