### PR TITLE
Global Gray-level Thresholding Based on Object Size

### DIFF
--- a/cellprofiler/modules/applythreshold.py
+++ b/cellprofiler/modules/applythreshold.py
@@ -9,11 +9,11 @@ from centrosome.threshold import TM_GLOBAL, TM_ADAPTIVE, TM_PER_OBJECT, TM_BINAR
 from centrosome.threshold import TM_METHODS, TM_MANUAL, TM_MOG, TM_OTSU, TM_SIZE_INTERVAL_PRECISION
 from scipy.ndimage.morphology import binary_dilation
 
-import cellprofiler.settings as cps
-from cellprofiler import cpimage
-from cellprofiler.cpmodule import CPModule
+import cellprofiler.setting as cps
+from cellprofiler import image
+from cellprofiler.module import Module
 from cellprofiler.modules.identify import get_threshold_measurement_columns
-from cellprofiler.settings import YES, NO
+from cellprofiler.setting import YES, NO
 from identify import FF_ORIG_THRESHOLD, FF_FINAL_THRESHOLD
 from identify import FF_SUM_OF_ENTROPIES, FF_WEIGHTED_VARIANCE
 from identify import FI_IMAGE_SIZE, TSM_NONE
@@ -156,7 +156,7 @@ class ApplyThreshold(Identify):
                         """Threshold setting, "%s" is not "%s" or "%s".""" %
                         (self.low_or_high.value, TH_BELOW_THRESHOLD,
                          TH_ABOVE_THRESHOLD))
-        output = cpimage.Image(pixels, parent_image=input)
+        output = image.Image(pixels, parent_image=input)
         workspace.image_set.add(self.thresholded_image_name.value, output)
         if self.show_window:
             workspace.display_data.input_pixel_data = input.pixel_data

--- a/cellprofiler/modules/applythreshold.py
+++ b/cellprofiler/modules/applythreshold.py
@@ -4,32 +4,22 @@
 based on a threshold which can be pre-selected or calculated automatically using one of many methods.
 """
 
-# CellProfiler is distributed under the GNU General Public License.
-# See the accompanying file LICENSE for details.
-# 
-# Copyright (c) 2003-2009 Massachusetts Institute of Technology
-# Copyright (c) 2009-2014 Broad Institute
-# 
-# Please see the AUTHORS file for credits.
-# 
-# Website: http://www.cellprofiler.org
+from centrosome.cpmorphology import strel_disk
+from centrosome.threshold import TM_GLOBAL, TM_ADAPTIVE, TM_PER_OBJECT, TM_BINARY_IMAGE
+from centrosome.threshold import TM_METHODS, TM_MANUAL, TM_MOG, TM_OTSU, TM_SIZE_INTERVAL_PRECISION
+from scipy.ndimage.morphology import binary_dilation
 
-from cellprofiler.cpmodule import CPModule
-from cellprofiler import cpimage
 import cellprofiler.settings as cps
+from cellprofiler import cpimage
+from cellprofiler.cpmodule import CPModule
+from cellprofiler.modules.identify import get_threshold_measurement_columns
 from cellprofiler.settings import YES, NO
-from identify import Identify, O_BACKGROUND, O_ENTROPY
-from identify import O_FOREGROUND, O_THREE_CLASS
-from identify import O_TWO_CLASS, O_WEIGHTED_VARIANCE
 from identify import FF_ORIG_THRESHOLD, FF_FINAL_THRESHOLD
 from identify import FF_SUM_OF_ENTROPIES, FF_WEIGHTED_VARIANCE
 from identify import FI_IMAGE_SIZE, TSM_NONE
-from cellprofiler.modules.identify import get_threshold_measurement_columns
-from cellprofiler.cpmath.threshold import TM_METHODS, TM_MANUAL, TM_MOG, TM_OTSU
-from cellprofiler.cpmath.threshold import TM_GLOBAL, TM_ADAPTIVE, TM_PER_OBJECT, TM_BINARY_IMAGE
-
-from cellprofiler.cpmath.cpmorphology import strel_disk
-from scipy.ndimage.morphology import binary_dilation
+from identify import Identify, O_BACKGROUND, O_ENTROPY
+from identify import O_FOREGROUND, O_THREE_CLASS
+from identify import O_TWO_CLASS, O_WEIGHTED_VARIANCE
 
 RETAIN = "Retain"
 SHIFT = "Shift"
@@ -42,8 +32,8 @@ TH_ABOVE_THRESHOLD = "Above threshold"
 '''# of non-threshold settings in current revision'''
 N_SETTINGS = 6
 
-class ApplyThreshold(Identify):
 
+class ApplyThreshold(Identify):
     module_name = "ApplyThreshold"
     variable_revision_number = 7
     category = "Image Processing"
@@ -53,59 +43,61 @@ class ApplyThreshold(Identify):
                              if method != TM_BINARY_IMAGE]
 
         self.image_name = cps.ImageNameSubscriber(
-            "Select the input image",doc = '''
+                "Select the input image", doc='''
             Choose the image to be thresholded.''')
-        
+
         self.thresholded_image_name = cps.ImageNameProvider(
-            "Name the output image",
-            "ThreshBlue", doc = '''
+                "Name the output image",
+                "ThreshBlue", doc='''
             Enter a name for the thresholded image.''')
-        
+
         self.binary = cps.Choice(
-            "Select the output image type", [GRAYSCALE, BINARY], doc = '''
+                "Select the output image type", [GRAYSCALE, BINARY], doc='''
             Two types of output images can be produced:<br>
             <ul>
-            <li><i>%(GRAYSCALE)s:</i> The pixels that are retained after some pixels 
-            are set to zero or shifted (based on your selections for thresholding 
-            options) will have their original 
+            <li><i>%(GRAYSCALE)s:</i> The pixels that are retained after some pixels
+            are set to zero or shifted (based on your selections for thresholding
+            options) will have their original
             intensity values.</li>
-            <li><i>%(BINARY)s:</i> The pixels that are retained after some pixels are 
-            set to zero (based on your selections for thresholding options) will be 
+            <li><i>%(BINARY)s:</i> The pixels that are retained after some pixels are
+            set to zero (based on your selections for thresholding options) will be
             white and all other pixels will be black (zeroes).</li>
-            </ul>'''%globals())
-        
+            </ul>''' % globals())
+
         # if not binary:
         self.low_or_high = cps.Choice(
-            "Set pixels below or above the threshold to zero?",
-            [TH_BELOW_THRESHOLD, TH_ABOVE_THRESHOLD], doc="""
+                "Set pixels below or above the threshold to zero?",
+                [TH_BELOW_THRESHOLD, TH_ABOVE_THRESHOLD], doc="""
             <i>(Used only when "%(GRAYSCALE)s" thresholding is selected)</i><br>
-            For grayscale output, the dim pixels below 
-            the threshold can be set to zero or the bright pixels above 
-            the threshold can be set to zero.
-            Choose <i>%(TH_BELOW_THRESHOLD)s</i> to threshold dim pixels and
-            <i>%(TH_ABOVE_THRESHOLD)s</i> to threshold bright pixels."""%globals())
-        
+            This option adjusts how pixels above or below the threshold are handled:
+            <ul>
+            <li><i>%(TH_BELOW_THRESHOLD)s:</i> Set the dim pixels below
+            the threshold to zero.</li>
+            <li><i>%(TH_ABOVE_THRESHOLD)s:</i> Set the bright pixels above the
+            threshold to zero.</li>
+            </ul>
+            """ % globals())
+
         # if not binary and below threshold
-        
+
         self.shift = cps.Binary(
-            "Subtract the threshold value from the remaining pixel intensities?", False, doc ='''
+                "Subtract the threshold value from the remaining pixel intensities?", False, doc='''
             <i>(Used only if the output image is %(GRAYSCALE)s and pixels below a given intensity are to be set to zero)</i><br>
-            Select <i>%(YES)s</i> to shift the value of the dim pixels by the threshold value.'''%globals())
-        
+            Select <i>%(YES)s</i> to shift the value of the dim pixels by the threshold value.''' % globals())
+
         # if not binary and above threshold
-        
+
         self.dilation = cps.Float(
-            "Number of pixels by which to expand the thresholding around those excluded bright pixels",
-            0.0, doc = '''
+                "Number of pixels by which to expand the thresholding around those excluded bright pixels",
+                0.0, doc='''
             <i>(Used only if the output image is grayscale and pixels above a given intensity are to be set to zero)</i><br>
-            This setting is useful when attempting to exclude bright artifactual objects: 
+            This setting is useful when attempting to exclude bright artifactual objects:
             first, set the threshold to exclude these bright objects; it may also be desirable to expand the
             thresholded region around those bright objects by a certain distance so as to avoid a "halo" effect.''')
 
         self.create_threshold_settings(threshold_methods)
         self.threshold_smoothing_choice.value = TSM_NONE
-        
-        
+
     def visible_settings(self):
         vv = [self.image_name, self.thresholded_image_name, self.binary]
         if self.binary.value == GRAYSCALE:
@@ -116,22 +108,22 @@ class ApplyThreshold(Identify):
                 vv.extend([self.dilation])
         vv += self.get_threshold_visible_settings()
         return vv
-    
+
     def settings(self):
         return [self.image_name, self.thresholded_image_name,
-                self.binary, self.low_or_high, 
+                self.binary, self.low_or_high,
                 self.shift, self.dilation] + self.get_threshold_settings()
-    
+
     def help_settings(self):
         """Return all settings in a consistent order"""
         return [self.image_name, self.thresholded_image_name,
-                self.binary, self.low_or_high, 
-                self.shift, self.dilation] +\
+                self.binary, self.low_or_high,
+                self.shift, self.dilation] + \
                self.get_threshold_help_settings()
-    
-    def run(self,workspace):
+
+    def run(self, workspace):
         """Run the module
-        
+
         workspace    - the workspace contains:
             pipeline     - instance of CellProfiler.Pipeline for this run
             image_set    - the images in the image set being processed
@@ -143,7 +135,7 @@ class ApplyThreshold(Identify):
                                               must_be_grayscale=True)
         pixels = input.pixel_data.copy()
         binary_image, local_thresh = self.threshold_image(
-            self.image_name.value, workspace, wants_local_threshold=True)
+                self.image_name.value, workspace, wants_local_threshold=True)
         if self.binary != 'Grayscale':
             pixels = binary_image & input.mask
         else:
@@ -152,18 +144,18 @@ class ApplyThreshold(Identify):
                 if self.shift.value:
                     pixels[input.mask & binary_image] -= \
                         local_thresh if self.threshold_modifier == TM_GLOBAL \
-                        else local_thresh[input.mask & binary_image]
+                            else local_thresh[input.mask & binary_image]
             elif self.low_or_high == TH_ABOVE_THRESHOLD:
                 undilated = input.mask & binary_image
-                dilated = binary_dilation(undilated, 
-                                          strel_disk(self.dilation.value), 
+                dilated = binary_dilation(undilated,
+                                          strel_disk(self.dilation.value),
                                           mask=input.mask)
                 pixels[dilated] = 0
             else:
                 raise NotImplementedError(
-                    """Threshold setting, "%s" is not "%s" or "%s".""" %
-                    (self.low_or_high.value, TH_BELOW_THRESHOLD, 
-                     TH_ABOVE_THRESHOLD))
+                        """Threshold setting, "%s" is not "%s" or "%s".""" %
+                        (self.low_or_high.value, TH_BELOW_THRESHOLD,
+                         TH_ABOVE_THRESHOLD))
         output = cpimage.Image(pixels, parent_image=input)
         workspace.image_set.add(self.thresholded_image_name.value, output)
         if self.show_window:
@@ -171,46 +163,47 @@ class ApplyThreshold(Identify):
             workspace.display_data.output_pixel_data = output.pixel_data
             statistics = workspace.display_data.statistics = []
             workspace.display_data.col_labels = ("Feature", "Value")
-            
+
             for column in self.get_measurement_columns(workspace.pipeline):
                 value = workspace.measurements.get_current_image_measurement(column[1])
                 statistics += [(column[1].split('_')[1], str(value))]
-                
+
     def display(self, workspace, figure):
         figure.set_subplots((3, 1))
 
