### PR TITLE
Make sure we actually check the value of the option.

### DIFF
--- a/cellprofiler/modules/measureobjectintensitydistribution.py
+++ b/cellprofiler/modules/measureobjectintensitydistribution.py
@@ -435,7 +435,7 @@ class MeasureObjectIntensityDistribution(cpm.Module):
                                              o.center_choice.value,
                                              bin_count_settings,
                                              d)
-        if self.wants_zernikes:
+        if self.wants_zernikes != Z_NONE:
             self.calculate_zernikes(workspace)
 
         if self.show_window:


### PR DESCRIPTION
#2193 highlighted a problem with calculating Zernikes even when not asked to.  It seems the check if Zernikes are wanted before calculating them does not check the value of the option but falls into Pythons default `True` if a class has no `__nonzero__` or `__len__` defined.

Reran some jobs which were failing and it now works when you have the Zernike option turned off.