### PR TITLE
exit code never assigned

### DIFF
--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -699,6 +699,8 @@ def run_pipeline_headless(options, args):
         fd = open(options.done_file, "wt")
         fd.write("%s\n" % done_text)
         fd.close()
+    else:
+        exit_code = 0
 
     if measurements is not None:
         measurements.close()


### PR DESCRIPTION
As mentioned on the forums [here](http://forum.cellprofiler.org/t/converting-example-pipeline-to-run-headless/3575/6?u=sjwarch), if `options.done_file` **is** `None`, then the exit code is never assigned.

Not sure why this is happening in our case, but it means the processes are not exiting on our cluster.