-        figure.subplot_imshow_grayscale(0,0, workspace.display_data.input_pixel_data,
-                              title = "Original image: %s" % 
-                              self.image_name.value)
+        figure.subplot_imshow_grayscale(0, 0, workspace.display_data.input_pixel_data,
+                                        title="Original image: %s" %
+                                              self.image_name.value)
 
-        figure.subplot_imshow_grayscale(1,0, workspace.display_data.output_pixel_data,
-                              title = "Thresholded image: %s" %
-                              self.thresholded_image_name.value, 
-                              sharexy = figure.subplot(0,0))
+        figure.subplot_imshow_grayscale(1, 0, workspace.display_data.output_pixel_data,
+                                        title="Thresholded image: %s" %
+                                              self.thresholded_image_name.value,
+                                        sharexy=figure.subplot(0, 0))
         figure.subplot_table(
-            2, 0, workspace.display_data.statistics,
-            workspace.display_data.col_labels)
-        
+                2, 0, workspace.display_data.statistics,
+                workspace.display_data.col_labels)
+
     def get_measurement_objects_name(self):
         '''Return the name of the "objects" used to name thresholding measurements
-        
+
         In the case of ApplyThreshold, we use the image name to name the
         measurements, so the code here works, but is misnamed.
         '''
         return self.thresholded_image_name.value
-    
+
     def get_measurement_columns(self, pipeline):
         return get_threshold_measurement_columns(self.thresholded_image_name.value)
-    
+
     def get_categories(self, pipeline, object_name):
         return self.get_threshold_categories(pipeline, object_name)
-    
+
     def get_measurements(self, pipeline, object_name, category):
         return self.get_threshold_measurements(pipeline, object_name, category)
-    
+
     def get_measurement_images(self, pipeline, object_name, category, measurement):
         return self.get_threshold_measurement_objects(
-            pipeline, object_name, category, measurement)
+                pipeline, object_name, category, measurement)
+
     def upgrade_settings(self, setting_values,
                          variable_revision_number, module_name,
                          from_matlab):
@@ -218,34 +211,34 @@ class ApplyThreshold(Identify):
             raise NotImplementedError, ("TODO: Handle Matlab CP pipelines for "
                                         "ApplyThreshold with revision < 4")
         if from_matlab and variable_revision_number == 4:
-            setting_values = [ setting_values[0],  # ImageName
-                                setting_values[1],  # ThresholdedImageName
-                                None,
-                                None,
-                                None,
-                                setting_values[2],  # LowThreshold
-                                setting_values[3],  # Shift
-                                setting_values[4],  # HighThreshold
-                                setting_values[5],  # DilationValue
-                                TM_MANUAL,          # Manual thresholding
-                                setting_values[6],  # BinaryChoice
-                                "0,1",              # Threshold range
-                                "1",                # Threshold correction factor
-                                ".2",               # Object fraction
-                                cps.NONE              # Enclosing objects name
-                                ]
+            setting_values = [setting_values[0],  # ImageName
+                              setting_values[1],  # ThresholdedImageName
+                              None,
+                              None,
+                              None,
+                              setting_values[2],  # LowThreshold
+                              setting_values[3],  # Shift
+                              setting_values[4],  # HighThreshold
+                              setting_values[5],  # DilationValue
+                              TM_MANUAL,  # Manual thresholding
+                              setting_values[6],  # BinaryChoice
+                              "0,1",  # Threshold range
+                              "1",  # Threshold correction factor
+                              ".2",  # Object fraction
+                              cps.NONE  # Enclosing objects name
+                              ]
             setting_values[2] = (BINARY if float(setting_values[10]) > 0
-                                 else GRAYSCALE) # binary flag
+                                 else GRAYSCALE)  # binary flag
             setting_values[3] = (cps.YES if float(setting_values[5]) > 0
-                                 else cps.NO) # low threshold set
+                                 else cps.NO)  # low threshold set
             setting_values[4] = (cps.YES if float(setting_values[7]) > 0
-                                 else cps.NO) # high threshold set
+                                 else cps.NO)  # high threshold set
             variable_revision_number = 2
             from_matlab = False
         if (not from_matlab) and variable_revision_number == 1:
-            setting_values = (setting_values[:9] + 
+            setting_values = (setting_values[:9] +
                               [TM_MANUAL, setting_values[9], "O,1", "1",
-                               ".2",cps.NONE])
+                               ".2", cps.NONE])
             variable_revision_number = 2
         if (not from_matlab) and variable_revision_number == 2:
             # Added Otsu options
@@ -253,7 +246,7 @@ class ApplyThreshold(Identify):
             setting_values += [O_TWO_CLASS, O_WEIGHTED_VARIANCE,
                                O_FOREGROUND]
             variable_revision_number = 3
-            
+
         if (not from_matlab) and variable_revision_number == 3:
             #
             # Only low or high, not both + removed manual threshold settings
@@ -276,31 +269,31 @@ class ApplyThreshold(Identify):
                               setting_values[2],  # binary or gray
                               th,
                               setting_values[6],  # shift
-                              ] +setting_values[8:]
+                              ] + setting_values[8:]
             variable_revision_number = 4
-            
+
         if (not from_matlab) and variable_revision_number == 4:
             # Added measurements to threshold methods
             setting_values = setting_values + [cps.NONE]
             variable_revision_number = 5
-                              
+
         if (not from_matlab) and variable_revision_number == 5:
             # Added adaptive thresholding settings
             setting_values += [FI_IMAGE_SIZE, "10"]
             variable_revision_number = 6
-            
+
         if (not from_matlab) and variable_revision_number == 6:
             image_name, thresholded_image_name, binary, low_or_high, \
