### PR TITLE
Close Bio-Formats readers

### DIFF
--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -163,6 +163,12 @@ def __version__(exit_code):
 def stop_cellprofiler():
     cellprofiler.utilities.zmqrequest.join_to_the_boundary()
 
+    # Bioformats readers have to be properly closed.
+    # This is especially important when using OmeroReaders as leaving the
+    # readers open leaves the OMERO.server services open which in turn leads to
+    # high memory consuption.
+    bioformats.formatreader.clear_image_reader_cache()
+
     cellprofiler.utilities.cpjvm.cp_stop_vm()
 
 

--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -166,7 +166,7 @@ def stop_cellprofiler():
     # Bioformats readers have to be properly closed.
     # This is especially important when using OmeroReaders as leaving the
     # readers open leaves the OMERO.server services open which in turn leads to
-    # high memory consuption.
+    # high memory consumption.
     bioformats.formatreader.clear_image_reader_cache()
 
     cellprofiler.utilities.cpjvm.cp_stop_vm()

--- a/cellprofiler/pipeline.py
+++ b/cellprofiler/pipeline.py
@@ -46,6 +46,7 @@ import cellprofiler.workspace as cpw
 import cellprofiler.setting as cps
 from cellprofiler.utilities.utf16encode import utf16encode, utf16decode
 from bioformats.omexml import OMEXML
+from bioformats.formatreader import clear_image_reader_cache
 import javabridge as J
 
 '''The measurement name of the image number'''
@@ -1818,7 +1819,10 @@ class Pipeline(object):
                         measurements.add_experiment_measurement(EXIT_STATUS, "Failure")
 
                         return
-
+            # Close cached readers.
+            # This may play a big role with cluster deployments or long standing jobs
+            # by freeing up memory and resources.
+            clear_image_reader_cache()
             if measurements is not None:
                 workspace = cpw.Workspace(self, None, None, None, measurements, image_set_list, frame)
 


### PR DESCRIPTION
The changes introduced in this PR make sure the Bio-Formats readers are closed when the app is terminated and after each pipeline cycle. This should prevent memory leaks and improve performance especially in conjunction with OMERO reader (java or python).