### PR TITLE
Add missing measurements for Image, MeasureObjectSizeShape

### DIFF
--- a/cellprofiler/module.py
+++ b/cellprofiler/module.py
@@ -965,6 +965,15 @@ class ImageProcessing(Module):
 class ImageSegmentation(Module):
     category = "Image Segmentation"
 
+    def add_measurements(self, measurements, labels):
+        n_objects = len(np.unique(labels)[1:]) if 0 in labels else len(np.unique(labels))
+
+        measurements.add_measurement(
+            "Image",
+            "Count_{}".format(self.y_name.value),
+            np.array([n_objects], dtype=np.float)
+        )
+
     def create_settings(self):
         self.x_name = cellprofiler.setting.ImageNameSubscriber(
             "Input"

--- a/cellprofiler/modules/activecontourmodel.py
+++ b/cellprofiler/modules/activecontourmodel.py
@@ -88,6 +88,8 @@ class ActiveContourModel(cellprofiler.module.ImageSegmentation):
 
         workspace.object_set.add_objects(objects, y_name)
 
+        self.add_measurements(workspace.measurements, y_data)
+
         if self.show_window:
             workspace.display_data.x_data = x_data
 

--- a/cellprofiler/modules/measureobjectsizeshape.py
+++ b/cellprofiler/modules/measureobjectsizeshape.py
@@ -471,6 +471,12 @@ class MeasureObjectSizeShape(cpm.Module):
             else:
                 self.record_measurement(workspace, object_name, F_PERIMETER, perimeters)
 
+            for feature in self.get_feature_names():
+                if feature in [F_AREA, F_EXTENT, F_CENTER_X, F_CENTER_Y, F_CENTER_Z, F_PERIMETER]:
+                    continue
+
+                self.record_measurement(workspace, object_name, feature, [np.nan])
+
     def display(self, workspace, figure):
         figure.set_subplots((1, 1))
         figure.subplot_table(0, 0,

--- a/cellprofiler/modules/randomwalkeralgorithm.py
+++ b/cellprofiler/modules/randomwalkeralgorithm.py
@@ -99,6 +99,8 @@ class RandomWalkerAlgorithm(cellprofiler.module.ImageSegmentation):
 
         workspace.object_set.add_objects(objects, y_name)
 
+        self.add_measurements(workspace.measurements, y_data)
+
         if self.show_window:
             workspace.display_data.x_data = x_data
 

--- a/cellprofiler/modules/watershed.py
+++ b/cellprofiler/modules/watershed.py
@@ -176,6 +176,8 @@ class Watershed(cellprofiler.module.ImageSegmentation):
 
         workspace.object_set.add_objects(objects, y_name)
 
+        self.add_measurements(workspace.measurements, y_data)
+
         if self.show_window:
             workspace.display_data.x_data = x.pixel_data
 

--- a/cellprofiler/utilities/hdf5_dict.py
+++ b/cellprofiler/utilities/hdf5_dict.py
@@ -375,7 +375,9 @@ class HDF5Dict(object):
             return result if result is None else result[0]
 
         feature_exists = self.has_feature(object_name, feature_name)
-        assert feature_exists
+
+        assert feature_exists, "Feature {} for {} does not exist".format(feature_name, object_name)
+
         with self.lock:
             indices = self.get_indices(object_name, feature_name)
             dataset = self.get_dataset(object_name, feature_name)


### PR DESCRIPTION
Resolves #2553 

* `Image_Count` is an expected measurement when objects are present.
* MeasureObjectSizeShape does not measure the same features in 2D as in 3D. Defining separate measurements based on whether or not an image is 2D or 3D requires significant refactoring. Set unmeasured features to `NaN`.