-                shift, dilation, threshold_method, manual_threshold, \
-                threshold_range, threshold_correction_factor, \
-                object_fraction, enclosing_objects_name, \
-                two_class_otsu, use_weighted_variance, \
-                assign_middle_to_foreground, thresholding_measurement = \
+            shift, dilation, threshold_method, manual_threshold, \
+            threshold_range, threshold_correction_factor, \
+            object_fraction, enclosing_objects_name, \
+            two_class_otsu, use_weighted_variance, \
+            assign_middle_to_foreground, thresholding_measurement = \
                 setting_values[:16]
             setting_values = [
-                image_name, thresholded_image_name, binary, low_or_high, 
-                shift, dilation ] + self.upgrade_legacy_threshold_settings(
-                    threshold_method, TSM_NONE, threshold_correction_factor, 
+                                 image_name, thresholded_image_name, binary, low_or_high,
+                                 shift, dilation] + self.upgrade_legacy_threshold_settings(
+                    threshold_method, TSM_NONE, threshold_correction_factor,
                     threshold_range, object_fraction, manual_threshold,
                     thresholding_measurement, cps.NONE, two_class_otsu,
                     use_weighted_variance, assign_middle_to_foreground,
@@ -310,6 +303,5 @@ class ApplyThreshold(Identify):
         # Upgrade the threshold settings
         #
         setting_values = setting_values[:N_SETTINGS] + \
-            self.upgrade_threshold_settings(setting_values[N_SETTINGS:])
+                         self.upgrade_threshold_settings(setting_values[N_SETTINGS:])
         return setting_values, variable_revision_number, from_matlab
-        

--- a/cellprofiler/modules/identify.py
+++ b/cellprofiler/modules/identify.py
@@ -1,38 +1,30 @@
 """identify.py - a base class for common functionality for identify modules
-
-CellProfiler is distributed under the GNU General Public License.
-See the accompanying file LICENSE for details.
-
-Copyright (c) 2003-2009 Massachusetts Institute of Technology
-Copyright (c) 2009-2014 Broad Institute
-All rights reserved.
-
-Please see the AUTHORS file for credits.
-
-Website: http://www.cellprofiler.org
 """
 
-
 import math
+
+import centrosome.outline
+import numpy as np
 import scipy.ndimage
 import scipy.sparse
-import numpy as np
 import scipy.stats
+from centrosome.smooth import smooth_with_function_and_mask
+from centrosome.smooth import smooth_with_noise
+from centrosome.threshold import TM_GLOBAL, TM_ADAPTIVE, TM_BINARY_IMAGE
+from centrosome.threshold import TM_MANUAL, TM_MEASUREMENT, TM_METHODS, get_threshold
+from centrosome.threshold import TM_PER_OBJECT, TM_OTSU, TM_MOG, TM_MCT, TM_BACKGROUND, TM_KAPUR, TM_ROBUST_BACKGROUND, \
+    TM_RIDLER_CALVARD, TM_SIZE_INTERVAL_PRECISION
+from centrosome.threshold import mad, binned_mode
+from centrosome.threshold import weighted_variance, sum_of_entropies
+from centrosome.threshold import sizeintervalprecision
 
 import cellprofiler.cpmodule
-import cellprofiler.settings as cps
+import cellprofiler.icons
 import cellprofiler.measurements as cpmeas
-import cellprofiler.cpmath.outline
 import cellprofiler.objects
-from cellprofiler.cpmath.smooth import smooth_with_noise
-from cellprofiler.cpmath.smooth import smooth_with_function_and_mask
-from cellprofiler.cpmath.threshold import TM_MANUAL, TM_MEASUREMENT, TM_METHODS, get_threshold
-from cellprofiler.cpmath.threshold import TM_GLOBAL, TM_ADAPTIVE, TM_BINARY_IMAGE
-from cellprofiler.cpmath.threshold import TM_PER_OBJECT, TM_OTSU, TM_MOG, TM_MCT, TM_BACKGROUND, TM_KAPUR, TM_ROBUST_BACKGROUND, TM_RIDLER_CALVARD
-from cellprofiler.cpmath.threshold import weighted_variance, sum_of_entropies
+import cellprofiler.settings as cps
 from cellprofiler.gui.help import HELP_ON_PIXEL_INTENSITIES
-import cellprofiler.icons 
-        
+
 O_TWO_CLASS = 'Two classes'
 O_THREE_CLASS = 'Three classes'
 
@@ -42,8 +34,16 @@ O_ENTROPY = 'Entropy'
 O_FOREGROUND = 'Foreground'
 O_BACKGROUND = 'Background'
 
-FI_IMAGE_SIZE    = 'Image size'
-FI_CUSTOM        = 'Custom'
+FI_IMAGE_SIZE = 'Image size'
+FI_CUSTOM = 'Custom'
+
+RB_DEFAULT = "Default"
+RB_CUSTOM = "Custom"
+RB_MEAN = "Mean"
+RB_MEDIAN = "Median"
+RB_MODE = "Mode"
+RB_SD = "Standard deviation"
+RB_MAD = "Median absolute deviation"
 
 '''The location measurement category'''
 C_LOCATION = "Location"
@@ -71,11 +71,11 @@ R_CHILD = "Child"
 
 FTR_CENTER_X = "Center_X"
 '''The centroid X coordinate measurement feature name'''
-M_LOCATION_CENTER_X = '%s_%s'%(C_LOCATION, FTR_CENTER_X)
+M_LOCATION_CENTER_X = '%s_%s' % (C_LOCATION, FTR_CENTER_X)
 
 FTR_CENTER_Y = "Center_Y"
 '''The centroid Y coordinate measurement feature name'''
-M_LOCATION_CENTER_Y = '%s_%s'%(C_LOCATION, FTR_CENTER_Y)
+M_LOCATION_CENTER_Y = '%s_%s' % (C_LOCATION, FTR_CENTER_Y)
 
 FTR_OBJECT_NUMBER = "Object_Number"
 '''The object number - an index from 1 to however many objects'''
@@ -87,12 +87,12 @@ FF_COUNT = '%s_%%s' % C_COUNT
 FTR_FINAL_THRESHOLD = "FinalThreshold"
 
 '''Format string for the FinalThreshold feature name'''
-FF_FINAL_THRESHOLD = '%s_%s_%%s' %(C_THRESHOLD, FTR_FINAL_THRESHOLD)
+FF_FINAL_THRESHOLD = '%s_%s_%%s' % (C_THRESHOLD, FTR_FINAL_THRESHOLD)
 
 FTR_ORIG_THRESHOLD = "OrigThreshold"
 
 '''Format string for the OrigThreshold feature name'''
-FF_ORIG_THRESHOLD = '%s_%s_%%s' % (C_THRESHOLD,FTR_ORIG_THRESHOLD)
+FF_ORIG_THRESHOLD = '%s_%s_%%s' % (C_THRESHOLD, FTR_ORIG_THRESHOLD)
 
 FTR_WEIGHTED_VARIANCE = "WeightedVariance"
 
@@ -111,7 +111,7 @@ FF_CHILDREN_COUNT = "%s_%%s_Count" % C_CHILDREN
 FF_PARENT = "%s_%%s" % C_PARENT
 
 '''Threshold scope = automatic - use defaults of global + MCT, no adjustments'''
-TS_AUTOMATIC ="Automatic"
+TS_AUTOMATIC = "Automatic"
 
 '''Threshold scope = global - one threshold per image'''
 TS_GLOBAL = "Global"
@@ -131,7 +131,7 @@ TS_BINARY_IMAGE = "Binary image"
 '''Threshold scope = measurement - use a measurement value as the threshold'''
 TS_MEASUREMENT = "Measurement"
 
-TS_ALL = [TS_AUTOMATIC, TS_GLOBAL, TS_ADAPTIVE, TS_PER_OBJECT, TS_MANUAL, 
+TS_ALL = [TS_AUTOMATIC, TS_GLOBAL, TS_ADAPTIVE, TS_PER_OBJECT, TS_MANUAL,
           TS_BINARY_IMAGE, TS_MEASUREMENT]
 
 '''The legacy choice of object in per-object measurements
@@ -155,29 +155,31 @@ PROTIP_RECOMEND_ICON = "thumb-up.png"
 PROTIP_AVOID_ICON = "thumb-down.png"
 TECH_NOTE_ICON = "gear.png"
 
+
 class Identify(cellprofiler.cpmodule.CPModule):
-    threshold_setting_version = 1
-    def create_threshold_settings(self, methods = TM_METHODS):
-        
+    threshold_setting_version = 2
+
+    def create_threshold_settings(self, methods=TM_METHODS):
+
         '''Create settings related to thresholding'''
         # The threshold setting version is invisible to the user
         self.threshold_setting_version = cps.Integer(
-            "Threshold setting version", 
-            value = self.threshold_setting_version)
-        
+                "Threshold setting version",
+                value=self.threshold_setting_version)
+
         self.threshold_scope = cps.Choice(
-            'Threshold strategy',
-            TS_ALL, doc = """
+                'Threshold strategy',
+                TS_ALL, doc="""
             The thresholding strategy determines the type of input that is used
             to calculate the threshold. The image thresholds can be based on:
             <ul>
             <li>The pixel intensities of the input image (this is the most common).</li>
             <li>A single value manually provided by the user.</li>
             <li>A single value produced by a prior module measurement.</li>
-            <li>A binary image (called a <i>mask</i>) where some of the pixel intensity 
+            <li>A binary image (called a <i>mask</i>) where some of the pixel intensity
             values are set to 0, and others are set to 1.</li>
             </ul>
-            These options allow you to calculate a threshold based on the whole 
+            These options allow you to calculate a threshold based on the whole
             image or based on image sub-regions such as user-defined masks or
             objects supplied by a prior module.
             <br>
@@ -185,7 +187,7 @@ class Identify(cellprofiler.cpmodule.CPModule):
             <br><ul>
             <li><i>%(TS_AUTOMATIC)s:</i> Use the default settings for
             thresholding. This strategy calculates the threshold using the %(TM_MCT)s method
-            on the whole image (see below for details on this method) and applies the 
+            on the whole image (see below for details on this method) and applies the
             threshold to the image, smoothed with a Gaussian with sigma of 1.
             <dl>
             <dd><img src="memory:%(PROTIP_RECOMEND_ICON)s">&nbsp;
@@ -193,7 +195,7 @@ class Identify(cellprofiler.cpmodule.CPModule):
             algorithm and does not allow you to apply additional corrections to the
             threshold.</dd>
             </dl></li>
-            
+
             <li><i>%(TS_GLOBAL)s:</i> Calculate a single threshold value based on
             the unmasked pixels of the input image and use that value
             to classify pixels above the threshold as foreground and below
@@ -203,7 +205,7 @@ class Identify(cellprofiler.cpmodule.CPModule):
             This strategy is fast and robust, especially if
             the background is uniformly illuminated.</dd>
             </dl></li>
-            
+
             <li><i>%(TS_ADAPTIVE)s:</i> Partition the input image into tiles
             and calculate thresholds for each tile. For each tile, the calculated
             threshold is applied only to the pixels within that tile. <br>
@@ -213,19 +215,19 @@ class Identify(cellprofiler.cpmodule.CPModule):
             However, for signifcant illumination variation, using the <b>CorrectIllumination</b>
             modules is preferable.</dd>
             </dl></li>
-            
+
             <li><i>%(TS_PER_OBJECT)s:</i> Use objects from a prior module
             such as <b>IdentifyPrimaryObjects</b> to define the region of interest
-            to be thresholded. Calculate a separate threshold for each object and 
-            then apply that threshold to pixels within the object. The pixels outside 
+            to be thresholded. Calculate a separate threshold for each object and
+            then apply that threshold to pixels within the object. The pixels outside
             the objects are classified as background.
             <dl>
             <dd><img src="memory:%(PROTIP_RECOMEND_ICON)s">&nbsp;
-            This method can be useful for identifying sub-cellular particles or 
+            This method can be useful for identifying sub-cellular particles or
             single-molecule probes if the background intensity varies from cell to cell
             (e.g., autofluorescence or other mechanisms).</dd>
             </dl></li>
-            
+
             <li><i>%(TS_MANUAL)s:</i> Enter a single value between zero and
             one that applies to all cycles and is independent of the input
             image.
@@ -235,53 +237,53 @@ class Identify(cellprofiler.cpmodule.CPModule):
             negligible background, or if the input image is the probability
             map output of the <b>ClassifyPixels</b> module (in which case, a value
             of 0.5 should be chosen). If the input image is already binary (i.e.,
-            where the foreground is 1 and the background is 0), a manual value 
+            where the foreground is 1 and the background is 0), a manual value
             of 0.5 will identify the objects.</dd>
             </dl></li>
-            
+
             <li><i>%(TS_BINARY_IMAGE)s:</i> Use a binary image to classify
             pixels as foreground or background. Pixel values other than zero
             will be foreground and pixel values that are zero will be
-            background. This method can be used to import a ground-truth segmentation created 
-            by CellProfiler or another program. 
+            background. This method can be used to import a ground-truth segmentation created
+            by CellProfiler or another program.
             <dl>
             <dd><img src="memory:%(PROTIP_RECOMEND_ICON)s">&nbsp;
-            The most typical approach to produce a 
-            binary image is to use the <b>ApplyThreshold</b> module (image as input, 
-            image as output) or the <b>ConvertObjectsToImage</b> module (objects as input, 
-            image as output); both have options to produce a binary image. It can also be 
-            used to create objects from an image mask produced by other CellProfiler 
-            modules, such as <b>Morph</b>. Note that even though no algorithm is actually 
-            used to find the threshold in this case, the final threshold value is reported 
+            The most typical approach to produce a
+            binary image is to use the <b>ApplyThreshold</b> module (image as input,
+            image as output) or the <b>ConvertObjectsToImage</b> module (objects as input,
+            image as output); both have options to produce a binary image. It can also be
+            used to create objects from an image mask produced by other CellProfiler
+            modules, such as <b>Morph</b>. Note that even though no algorithm is actually
+            used to find the threshold in this case, the final threshold value is reported
             as the <i>%(TM_OTSU)s</i> threshold calculated for the foreground region.</dd>
             </dl></li>
-            
+
             <li><i>%(TS_MEASUREMENT)s:</i> Use a prior image measurement as the
             threshold. The measurement should have values between zero and one.
-            This strategy can be used to apply a pre-calculated threshold imported 
+            This strategy can be used to apply a pre-calculated threshold imported
             as per-image metadata via the <b>Metadata</b> module.
             <dl>
             <dd><img src="memory:%(PROTIP_RECOMEND_ICON)s">&nbsp;
-            Like manual thresholding, this approach can be useful when you are certain what 
-            the cutoff should be. The difference in this case is that the desired threshold does 
+            Like manual thresholding, this approach can be useful when you are certain what
+            the cutoff should be. The difference in this case is that the desired threshold does
             vary from image to image in the experiment but can be measured using another module,
             such as one of the <b>Measure</b> modules, <b>ApplyThreshold</b> or
             an <b>Identify</b> module.</dd>
             </dl></li>
             </ul>
 	    """ % globals())
-        
+
         self.threshold_method = cps.Choice(
-            'Thresholding method',
-            methods, doc="""
+                'Thresholding method',
+                methods, doc="""
             The intensity threshold affects the decision of whether each pixel
             will be considered foreground (region(s) of interest) or background.
-            A higher threshold value will result in only the brightest regions being identified, 
-            whereas a lower threshold value will include dim regions. You can have the threshold 
-            automatically calculated from a choice of several methods, 
+            A higher threshold value will result in only the brightest regions being identified,
+            whereas a lower threshold value will include dim regions. You can have the threshold
+            automatically calculated from a choice of several methods,
             or you can enter a number manually between 0 and 1 for the threshold.
-            
-            <p>Both the automatic and manual options have advantages and disadvantages. 
+
+            <p>Both the automatic and manual options have advantages and disadvantages.
             <dl>
             <dd><img src="memory:%(PROTIP_RECOMEND_ICON)s">&nbsp;
             An automatically-calculated threshold adapts to changes in
@@ -292,122 +294,122 @@ class Identify(cellprofiler.cpmodule.CPModule):
             <dd>In contrast, an advantage of a manually-entered number is that it treats every image identically,
             so use this option when you have a good sense for what the threshold should be
             across all images. To help determine the choice of threshold manually, you
-            can inspect the pixel intensities in an image of your choice. 
+            can inspect the pixel intensities in an image of your choice.
             %(HELP_ON_PIXEL_INTENSITIES)s. </dd>
             <dd><img src="memory:%(PROTIP_AVOID_ICON)s">&nbsp;
-            The manual method is not robust with regard to slight changes in lighting/staining 
+            The manual method is not robust with regard to slight changes in lighting/staining
             conditions between images. </dd>
-            <dd>The automatic methods may ocasionally produce a poor 
+            <dd>The automatic methods may ocasionally produce a poor
             threshold for unusual or artifactual images. It also takes a small amount of time to
             calculate, which can add to processing time for analysis runs on a large
             number of images.</dd>
             </dl></p>
-            
-            <p>The threshold that is used for each image is recorded as a per-image 
+
+            <p>The threshold that is used for each image is recorded as a per-image
             measurement, so if you are surprised by unusual measurements from
             one of your images, you might check whether the automatically calculated
             threshold was unusually high or low compared to the other images. See the
             <b>FlagImage</b> module if you would like to flag an image based on the threshold
             value.</p>
-            
+
             <p>There are a number of methods for finding thresholds automatically:
             <ul>
             <li><i>%(TM_OTSU)s:</i> This approach calculates the threshold separating the
-            two classes of pixels (foreground and background) by minimizing the variance within the 
+            two classes of pixels (foreground and background) by minimizing the variance within the
             each class.
             <dl>
             <dd><img src="memory:%(PROTIP_RECOMEND_ICON)s">&nbsp;
             This method is a good initial approach if you do not know much about
-            the image characteristics of all the images in your experiment, 
-            especially if the percentage of the image covered by foreground varies 
+            the image characteristics of all the images in your experiment,
+            especially if the percentage of the image covered by foreground varies
             substantially from image to image. </dd>
             </dl>
             <dl>
             <dd><img src="memory:%(TECH_NOTE_ICON)s">&nbsp;
-            Our implementation of Otsu's method allows for assigning the threhsold value based on
-            splitting the image into either two classes (foreground and background) or three classes 
+            Our implementation of Otsu's method allows for assigning the threshold value based on
+            splitting the image into either two classes (foreground and background) or three classes
             (foreground, mid-level, and background). See the help below for more details.</dd>
             </dl>
             </li>
-            
-            <li><i>Mixture of Gaussian (%(TM_MOG)s):</i>This function assumes that the 
+
+            <li><i>Mixture of Gaussian (%(TM_MOG)s):</i>This function assumes that the
             pixels in the image belong to either a background class or a foreground
-            class, using an initial guess of the fraction of the image that is 
-            covered by foreground. 
+            class, using an initial guess of the fraction of the image that is
+            covered by foreground.
             <dl>
             <dd><img src="memory:%(PROTIP_RECOMEND_ICON)s">&nbsp;
-            If you know that the percentage of each image that is foreground does not 
-            vary much from image to image, the %(TM_MOG)s method can be better, especially if the 
+            If you know that the percentage of each image that is foreground does not
+            vary much from image to image, the %(TM_MOG)s method can be better, especially if the
             foreground percentage is not near 50%%.</dd>
             </dl>
             <dl>
             <dd><img src="memory:%(TECH_NOTE_ICON)s">&nbsp;
             This method is our own version of a Mixture of Gaussians
             algorithm (<i>O. Friman, unpublished</i>). Essentially, there are two steps:
-            <ol><li>First, a number of Gaussian distributions are estimated to 
-            match the distribution of pixel intensities in the image. Currently 
-            three Gaussian distributions are fitted, one corresponding to a 
-            background class, one corresponding to a foreground class, and one 
+            <ol><li>First, a number of Gaussian distributions are estimated to
+            match the distribution of pixel intensities in the image. Currently
+            three Gaussian distributions are fitted, one corresponding to a
+            background class, one corresponding to a foreground class, and one
             distribution for an intermediate class. The distributions are fitted
-            using the Expectation-Maximization algorithm, a procedure referred 
+            using the Expectation-Maximization algorithm, a procedure referred
             to as Mixture of Gaussians modeling. </li>
-            <li>When the three Gaussian distributions have been fitted, a decision 
-            is made whether the intermediate class more closely models the background pixels 
+            <li>When the three Gaussian distributions have been fitted, a decision
+            is made whether the intermediate class more closely models the background pixels
             or foreground pixels, based on the estimated fraction provided by the user.</li></ol></dd>
             </dl>
             </li>
-            
-            <li><i>%(TM_BACKGROUND)s:</i> This method simply finds the mode of the 
-            histogram of the image, which is assumed to be the background of the 
-            image, and chooses a threshold at twice that value (which you can 
-            adjust with a Threshold Correction Factor; see below).  The calculation 
-	    includes those pixels between 2%% and 98%% of the intensity range. 
+
+            <li><i>%(TM_BACKGROUND)s:</i> This method simply finds the mode of the
+            histogram of the image, which is assumed to be the background of the
+            image, and chooses a threshold at twice that value (which you can
+            adjust with a Threshold Correction Factor; see below).  The calculation
+	    includes those pixels between 2%% and 98%% of the intensity range.
             <dl>
             <dd><img src="memory:%(PROTIP_RECOMEND_ICON)s">&nbsp;
-            This thresholding method is appropriate for images in which most of the image is background. 
-	    It can also be helpful if your images vary in overall brightness, but the objects of 
+            This thresholding method is appropriate for images in which most of the image is background.
+	    It can also be helpful if your images vary in overall brightness, but the objects of
             interest are consistently <i>N</i> times brighter than the background level of the image.</dd>
             </dl></li>
-            
-            <li><i>%(TM_ROBUST_BACKGROUND)s:</i> Much like the %(TM_BACKGROUND)s: method, this method is 
+
+            <li><i>%(TM_ROBUST_BACKGROUND)s:</i> Much like the %(TM_BACKGROUND)s: method, this method is
 	    also simple and assumes that the background distribution
-	    approximates a Gaussian by trimming the brightest and dimmest 5%% of pixel 
-	    intensities. It then calculates the mean and standard deviation of the 
-            remaining pixels and calculates the threshold as the mean + 2 times 
-            the standard deviation. 
+	    approximates a Gaussian by trimming the brightest and dimmest 5%% of pixel
+	    intensities. It then calculates the mean and standard deviation of the
+            remaining pixels and calculates the threshold as the mean + 2 times
+            the standard deviation.
             <dl>
             <dd><img src="memory:%(PROTIP_RECOMEND_ICON)s">&nbsp;
             This thresholding method can be helpful if the majority
 	    of the image is background, and the results are often comparable or better than the
 	    <i>%(TM_BACKGROUND)s</i> method.</dd></dl></li>
-            
+
             <li><i>%(TM_RIDLER_CALVARD)s:</i> This method is simple and its results are
-            often very similar to <i>%(TM_OTSU)s</i>. 
-            <i>%(TM_RIDLER_CALVARD)s</i> chooses an initial threshold and then iteratively 
-            calculates the next one by taking the mean of the average intensities of 
-            the background and foreground pixels determined by the first threshold. 
+            often very similar to <i>%(TM_OTSU)s</i>.
+            <i>%(TM_RIDLER_CALVARD)s</i> chooses an initial threshold and then iteratively
+            calculates the next one by taking the mean of the average intensities of
+            the background and foreground pixels determined by the first threshold.
             The algorithm then repeats this process until the threshold converges to a single value.
             <dl>
             <dd></dd>
             <dd><img src="memory:%(TECH_NOTE_ICON)s">&nbsp;
-            This is an implementation of the method described in Ridler and Calvard, 1978. 
-            According to Sezgin and Sankur 2004, Otsu's 
-            overall quality on testing 40 nondestructive testing images is slightly 
+            This is an implementation of the method described in Ridler and Calvard, 1978.
+            According to Sezgin and Sankur 2004, Otsu's
+            overall quality on testing 40 nondestructive testing images is slightly
             better than Ridler's (average error: Otsu, 0.318; Ridler, 0.401).</dd>
             </dl>
             </li>
-            
-            <li><i>%(TM_KAPUR)s:</i> This method computes the threshold of an image by 
-            searching for the threshold that maximizes the sum of entropies of the foreground 
+
+            <li><i>%(TM_KAPUR)s:</i> This method computes the threshold of an image by
+            searching for the threshold that maximizes the sum of entropies of the foreground
             and background pixel values, when treated as separate distributions.
             <dl>
             <dd><img src="memory:%(TECH_NOTE_ICON)s">&nbsp;
             This is an implementation of the method described in Kapur <i>et al</i>, 1985.</dd>
             </dl></li>
-            
-            <li><i>Maximum correlation thresholding (%(TM_MCT)s):</i> This method computes 
+
+            <li><i>Maximum correlation thresholding (%(TM_MCT)s):</i> This method computes
             the maximum correlation between the binary mask created by thresholding and
-            the thresholded image and is somewhat similar mathematically to <i>%(TM_OTSU)s</i>. 
+            the thresholded image and is somewhat similar mathematically to <i>%(TM_OTSU)s</i>.
             <dl>
             <dd><img src="memory:%(PROTIP_RECOMEND_ICON)s">&nbsp;
             The authors of this method claim superior results when thresholding images
@@ -417,34 +419,48 @@ class Identify(cellprofiler.cpmodule.CPModule):
             <dd><img src="memory:%(TECH_NOTE_ICON)s">&nbsp;
             This is an implementation of the method described in Padmanabhan <i>et al</i>, 2010.</dd>
             </dl></li>
+
+            <li><i>Size interval precision (%(TM_SIZE_INTERVAL_PRECISION)s):</i> This method computes
+            the threshold level that optimizes the global precision with regards to a given
+            expected object size range.</i>.
+            <dl>
+            <dd><img src="memory:%(PROTIP_RECOMEND_ICON)s">&nbsp;
+            The authors of this method claim superior results when thresholding images
+            of known expected object size range.</dd>
+            </dl>
+            <dl>
+            <dd><img src="memory:%(TECH_NOTE_ICON)s">&nbsp;
+            This is an implementation of the method described in Ranefall and Wahlby, 2016.</dd>
+            </dl></li>
             </ul>
-            
+
             <p><b>References</b>
             <ul>
-            <li>Sezgin M, Sankur B (2004) "Survey over image thresholding techniques and quantitative 
+            <li>Sezgin M, Sankur B (2004) "Survey over image thresholding techniques and quantitative
             performance evaluation." <i>Journal of Electronic Imaging</i>, 13(1), 146-165.
             (<a href="http://dx.doi.org/10.1117/1.1631315">link</a>)</li>
             <li>Padmanabhan K, Eddy WF, Crowley JC (2010) "A novel algorithm for
-            optimal image thresholding of biological data" <i>Journal of 
+            optimal image thresholding of biological data" <i>Journal of
             Neuroscience Methods</i> 193, 380-384.
             (<a href="http://dx.doi.org/10.1016/j.jneumeth.2010.08.031">link</a>)</li>
             <li>Ridler T, Calvard S (1978) "Picture thresholding using an iterative selection method",
             <i>IEEE Transactions on Systems, Man and Cybernetics</i>, 8(8), 630-632.</li>
-            <li>Kapur JN, Sahoo PK, Wong AKC (1985) "A new method of gray level picture thresholding 
-            using the entropy of the histogram." <i>Computer Vision, Graphics and Image Processing</i>, 
+            <li>Kapur JN, Sahoo PK, Wong AKC (1985) "A new method of gray level picture thresholding
+            using the entropy of the histogram." <i>Computer Vision, Graphics and Image Processing</i>,
             29, 273-285.</li>
+            <li>Ranefall P, Wahlby C (2016) "Global Gray-level Thresholding Based on Object Size." <i>Cytometry Part A</i>, 89:4, 385-390.</li>
             </ul></p>
-            """%globals())
-        
+            """ % globals())
+
         self.threshold_smoothing_choice = cps.Choice(
-            "Select the smoothing method for thresholding", 
-            [TSM_AUTOMATIC, TSM_MANUAL, TSM_NONE], doc = """
+                "Select the smoothing method for thresholding",
+                [TSM_AUTOMATIC, TSM_MANUAL, TSM_NONE], doc="""
             <i>(Only used for strategies other than %(TS_AUTOMATIC)s and
             %(TS_BINARY_IMAGE)s)</i><br>
             The input image can be optionally smoothed before being thresholded.
-            Smoothing can improve the uniformity of the resulting objects, by 
-            removing holes and jagged edges caused by noise in the acquired image. 
-            Smoothing is most likely <i>not</i> appropriate if the input image is 
+            Smoothing can improve the uniformity of the resulting objects, by
+            removing holes and jagged edges caused by noise in the acquired image.
+            Smoothing is most likely <i>not</i> appropriate if the input image is
             binary, if it has already been smoothed or if it is an output of the
             <i>ClassifyPixels</i> module.<br>
             The choices are:
@@ -454,44 +470,44 @@ class Identify(cellprofiler.cpmodule.CPModule):
             for most analysis applications.</li>
             <li><i>%(TSM_MANUAL)s</i>: Smooth the image with a Gaussian with
             user-controlled scale.</li>
-            <li><i>%(TSM_NONE)s</i>: Do not apply any smoothing prior to 
+            <li><i>%(TSM_NONE)s</i>: Do not apply any smoothing prior to
             thresholding.</li>
             </ul>""" % globals())
-        
+
         self.threshold_smoothing_scale = cps.Float(
-            "Threshold smoothing scale", 1.0, minval = 0,doc ="""
+                "Threshold smoothing scale", 1.0, minval=0, doc="""
             <i>(Only used if smoothing for threshold is %(TSM_MANUAL)s)</i><br>
             This setting controls the scale used to smooth the input image
             before the threshold is applied. The scale should be approximately
             the size of the artifacts to be eliminated by smoothing. A Gaussian
             is used with a sigma adjusted so that 1/2 of the Gaussian's
             distribution falls within the diameter given by the scale
-            (sigma = scale / 0.674)"""%globals())
+            (sigma = scale / 0.674)""" % globals())
 
         self.threshold_correction_factor = cps.Float(
-            "Threshold correction factor", 1, doc ="""
+                "Threshold correction factor", 1, doc="""
             This setting allows you to adjust the threshold as calculated by the
-            above method. The value entered here adjusts the threshold either 
-            upwards or downwards, by multiplying it by this value. 
-            A value of 1 means no adjustment, 0 to 1 makes the threshold more 
-            lenient and &gt; 1 makes the threshold more stringent. 
+            above method. The value entered here adjusts the threshold either
+            upwards or downwards, by multiplying it by this value.
+            A value of 1 means no adjustment, 0 to 1 makes the threshold more
+            lenient and &gt; 1 makes the threshold more stringent.
             <dl>
             <dd><img src="memory:%(PROTIP_RECOMEND_ICON)s">&nbsp;
-            When the threshold is calculated automatically, you may find that 
+            When the threshold is calculated automatically, you may find that
             the value is consistently too stringent or too lenient across all
             images. This setting
-            is helpful for adjusting the threshold to a value that you empirically 
+            is helpful for adjusting the threshold to a value that you empirically
             determine is more suitable. For example, the
             %(TM_OTSU)s automatic thresholding inherently assumes that 50%% of the image is
             covered by objects. If a larger percentage of the image is covered, the
             Otsu method will give a slightly biased threshold that may have to be
             corrected using this setting.</dd>
-            </dl>"""%globals())
-        
+            </dl>""" % globals())
+
         self.threshold_range = cps.FloatRange(
-            'Lower and upper bounds on threshold', (0,1), minval=0,
-            maxval=1, doc="""
-            Enter the minimum and maximum allowable threshold, a value from 0 to 1.  
+                'Lower and upper bounds on threshold', (0, 1), minval=0,
+                maxval=1, doc="""
+            Enter the minimum and maximum allowable threshold, a value from 0 to 1.
             This is helpful as a safety precaution when the threshold is calculated
             automatically, by overriding the automatic threshold.
             <dl>
@@ -503,108 +519,209 @@ class Identify(cellprofiler.cpmodule.CPModule):
             In such cases, you can estimate the background pixel intensity and set the lower
             bound according to this empirically-determined value. </dd>
             <dd>%(HELP_ON_PIXEL_INTENSITIES)s</dd>
-            </dl>"""%globals())
-        
+            </dl>""" % globals())
+
         self.object_fraction = cps.CustomChoice(
-            'Approximate fraction of image covered by objects?', 
-            ['0.01','0.1','0.2','0.3', '0.4','0.5','0.6','0.7', '0.8','0.9','0.99'], doc="""
+                'Approximate fraction of image covered by objects?',
+                ['0.01', '0.1', '0.2', '0.3', '0.4', '0.5', '0.6', '0.7', '0.8', '0.9', '0.99'], doc="""
             <i>(Used only when applying the %(TM_MOG)s thresholding method)</i><br>
             Enter an estimate of how much of the image is covered with objects, which
-            is used to estimate the distribution of pixel intensities."""%globals())
-        
+            is used to estimate the distribution of pixel intensities.""" % globals())
+
         self.manual_threshold = cps.Float(
-            "Manual threshold", 
-             value=0.0, minval=0.0, maxval=1.0,doc="""
+                "Manual threshold",
+                value=0.0, minval=0.0, maxval=1.0, doc="""
             <i>(Used only if Manual selected for thresholding method)</i><br>
             Enter the value that will act as an absolute threshold for the images, a value from 0 to 1.""")
-        
+
         self.thresholding_measurement = cps.Measurement("Select the measurement to threshold with",
-            lambda : cpmeas.IMAGE, doc = """
+                                                        lambda: cpmeas.IMAGE, doc="""
             <i>(Used only if Measurement is selected for thresholding method)</i><br>
             Choose the image measurement that will act as an absolute threshold for the images.""")
-        
+
         self.binary_image = cps.ImageNameSubscriber(
-            "Select binary image", cps.NONE, doc = """
+                "Select binary image", cps.NONE, doc="""
             <i>(Used only if Binary image selected for thresholding method)</i><br>
             Select the binary image to be used for thresholding.""")
-        
+
         self.masking_objects = MaskObjectNameSubscriber(
-            "Masking objects", cps.NONE,doc = """
+                "Masking objects", cps.NONE, doc="""
             <i>(Used only if %(TS_PER_OBJECT)s is selected for the
             thresholding strategy)</i><br>A threshold will be calculated for
             each object and applied to the pixels inside that object. Pixels
             outside of any object will be assigned to the background.
             You can either select a prior object or if you select <i>%(O_FROM_IMAGE)s,</i>
-            the input image's mask will be used.</p>"""%globals())
-        
+            the input image's mask will be used.</p>""" % globals())
+
         self.two_class_otsu = cps.Choice(
-            'Two-class or three-class thresholding?',
-            [O_TWO_CLASS, O_THREE_CLASS],doc="""
+                'Two-class or three-class thresholding?',
+                [O_TWO_CLASS, O_THREE_CLASS], doc="""
             <i>(Used only for the Otsu thresholding method)</i> <br>
             <ul>
-            <li><i>%(O_TWO_CLASS)s:</i> Select this option if the grayscale levels are readily 
-            distinguishable into only two classes: foreground (i.e., regions of interest) 
+            <li><i>%(O_TWO_CLASS)s:</i> Select this option if the grayscale levels are readily
+            distinguishable into only two classes: foreground (i.e., regions of interest)
             and background.</li>
-            <li><i>%(O_THREE_CLASS)s</i>: Choose this option if the grayscale 
+            <li><i>%(O_THREE_CLASS)s</i>: Choose this option if the grayscale
             levels fall instead into three classes: foreground, background and a middle intensity
-            between the two. You will then be asked whether 
-            the middle intensity class should be added to the foreground or background 
+            between the two. You will then be asked whether
+            the middle intensity class should be added to the foreground or background
             class in order to generate the final two-class output. </li>
             </ul>
-            Note that whether 
-            two- or three-class thresholding is chosen, the image pixels are always 
+            Note that whether
+            two- or three-class thresholding is chosen, the image pixels are always
             finally assigned two classes: foreground and background.
             <dl>
             <dd><img src="memory:%(PROTIP_RECOMEND_ICON)s">&nbsp;
-            Three-class thresholding may be useful for images in which you have nuclear staining along with 
+            Three-class thresholding may be useful for images in which you have nuclear staining along with
             low-intensity non-specific cell staining. Where two-class thresholding
-            might incorrectly assign this intermediate staining to the nuclei 
-            objects for some cells, three-class thresholding allows you to assign it to the 
+            might incorrectly assign this intermediate staining to the nuclei
+            objects for some cells, three-class thresholding allows you to assign it to the
             foreground or background as desired. </dd>
             </dl>
             <dl>
             <dd><img src="memory:%(PROTIP_AVOID_ICON)s">&nbsp;
-            However, in extreme cases where either 
-            there are almost no objects or the entire field of view is covered with 
+            However, in extreme cases where either
+            there are almost no objects or the entire field of view is covered with
             objects, three-class thresholding may perform worse than two-class.</dd>
-            </dl>"""%globals())
-        
+            </dl>""" % globals())
+
         self.use_weighted_variance = cps.Choice(
-            'Minimize the weighted variance or the entropy?',
-            [O_WEIGHTED_VARIANCE, O_ENTROPY])
-        
+                'Minimize the weighted variance or the entropy?',
+                [O_WEIGHTED_VARIANCE, O_ENTROPY])
+
         self.assign_middle_to_foreground = cps.Choice(
-            'Assign pixels in the middle intensity class to the foreground '
-            'or the background?', [O_FOREGROUND, O_BACKGROUND],doc="""
+                'Assign pixels in the middle intensity class to the foreground '
+                'or the background?', [O_FOREGROUND, O_BACKGROUND], doc="""
             <i>(Used only for three-class thresholding)</i><br>
-            Choose whether you want the pixels with middle grayscale intensities to be assigned 
+            Choose whether you want the pixels with middle grayscale intensities to be assigned
             to the foreground class or the background class.""")
-        
+
+        self.rb_custom_choice = cps.Choice(
+                "Use default parameters?", [RB_DEFAULT, RB_CUSTOM],
+                doc="""
+            <i>(Used only with the %(TM_ROBUST_BACKGROUND)s method)</i><br>
+            This setting determines whether the %(TM_ROBUST_BACKGROUND)s method
+            uses its default parameters or lets the user customize them.
+            <ul>
+            <li><i>%(RB_DEFAULT)s:</i> Use the default parameters,
+            discarding the 5%% highest and lowest
+            intensity pixels and calculating the threshold as the mean plus
+            two standard deviations of the remaining pixels.</li>
+            <li><i>%(RB_CUSTOM)s:</i> Choose this option to fully customize the method.</li>
+            </ul>
+            """ % globals())
+
+        self.lower_outlier_fraction = cps.Float(
+                "Lower outlier fraction", .05,
+                minval=0,
+                maxval=1,
+                doc="""
+            <i>(Used only when customizing the %(TM_ROBUST_BACKGROUND)s method)</i><br>
+            Discard this fraction of the pixels in the image starting with
+            those of the lowest intensity.
+            """ % globals())
+
+        self.upper_outlier_fraction = cps.Float(
+                "Upper outlier fraction", .05,
+                minval=0,
+                maxval=1,
+                doc="""
+            <i>(Used only when customizing the %(TM_ROBUST_BACKGROUND)s method)</i><br>
+            Discard this fraction of the pixels in the image starting with
+            those of the highest intensity.
+            """ % globals())
+
+        self.averaging_method = cps.Choice(
+                "Averaging method",
+                [RB_MEAN, RB_MEDIAN, RB_MODE],
+                doc="""
+            <i>(Used only when customizing the %(TM_ROBUST_BACKGROUND)s method)</i><br>
+            This setting determines how the intensity midpoint is determined.
+            <br><ul><li><i>%(RB_MEAN)s</i>: Use the mean of the pixels
+            remaining after discarding the outliers. This is a good choice if
+            the cell density is variable or high.</li>
+            <li><i>%(RB_MEDIAN)s</i>: Use the median of the pixels. This is a
+            good choice if, for all images, more than half of the pixels
+            are in the background after removing outliers.</li>
+            <li><i>%(RB_MODE)s</i>: Use the most frequently occurring value
+            from among the pixel values. The %(TM_ROBUST_BACKGROUND)s method groups
+            the intensities into bins (the number of bins is the square root
+            of the number of pixels in the unmasked portion of the image) and
+            chooses the intensity associated with the bin with the most pixels.
+            </li></ul>
+            """ % globals())
+        self.variance_method = cps.Choice(
+                "Variance method",
+                [RB_SD, RB_MAD],
+                doc="""
+            <i>(Used only when customizing the %(TM_ROBUST_BACKGROUND)s method)</i><br>
+            Robust background adds a number of deviations (standard or MAD) to
+            the average to get the final background. This setting chooses the
+            method used to assess the variance in the pixels, after removing
+            outliers.<br>Choose one of <i>%(RB_SD)s</i> or <i>%(RB_MAD)s</i>
+            (the median of the absolute difference of the pixel intensities
+            from their median).
+            """ % globals())
+
+        self.number_of_deviations = cps.Float(
+                "# of deviations", 2,
+                doc="""
+            <i>(Used only when customizing the %(TM_ROBUST_BACKGROUND)s method)</i><br>
+            Robust background calculates the variance, multiplies it by the
+            value given by this setting and adds it to the average. Adding
+            several deviations raises the background value above the average,
+            which should be close to the average background, excluding most
+            background pixels. Use a larger number to exclude more background
+            pixels. Use a smaller number to include more low-intensity
+            foreground pixels. It's possible to use a negative number
+            to lower the threshold if the averaging method picks a threshold
+            that is within the range of foreground pixel intensities.
+            """ % globals())
+
         self.adaptive_window_method = cps.Choice(
-            "Method to calculate adaptive window size",
-            [FI_IMAGE_SIZE, FI_CUSTOM], doc="""
+                "Method to calculate adaptive window size",
+                [FI_IMAGE_SIZE, FI_CUSTOM], doc="""
             <i>(Used only if an adaptive thresholding method is used)</i><br>
-            The adaptive method breaks the image into blocks, computing the threshold 
+            The adaptive method breaks the image into blocks, computing the threshold
             for each block. There are two ways to compute the block size:
             <ul>
             <li><i>%(FI_IMAGE_SIZE)s:</i> The block size is one-tenth of the image dimensions,
             or 50 &times; 50 pixels, whichever is bigger.</li>
             <li><i>%(FI_CUSTOM)s:</i> The block size is specified by the user.</li>
-            </ul>"""%globals())
-                                            
+            </ul>""" % globals())
+
         self.adaptive_window_size = cps.Integer(
-            'Size of adaptive window', 10, doc="""
-            <i>(Used only if an adaptive thresholding method with a %(FI_CUSTOM)s window size 
+                'Size of adaptive window', 10, doc="""
+            <i>(Used only if an adaptive thresholding method with a %(FI_CUSTOM)s window size
             are selected)</i><br>
             Enter the window for the adaptive method. For example,
-            you may want to use a multiple of the largest expected object size."""%globals())
-        
+            you may want to use a multiple of the largest expected object size.""" % globals())
+
+        self.min_diameter = cps.Integer(
+                'Minimum value of typical diameter of objects, in pixel units', 10, doc="""
+            Lower limit of expected object diameter. In practise the algorithm uses area limit = PI*d2/4.
+            Note: this interval guides the threshold setting, but the result is a global
+            threshold value. If you want to exclude objects outside a given size range use "Discard objects outside the diameter range".
+            """ % globals())
+
+        self.max_diameter = cps.Integer(
+                'Maximum value of typical diameter of objects, in pixel units', 40, doc="""
+            Upper limit of expected object diameter. In practise the algorithm uses area limit = PI*d2/4.
+            Note: this interval guides the threshold setting, but the result is a global
+            threshold value. If you want to exclude objects outside a given size range use "Discard objects outside the diameter range".
+            """ % globals())
+
+        self.ignore_large = cps.Binary(
+                'Ignore large objects', False, doc="""
+            Use this setting to ignore objects above the upper interval limit. This is used to handle clustered objects. The recommendation is that this should be set to Yes for most applications where there is a risk of having clustered objects.
+            """ % globals())
+
     def get_threshold_settings(self):
         '''Return the threshold settings to be saved in the pipeline'''
         return [self.threshold_setting_version,
-                self.threshold_scope, self.threshold_method, 
-                self.threshold_smoothing_choice, 
-                self.threshold_smoothing_scale, 
+                self.threshold_scope, self.threshold_method,
+                self.threshold_smoothing_choice,
+                self.threshold_smoothing_scale,
                 self.threshold_correction_factor,
                 self.threshold_range,
                 self.object_fraction,
@@ -616,8 +733,17 @@ class Identify(cellprofiler.cpmodule.CPModule):
                 self.use_weighted_variance,
                 self.assign_middle_to_foreground,
                 self.adaptive_window_method,
-                self.adaptive_window_size]
-    
+                self.adaptive_window_size,
+                self.rb_custom_choice,
+                self.lower_outlier_fraction,
+                self.upper_outlier_fraction,
+                self.averaging_method,
+                self.variance_method,
+                self.number_of_deviations,
+                self.min_diameter,
+                self.max_diameter,
+                self.ignore_large]
+
     def get_threshold_help_settings(self):
         '''Return the threshold settings to be displayed in help'''
         return [self.threshold_scope,
@@ -629,26 +755,35 @@ class Identify(cellprofiler.cpmodule.CPModule):
                 self.use_weighted_variance,
                 self.assign_middle_to_foreground,
                 self.object_fraction,
+                self.rb_custom_choice,
+                self.lower_outlier_fraction,
+                self.upper_outlier_fraction,
+                self.averaging_method,
+                self.variance_method,
+                self.number_of_deviations,
                 self.adaptive_window_method,
                 self.adaptive_window_size,
                 self.threshold_correction_factor,
                 self.threshold_range,
                 self.threshold_smoothing_choice,
-                self.threshold_smoothing_scale]
-    
+                self.threshold_smoothing_scale,
+                self.min_diameter,
+                self.max_diameter,
+                self.ignore_large]
+
     def upgrade_legacy_threshold_settings(
-        self, threshold_method, threshold_smoothing_choice, threshold_correction_factor,
-        threshold_range, object_fraction, manual_threshold,
-        thresholding_measurement, binary_image, 
-        two_class_otsu, use_weighted_variance, assign_middle_to_foreground,
-        adaptive_window_method, adaptive_window_size,
-        masking_objects = O_FROM_IMAGE):
+            self, threshold_method, threshold_smoothing_choice, threshold_correction_factor,
+            threshold_range, object_fraction, manual_threshold,
+            thresholding_measurement, binary_image,
+            two_class_otsu, use_weighted_variance, assign_middle_to_foreground,
+            adaptive_window_method, adaptive_window_size, min_diameter, max_diameter, ignore_large,
+            masking_objects=O_FROM_IMAGE):
         '''Return threshold setting strings built from the legacy elements
-        
+
         IdentifyPrimaryObjects, IdentifySecondaryObjects and ApplyThreshold
         used to store their settings independently. This method creates the
         unified settings block from the values in their separate arrangements.
-        
+
         All parameters should be self-explanatory except for
         threshold_smoothing_choice which should be TSM_AUTOMATIC if
         smoothing was applied to the image before thresholding or TSM_NONE
@@ -670,26 +805,36 @@ class Identify(cellprofiler.cpmodule.CPModule):
                 threshold_scope = TS_PER_OBJECT
             elif threshold_scope == TM_ADAPTIVE:
                 threshold_scope = TS_ADAPTIVE
-        setting_values = [ 
+        setting_values = [
             "1", threshold_scope, threshold_method, threshold_smoothing_choice,
             "1", threshold_correction_factor, threshold_range,
-            object_fraction, manual_threshold, thresholding_measurement, 
+            object_fraction, manual_threshold, thresholding_measurement,
             binary_image, masking_objects, two_class_otsu,
-            use_weighted_variance, assign_middle_to_foreground, 
-            adaptive_window_method, adaptive_window_size]
+            use_weighted_variance, assign_middle_to_foreground,
+            adaptive_window_method, adaptive_window_size, min_diameter, max_diameter, ignore_large]
         return setting_values
-        
+
     def upgrade_threshold_settings(self, setting_values):
         '''Upgrade the threshold settings to the current version
-        
+
         use the first setting which is the version to determine the
         threshold settings version and upgrade as appropriate
         '''
         version = int(setting_values[0])
+        if version == 1:
+            # Added robust background settings
+            #
+            setting_values = setting_values + [
+                RB_DEFAULT,  # Robust background custom choice
+                .05, .05,  # lower and upper outlier fractions
+                RB_MEAN,  # averaging method
+                RB_SD,  # variance method
+                2]  # of standard deviations
+            version = 2
         if version > self.threshold_setting_version:
             raise ValueError("Unsupported pipeline version: threshold setting version = %d" % version)
         return setting_values
-    
+
     def get_threshold_visible_settings(self):
         '''Return visible settings related to thresholding'''
         vv = [self.threshold_scope]
@@ -709,50 +854,62 @@ class Identify(cellprofiler.cpmodule.CPModule):
                 vv += [self.two_class_otsu, self.use_weighted_variance]
                 if self.two_class_otsu == O_THREE_CLASS:
                     vv.append(self.assign_middle_to_foreground)
-            if self.threshold_method == TM_MOG:
+            elif self.threshold_method == TM_MOG:
                 vv += [self.object_fraction]
-        if self.threshold_scope != TM_BINARY_IMAGE:
-            vv += [ self.threshold_smoothing_choice]
+            elif self.threshold_method == TM_ROBUST_BACKGROUND:
+                vv += [self.rb_custom_choice]
+                if self.rb_custom_choice == RB_CUSTOM:
+                    vv += [self.lower_outlier_fraction,
+                           self.upper_outlier_fraction,
+                           self.averaging_method,
+                           self.variance_method,
+                           self.number_of_deviations]
+            elif self.threshold_method == TM_SIZE_INTERVAL_PRECISION:
+                vv += [self.min_diameter, self.max_diameter, self.ignore_large]
+        if self.threshold_scope not in \
+                (TS_BINARY_IMAGE, TS_MEASUREMENT, TS_MANUAL):
+            vv += [self.threshold_smoothing_choice]
             if self.threshold_smoothing_choice == TSM_MANUAL:
                 vv += [self.threshold_smoothing_scale]
         if not self.threshold_scope in (TM_MANUAL, TM_BINARY_IMAGE):
-            vv += [ self.threshold_correction_factor, self.threshold_range]
+            vv += [self.threshold_correction_factor, self.threshold_range]
         if self.threshold_scope == TM_ADAPTIVE:
-            vv += [ self.adaptive_window_method ]
+            vv += [self.adaptive_window_method]
             if self.adaptive_window_method == FI_CUSTOM:
-                vv += [ self.adaptive_window_size ]
-            
+                vv += [self.adaptive_window_size]
+
         return vv
-        
-    def threshold_image(self, image_name, workspace, 
+
+    def threshold_image(self, image_name, workspace,
                         wants_local_threshold=False):
         """Compute the threshold using whichever algorithm was selected by the user
-        
+
         image_name - name of the image to use for thresholding
-        
+
         workspace - get any measurements / objects / images from the workspace
-        
+
         returns: thresholded binary image
         """
         #
         # Retrieve the relevant image and mask
         #
         image = workspace.image_set.get_image(image_name,
-                                              must_be_grayscale = True)
+                                              must_be_grayscale=True)
         img = image.pixel_data
         mask = image.mask
         if self.threshold_scope == TS_BINARY_IMAGE:
             binary_image = workspace.image_set.get_image(
-                self.binary_image.value, must_be_binary = True).pixel_data
+                    self.binary_image.value, must_be_binary=True).pixel_data
             self.add_fg_bg_measurements(
-                workspace.measurements, img, mask, binary_image)
+                    workspace.measurements, img, mask, binary_image)
             if wants_local_threshold:
                 return binary_image, None
             return binary_image
         local_threshold, global_threshold = self.get_threshold(
-            image, mask, workspace)
-    
-        if self.threshold_smoothing_choice == TSM_NONE:
+                image, mask, workspace)
+
+        if self.threshold_smoothing_choice == TSM_NONE or \
+                        self.threshold_scope in (TS_MEASUREMENT, TS_MANUAL):
             blurred_image = img
             sigma = 0
         else:
