### PR TITLE
Improve running time for MeasureObjectSizeShape (resolves #2548)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,11 +45,10 @@ install:
   - pip install joblib
   - pip install scikit-learn
   - pip install --no-deps pyzmq==13.1.0
-  - pip install --requirement requirements.txt
   - pip install --editable git+https://github.com/h5py/h5py.git#egg=h5py
   - pip install --editable git+https://github.com/CellH5/cellh5.git#egg=cellh5
   - pip install --editable git+https://github.com/scikit-image/scikit-image.git#egg=scikit-image-0.13.0dev
   - pip freeze
-  - pip install --no-deps .
+  - pip install --no-deps --requirement requirements.txt
 script:
   - python setup.py test -a -x

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,11 +44,11 @@ install:
   - pip install --upgrade cython
   - pip install joblib
   - pip install scikit-learn
-  - pip install https://pypi.python.org/packages/source/s/scikit-image/scikit-image-0.12.3.tar.gz#md5=04ea833383e0b6ad5f65da21292c25e1
   - pip install --no-deps pyzmq==13.1.0
   - pip install --requirement requirements.txt
   - pip install --editable git+https://github.com/h5py/h5py.git#egg=h5py
   - pip install --editable git+https://github.com/CellH5/cellh5.git#egg=cellh5
+  - pip install --editable git+https://github.com/scikit-image/scikit-image.git#egg=scikit-image-0.13.0dev
   - pip freeze
   - pip install --no-deps .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,6 @@ install:
   - pip install --editable git+https://github.com/CellH5/cellh5.git#egg=cellh5
   - pip install --editable git+https://github.com/scikit-image/scikit-image.git#egg=scikit-image-0.13.0dev
   - pip freeze
-  - pip install --no-deps --requirement requirements.txt
+  - pip install --requirement requirements.txt
 script:
   - python setup.py test -a -x

--- a/cellprofiler/modules/measureobjectsizeshape.py
+++ b/cellprofiler/modules/measureobjectsizeshape.py
@@ -458,7 +458,7 @@ class MeasureObjectSizeShape(cpm.Module):
 
                 volume[labels == label] = True
 
-                verts, faces = skimage.measure.marching_cubes(
+                verts, faces, _, _ = skimage.measure.marching_cubes(
                     volume,
                     spacing=spacing,
                     level=0

--- a/setup.py
+++ b/setup.py
@@ -324,6 +324,9 @@ setuptools.setup(
             }
         ],
         description="",
+        dependency_links=[
+            "git+https://github.com/scikit-image/scikit-image.git#egg=scikit-image-0.13.0dev"
+        ],
         entry_points={
             "console_scripts": [
                 "cellprofiler=cellprofiler.__main__:main"
@@ -346,7 +349,7 @@ setuptools.setup(
             "pytest",
             "python-bioformats",
             "pyzmq",
-            "scikit-image>=0.12.3",
+            "scikit-image==0.13.0dev",
             "scipy"
         ],
         keywords="",


### PR DESCRIPTION
Run `pip install -e . --process-dependency-links` to install scikit-image from source (verified os x).