### PR TITLE
Overlay labels on image in segmentation display

### DIFF
--- a/cellprofiler/module.py
+++ b/cellprofiler/module.py
@@ -10,6 +10,7 @@ import cellprofiler.measurement
 import cellprofiler.object
 import cellprofiler.setting as cps
 import pipeline as cpp
+import skimage.color
 
 
 class Module(object):
@@ -975,6 +976,22 @@ class ImageSegmentation(Module):
     def display(self, workspace, figure):
         layout = (2, 1)
 
+        if workspace.display_data.dimensions is 3:
+            overlay = np.zeros(workspace.display_data.x_data.shape + (3,))
+
+            for index, data in enumerate(workspace.display_data.x_data):
+                overlay[index] = skimage.color.label2rgb(
+                    workspace.display_data.y_data[index],
+                    image=data,
+                    bg_label=0
+                )
+        else:
+            overlay = skimage.color.label2rgb(
+                workspace.display_data.y_data,
+                image=workspace.display_data.x_data,
+                bg_label=0
+            )
+
         figure.set_subplots(
             dimensions=workspace.display_data.dimensions,
             subplots=layout
@@ -989,7 +1006,7 @@ class ImageSegmentation(Module):
 
         figure.subplot_imshow(
             dimensions=workspace.display_data.dimensions,
-            image=workspace.display_data.y_data,
+            image=overlay,
             x=1,
             y=0
         )


### PR DESCRIPTION
Resolves #2380 

Not a great segmentation, but this gives an idea of the output:

<img width="1310" alt="screen shot 2016-10-03 at 9 54 14 am" src="https://cloud.githubusercontent.com/assets/4721755/19039925/db608f1e-894f-11e6-90a5-bc64070dfcec.png">