@@ -764,27 +921,29 @@ class Identify(cellprofiler.cpmodule.CPModule):
                 # intensity is contributed from within the smoothing diameter
                 # and 1/2 is contributed from outside.
                 sigma = self.threshold_smoothing_scale.value / 0.6744 / 2.0
+
             def fn(img, sigma=sigma):
                 return scipy.ndimage.gaussian_filter(
-                    img, sigma, mode='constant', cval=0)
+                        img, sigma, mode='constant', cval=0)
+
             blurred_image = smooth_with_function_and_mask(img, fn, mask)
-        if hasattr(workspace,"display_data"):
-            workspace.display_data.threshold_sigma = sigma          
-            
+        if hasattr(workspace, "display_data"):
+            workspace.display_data.threshold_sigma = sigma
+
         binary_image = (blurred_image >= local_threshold) & mask
         self.add_fg_bg_measurements(
-            workspace.measurements, img, mask, binary_image)
+                workspace.measurements, img, mask, binary_image)
         if wants_local_threshold:
             return binary_image, local_threshold
         return binary_image
-        
+
     def get_threshold(self, image, mask, workspace):
         '''Calculate a local and global threshold
-        
+
         img - base the threshold on this image's intensity
-        
+
         mask - use this mask to define the pixels of interest
-        
+
         workspace - get objects and measurements from this workspace and
                     add threshold measurements to this workspace's measurements.
         '''
@@ -796,7 +955,7 @@ class Identify(cellprofiler.cpmodule.CPModule):
                 # Thresholds are stored as single element arrays.  Cast to
                 # float to extract the value.
                 value = float(m.get_current_image_measurement(
-                    self.thresholding_measurement.value))
+                        self.thresholding_measurement.value))
                 value *= self.threshold_correction_factor.value
                 if not self.threshold_range.min is None:
                     value = max(value, self.threshold_range.min)
@@ -810,167 +969,225 @@ class Identify(cellprofiler.cpmodule.CPModule):
                         masking_objects = image.masking_objects
                     else:
                         masking_objects = workspace.object_set.get_objects(
-                            self.masking_objects.value)
+                                self.masking_objects.value)
                     if masking_objects is not None:
                         label_planes = masking_objects.get_labels(img.shape[:2])
+                        if len(label_planes) == 1:
+                            labels = label_planes[0][0]
+                        else:
+                            # For overlaps, we arbitrarily assign a pixel to
+                            # the first label it appears in. Alternate would be
+                            # to average, seems like it's too fine a point
+                            # to deal with it. A third possibility would be to
+                            # treat overlaps as distinct entities since the overlapping
+                            # areas will likely be different than either object.
+                            labels = np.zeros(label_planes[0][0].shape,
+                                              label_planes[0][0].dtype)
+                            for label_plane, indices in label_planes:
+                                labels[labels == 0] = label_plane[labels == 0]
                     else:
-                        label_planes = [image.mask.astype(int)]
-                    if len(label_planes) == 1:
-                        labels = label_planes[0][0]
-                    else:
-                        # For overlaps, we arbitrarily assign a pixel to
-                        # the first label it appears in. Alternate would be
-                        # to average, seems like it's too fine a point
-                        # to deal with it. A third possibility would be to 
-                        # treat overlaps as distinct entities since the overlapping
-                        # areas will likely be different than either object.
-                        labels = np.zeros(label_planes[0][0].shape,
-                                          label_planes[0][0].dtype)
-                        for label_plane, indices in label_planes:
-                            labels[labels == 0] = label_plane[labels == 0]
+                        # use the image mask as the masking objects
+                        labels = image.mask.astype(int)
                 else:
                     labels = None
                 if self.threshold_scope == TS_ADAPTIVE:
                     if self.adaptive_window_method == FI_IMAGE_SIZE:
-                         # The original behavior
+                        # The original behavior
                         image_size = np.array(img.shape[:2], dtype=int)
                         block_size = image_size / 10
-                        block_size[block_size<50] = 50
+                        block_size[block_size < 50] = 50
                     elif self.adaptive_window_method == FI_CUSTOM:
                         block_size = self.adaptive_window_size.value * \
-                            np.array([1,1])
+                                     np.array([1, 1])
                 else:
                     block_size = None
-                object_fraction = self.object_fraction.value
-                if object_fraction.endswith("%"):
-                    object_fraction = float(object_fraction[:-1])/100.0
-                else:
-                    object_fraction = float(object_fraction)
+                kwparams = {}
+                if self.threshold_scope != TS_AUTOMATIC:
+                    #
+                    # General manual parameters
+                    #
+                    kwparams['threshold_range_min'] = self.threshold_range.min
+                    kwparams['threshold_range_max'] = self.threshold_range.max
+                    kwparams['threshold_correction_factor'] = \
+                        self.threshold_correction_factor.value
+                if self.get_threshold_algorithm() == TM_OTSU:
+                    #
+                    # Otsu-specific parameters
+                    #
+                    kwparams['use_weighted_variance'] = \
+                        self.use_weighted_variance.value == O_WEIGHTED_VARIANCE
+                    kwparams['two_class_otsu'] = \
+                        self.two_class_otsu.value == O_TWO_CLASS
+                    kwparams['assign_middle_to_foreground'] = \
+                        self.assign_middle_to_foreground.value == O_FOREGROUND
+                elif self.get_threshold_algorithm() == TM_MOG:
+                    #
+                    # Mixture of gaussian parameters
+                    #
+                    object_fraction = self.object_fraction.value
+                    if object_fraction.endswith("%"):
+                        object_fraction = float(object_fraction[:-1]) / 100.0
+                    else:
+                        object_fraction = float(object_fraction)
+                    kwparams['object_fraction'] = object_fraction
+                elif self.get_threshold_algorithm() == TM_ROBUST_BACKGROUND and \
+                                self.rb_custom_choice == RB_CUSTOM:
+                    kwparams['lower_outlier_fraction'] = \
+                        self.lower_outlier_fraction.value
+                    kwparams['upper_outlier_fraction'] = \
+                        self.upper_outlier_fraction.value
+                    kwparams['deviations_above_average'] = \
+                        self.number_of_deviations.value
+                    kwparams['average_fn'] = {
+                        RB_MEAN: np.mean,
+                        RB_MEDIAN: np.median,
+                        RB_MODE: binned_mode
+                    }.get(self.averaging_method.value, np.mean)
+                    kwparams['variance_fn'] = {
+                        RB_SD: np.std,
+                        RB_MAD: mad}.get(self.variance_method.value, np.std)
+                elif self.get_threshold_algorithm() == TM_SIZE_INTERVAL_PRECISION:
+                    #
+                    # Size interval precicion
+                    #
+                    kwparams['min_diameter'] = self.min_diameter.value
+                    kwparams['max_diameter'] = self.max_diameter.value
+                    kwparams['ignore_large'] = self.ignore_large.value
+
                 local_threshold, global_threshold = get_threshold(
-                    self.threshold_algorithm,
-                    self.threshold_modifier,
-                    img, 
-                    mask = mask,
-                    labels = labels,
-                    threshold_range_min = self.threshold_range.min,
-                    threshold_range_max = self.threshold_range.max,
-                    threshold_correction_factor = self.threshold_correction_factor.value,
-                    object_fraction = object_fraction,
-                    two_class_otsu = self.two_class_otsu.value == O_TWO_CLASS,
-                    use_weighted_variance = self.use_weighted_variance.value == O_WEIGHTED_VARIANCE,
-                    assign_middle_to_foreground = self.assign_middle_to_foreground.value == O_FOREGROUND,
-                    adaptive_window_size = block_size)
+                        self.threshold_algorithm,
+                        self.threshold_modifier,
+                        img,
+                        mask=mask,
+                        labels=labels,
+                        adaptive_window_size=block_size,
+                        **kwparams)
         self.add_threshold_measurements(workspace.measurements,
                                         local_threshold, global_threshold)
         if hasattr(workspace.display_data, "statistics"):
             workspace.display_data.statistics.append(
-                ["Threshold","%0.3f"%(global_threshold)])
-            
+                    ["Threshold", "%0.3g" % global_threshold])
+
         return local_threshold, global_threshold
-    
+
     def get_measurement_objects_name(self):
         '''Return the name of the measurement objects
-        
+
         Identify modules and ApplyThreshold store measurements in the Image
         table and append an object name or, for ApplyThreshold, an image
         name to distinguish between different thresholds in the same pipeline.
         '''
         raise NotImplementedError(
-            "Please implement get_measurement_objects_name() for this module")
-    
+                "Please implement get_measurement_objects_name() for this module")
+
     def add_threshold_measurements(self, measurements,
                                    local_threshold, global_threshold):
-        '''Compute and add threshold statistics measurements 
-        
+        '''Compute and add threshold statistics measurements
+
         measurements - add the measurements here
-        local_threshold - either a per-pixel threshold (a matrix) or a 
+        local_threshold - either a per-pixel threshold (a matrix) or a
                           copy of the global threshold (a scalar)
         global_threshold - the globally-calculated threshold
         '''
         objname = self.get_measurement_objects_name()
         ave_threshold = np.mean(np.atleast_1d(local_threshold))
         measurements.add_measurement(cpmeas.IMAGE,
-                                     FF_FINAL_THRESHOLD%(objname),
+                                     FF_FINAL_THRESHOLD % objname,
                                      ave_threshold)
         measurements.add_measurement(cpmeas.IMAGE,
-                                     FF_ORIG_THRESHOLD%(objname),
+                                     FF_ORIG_THRESHOLD % objname,
                                      global_threshold)
-        
+
     def add_fg_bg_measurements(self, measurements, image, mask, binary_image):
         '''Add statistical measures of the within class variance and entropy
-        
+
         measurements - store measurements here
-        
+
         image - assess the variance and entropy on this intensity image
-        
+
         mask - mask of pixels to be considered
-        
+
         binary_image - the foreground / background segmentation of the image
         '''
         objname = self.get_measurement_objects_name()
         wv = weighted_variance(image, mask, binary_image)
         measurements.add_measurement(cpmeas.IMAGE,
-                                     FF_WEIGHTED_VARIANCE%(objname),
-                                     np.array([wv],dtype=float))
+                                     FF_WEIGHTED_VARIANCE % objname,
+                                     np.array([wv], dtype=float))
         entropies = sum_of_entropies(image, mask, binary_image)
         measurements.add_measurement(cpmeas.IMAGE,
-                                     FF_SUM_OF_ENTROPIES%(objname),
-                                     np.array([entropies],dtype=float))
-        
+                                     FF_SUM_OF_ENTROPIES % objname,
+                                     np.array([entropies], dtype=float))
+
     def validate_module(self, pipeline):
-        if hasattr(self, "object_fraction"):
-            try:
-                if self.object_fraction.value.endswith("%"):
-                    float(self.object_fraction.value[:-1])
-                else:
-                    float(self.object_fraction.value)
-            except ValueError:
-                raise cps.ValidationError("%s is not a floating point value"%
-                                          self.object_fraction.value,
-                                          self.object_fraction)
+        if not hasattr(self, "threshold_scope"):
+            # derived class does not have thresholding settings
+            return
+        if self.threshold_scope in (TS_ADAPTIVE, TS_GLOBAL, TS_PER_OBJECT):
+            if self.get_threshold_algorithm() == TM_MOG:
+                try:
+                    if self.object_fraction.value.endswith("%"):
+                        float(self.object_fraction.value[:-1])
+                    else:
+                        float(self.object_fraction.value)
+                except ValueError:
+                    raise cps.ValidationError("%s is not a floating point value" %
+                                              self.object_fraction.value,
+                                              self.object_fraction)
+            elif self.get_threshold_algorithm() == TM_ROBUST_BACKGROUND and \
+                            self.rb_custom_choice == RB_CUSTOM:
+                if self.lower_outlier_fraction.value + \
+                        self.upper_outlier_fraction.value >= 1:
+                    raise cps.ValidationError(
+                            ("The sum of the lower robust background outlier "
+                             "fraction (%f) and the upper fraction (%f) must "
+                             "be less than one.") % (
+                                self.lower_outlier_fraction.value,
+                                self.upper_outlier_fraction.value),
+                            self.upper_outlier_fraction)
 
     def get_threshold_modifier(self):
         """The threshold algorithm modifier
-        
+
         TM_GLOBAL                       = "Global"
         TM_ADAPTIVE                     = "Adaptive"
         TM_PER_OBJECT                   = "PerObject"
         """
         if self.threshold_scope.value in (TS_AUTOMATIC,
-            TS_GLOBAL, TS_BINARY_IMAGE, TS_MANUAL, TS_MEASUREMENT):
-            return TM_GLOBAL 
+                                          TS_GLOBAL, TS_BINARY_IMAGE, TS_MANUAL, TS_MEASUREMENT):
+            return TM_GLOBAL
         elif self.threshold_scope.value == TS_PER_OBJECT:
             return TM_PER_OBJECT
         return TM_ADAPTIVE
-    
+
     threshold_modifier = property(get_threshold_modifier)
-    
+
     def get_threshold_algorithm(self):
         """The thresholding algorithm, for instance TM_OTSU"""
         if self.threshold_scope == TS_AUTOMATIC:
             return TM_MCT
         return self.threshold_method.value
-    
+
     threshold_algorithm = property(get_threshold_algorithm)
-    
+
     def get_threshold_measurement_columns(self, pipeline):
         '''Return the measurement columns for the threshold measurements'''
         features = [FF_SUM_OF_ENTROPIES, FF_WEIGHTED_VARIANCE]
         if self.threshold_scope != TS_BINARY_IMAGE:
             features += [FF_ORIG_THRESHOLD, FF_FINAL_THRESHOLD]
-        return [(cpmeas.IMAGE, 
+        return [(cpmeas.IMAGE,
                  ftr % self.get_measurement_objects_name(),
                  cpmeas.COLTYPE_FLOAT) for ftr in features]
-    
+
     def get_threshold_categories(self, pipeline, object_name):
         '''Get categories related to thresholding'''
         if object_name == cpmeas.IMAGE:
             return [C_THRESHOLD]
         return []
-    
+
     def get_threshold_measurements(self, pipeline, object_name, category):
         '''Return a list of threshold measurements for a given category
-        
+
         object_name - either "Image" or an object name
         category - must be "Threshold" to get anything back
         '''
@@ -980,26 +1197,26 @@ class Identify(cellprofiler.cpmodule.CPModule):
             return [FTR_ORIG_THRESHOLD, FTR_FINAL_THRESHOLD,
                     FTR_SUM_OF_ENTROPIES, FTR_WEIGHTED_VARIANCE]
         return []
-    
-    def get_threshold_measurement_objects(self, pipeline, object_name, category, 
+
+    def get_threshold_measurement_objects(self, pipeline, object_name, category,
                                           measurement):
         '''Get the measurement objects for a threshold measurement
-        
+
         pipeline - not used
         object_name - either "Image" or an object name. (must be "Image")
         category - the measurement category. (must be "Threshold")
         measurement - the feature being measured
         '''
         if measurement in self.get_threshold_measurements(
-            pipeline, object_name, category):
+                pipeline, object_name, category):
             return [self.get_measurement_objects_name()]
         else:
             return []
-        
-    def get_object_categories(self, pipeline, object_name, 
+
+    def get_object_categories(self, pipeline, object_name,
                               object_dictionary):
         '''Get categories related to creating new children
-        
+
         pipeline - the pipeline being run (not used)
         object_name - the base object of the measurement: "Image" or an object
         object_dictionary - a dictionary where each key is the name of
@@ -1013,23 +1230,23 @@ class Identify(cellprofiler.cpmodule.CPModule):
             result += [C_LOCATION, C_NUMBER]
             if len(object_dictionary[object_name]) > 0:
                 result += [C_PARENT]
-        if object_name in reduce(lambda x,y: x+y, object_dictionary.values()):
+        if object_name in reduce(lambda x, y: x + y, object_dictionary.values()):
             result += [C_CHILDREN]
         return result
-    
+
     def get_object_measurements(self, pipleline, object_name, category,
                                 object_dictionary):
         '''Get measurements related to creating new children
-        
+
         pipeline - the pipeline being run (not used)
         object_name - the base object of the measurement: "Image" or an object
-        object_dictionary - a dictionary where each key is the name of 
+        object_dictionary - a dictionary where each key is the name of
                             an object created by this module and each
                             value is a list of names of parents.
         '''
         if object_name == cpmeas.IMAGE and category == C_COUNT:
             return list(object_dictionary.keys())
-        
+
         if object_dictionary.has_key(object_name):
             if category == C_LOCATION:
                 return [FTR_CENTER_X, FTR_CENTER_Y]
@@ -1044,12 +1261,13 @@ class Identify(cellprofiler.cpmodule.CPModule):
                     result += ["%s_Count" % child_object_name]
             return result
         return []
-    
-def add_object_location_measurements(measurements, 
+
+
+def add_object_location_measurements(measurements,
                                      object_name,
-                                     labels, object_count = None):
+                                     labels, object_count=None):
     """Add the X and Y centers of mass to the measurements
-    
+
     measurements - the measurements container
     object_name  - the name of the objects being measured
     labels       - the label matrix
@@ -1063,27 +1281,28 @@ def add_object_location_measurements(measurements,
     # Get the centers of each object - center_of_mass <- list of two-tuples.
     #
     if object_count:
-        centers = scipy.ndimage.center_of_mass(np.ones(labels.shape), 
-                                               labels, 
-                                               range(1,object_count+1))
+        centers = scipy.ndimage.center_of_mass(np.ones(labels.shape),
+                                               labels,
+                                               range(1, object_count + 1))
         centers = np.array(centers)
-        centers = centers.reshape((object_count,2))
-        location_center_y = centers[:,0]
-        location_center_x = centers[:,1]
-        number = np.arange(1,object_count+1)
+        centers = centers.reshape((object_count, 2))
+        location_center_y = centers[:, 0]
+        location_center_x = centers[:, 1]
+        number = np.arange(1, object_count + 1)
     else:
-        location_center_y = np.zeros((0,),dtype=float)
-        location_center_x = np.zeros((0,),dtype=float)
-        number = np.zeros((0,),dtype=int)
+        location_center_y = np.zeros((0,), dtype=float)
+        location_center_x = np.zeros((0,), dtype=float)
+        number = np.zeros((0,), dtype=int)
     measurements.add_measurement(object_name, M_LOCATION_CENTER_X,
                                  location_center_x)
     measurements.add_measurement(object_name, M_LOCATION_CENTER_Y,
                                  location_center_y)
     measurements.add_measurement(object_name, M_NUMBER_OBJECT_NUMBER, number)
-    
+
+
 def add_object_location_measurements_ijv(measurements,
                                          object_name,
-                                         ijv, object_count = None):
+                                         ijv, object_count=None):
     '''Add object location measurements for IJV-style objects'''
     if object_count is None:
         object_count = 0 if ijv.shape[0] == 0 else np.max(ijv[:, 2])
@@ -1098,20 +1317,21 @@ def add_object_location_measurements_ijv(measurements,
         center_y = np.bincount(ijv[:, 2], ijv[:, 0])[1:] / areas
     measurements.add_measurement(object_name, M_LOCATION_CENTER_X, center_x)
     measurements.add_measurement(object_name, M_LOCATION_CENTER_Y, center_y)
-    measurements.add_measurement(object_name, M_NUMBER_OBJECT_NUMBER, 
-                                 np.arange(1, object_count+1))
-    
+    measurements.add_measurement(object_name, M_NUMBER_OBJECT_NUMBER,
+                                 np.arange(1, object_count + 1))
+
 
 def add_object_count_measurements(measurements, object_name, object_count):
     """Add the # of objects to the measurements"""
     measurements.add_measurement('Image',
-                                 FF_COUNT%(object_name),
+                                 FF_COUNT % object_name,
                                  np.array([object_count],
-                                             dtype=float))
+                                          dtype=float))
+
 
 def get_object_measurement_columns(object_name):
     '''Get the column definitions for measurements made by identify modules
-    
+
     Identify modules can use this call when implementing
     CPModule.get_measurement_columns to get the column definitions for
     the measurements made by add_object_location_measurements and
@@ -1120,17 +1340,19 @@ def get_object_measurement_columns(object_name):
     return [(object_name, M_LOCATION_CENTER_X, cpmeas.COLTYPE_FLOAT),
             (object_name, M_LOCATION_CENTER_Y, cpmeas.COLTYPE_FLOAT),
             (object_name, M_NUMBER_OBJECT_NUMBER, cpmeas.COLTYPE_INTEGER),
-            (cpmeas.IMAGE, FF_COUNT%object_name, cpmeas.COLTYPE_INTEGER)]
+            (cpmeas.IMAGE, FF_COUNT % object_name, cpmeas.COLTYPE_INTEGER)]
+
 
 def get_threshold_measurement_columns(image_name):
     '''Get the column definitions for threshold measurements, if made
-    
+
     image_name - name of the image
     '''
-    return [(cpmeas.IMAGE, FF_FINAL_THRESHOLD%image_name, cpmeas.COLTYPE_FLOAT),
-            (cpmeas.IMAGE, FF_ORIG_THRESHOLD%image_name, cpmeas.COLTYPE_FLOAT),
-            (cpmeas.IMAGE, FF_WEIGHTED_VARIANCE%image_name, cpmeas.COLTYPE_FLOAT),
-            (cpmeas.IMAGE, FF_SUM_OF_ENTROPIES%image_name, cpmeas.COLTYPE_FLOAT)]
+    return [(cpmeas.IMAGE, FF_FINAL_THRESHOLD % image_name, cpmeas.COLTYPE_FLOAT),
+            (cpmeas.IMAGE, FF_ORIG_THRESHOLD % image_name, cpmeas.COLTYPE_FLOAT),
+            (cpmeas.IMAGE, FF_WEIGHTED_VARIANCE % image_name, cpmeas.COLTYPE_FLOAT),
+            (cpmeas.IMAGE, FF_SUM_OF_ENTROPIES % image_name, cpmeas.COLTYPE_FLOAT)]
+
 
 def draw_outline(img, outline, color):
     '''Draw the given outline on the given image in the given color'''
@@ -1140,12 +1362,14 @@ def draw_outline(img, outline, color):
     img[outline != 0, 0] = red
     img[outline != 0, 1] = green
     img[outline != 0, 2] = blue
-                
+
+
 class MaskObjectNameSubscriber(cps.ObjectNameSubscriber):
     '''This class allows the legacy "From Image" choice'''
+
     def __init__(self, *args, **kwargs):
         super(self.__class__, self).__init__(*args, **kwargs)
-        
+
     def test_valid(self, pipeline):
         if self.value == O_FROM_IMAGE:
             return

--- a/cellprofiler/modules/identify.py
+++ b/cellprofiler/modules/identify.py
@@ -448,7 +448,7 @@ class Identify(cellprofiler.module.Module):
             <li>Kapur JN, Sahoo PK, Wong AKC (1985) "A new method of gray level picture thresholding
             using the entropy of the histogram." <i>Computer Vision, Graphics and Image Processing</i>,
             29, 273-285.</li>
-			<li>Ranefall P, Wahlby C (2016) "Global Gray-level Thresholding Based on Object Size." <i>Cytometry Part A</i>, 89:4, 385-390.</li>
+            <li>Ranefall P, Wahlby C (2016) "Global Gray-level Thresholding Based on Object Size." <i>Cytometry Part A</i>, 89:4, 385-390.</li>
             </ul></p>
             """ % globals())
 
@@ -739,10 +739,7 @@ class Identify(cellprofiler.module.Module):
                 self.upper_outlier_fraction,
                 self.averaging_method,
                 self.variance_method,
-                self.number_of_deviations,
-                self.min_diameter,
-                self.max_diameter,
-                self.ignore_large]
+                self.number_of_deviations]
 
     def get_threshold_help_settings(self):
         '''Return the threshold settings to be displayed in help'''

--- a/cellprofiler/modules/identify.py
+++ b/cellprofiler/modules/identify.py
@@ -18,11 +18,11 @@ from centrosome.threshold import mad, binned_mode
 from centrosome.threshold import weighted_variance, sum_of_entropies
 from centrosome.threshold import sizeintervalprecision
 
-import cellprofiler.cpmodule
+import cellprofiler.module
 import cellprofiler.icons
-import cellprofiler.measurements as cpmeas
-import cellprofiler.objects
-import cellprofiler.settings as cps
+import cellprofiler.measurement as cpmeas
+import cellprofiler.object
+import cellprofiler.setting as cps
 from cellprofiler.gui.help import HELP_ON_PIXEL_INTENSITIES
 
 O_TWO_CLASS = 'Two classes'
@@ -156,7 +156,7 @@ PROTIP_AVOID_ICON = "thumb-down.png"
 TECH_NOTE_ICON = "gear.png"
 
 
-class Identify(cellprofiler.cpmodule.CPModule):
+class Identify(cellprofiler.module.Module):
     threshold_setting_version = 2
 
     def create_threshold_settings(self, methods=TM_METHODS):
@@ -448,7 +448,7 @@ class Identify(cellprofiler.cpmodule.CPModule):
             <li>Kapur JN, Sahoo PK, Wong AKC (1985) "A new method of gray level picture thresholding
             using the entropy of the histogram." <i>Computer Vision, Graphics and Image Processing</i>,
             29, 273-285.</li>
-            <li>Ranefall P, Wahlby C (2016) "Global Gray-level Thresholding Based on Object Size." <i>Cytometry Part A</i>, 89:4, 385-390.</li>
+			<li>Ranefall P, Wahlby C (2016) "Global Gray-level Thresholding Based on Object Size." <i>Cytometry Part A</i>, 89:4, 385-390.</li>
             </ul></p>
             """ % globals())
 
@@ -971,7 +971,7 @@ class Identify(cellprofiler.cpmodule.CPModule):
                         masking_objects = workspace.object_set.get_objects(
                                 self.masking_objects.value)
                     if masking_objects is not None:
-                        label_planes = masking_objects.get_labels(img.shape[:2])
+                        label_planes = masking_objects.get_labels()
                         if len(label_planes) == 1:
                             labels = label_planes[0][0]
                         else:


### PR DESCRIPTION
SizeIntervalPrecision
Object Feature based Gray-level Thresholding using optimized global precision.
Computes the threshold level that optimizes the golbal precision with regards to a given expected object size range.
Incorporated into ApplyThreshold, IdentifyPrimaryObjects, IdentifySecondaryObjects.
By Petter Ranefall 2016.
"Global Gray-level Thresholding Based on Object Size", Cytometry Part A, 89:4, 2016, pp. 385-390.
