### PR TITLE
add planewise functionality to closing...

### DIFF
--- a/cellprofiler/modules/closing.py
+++ b/cellprofiler/modules/closing.py
@@ -41,11 +41,31 @@ class Closing(cellprofiler.module.ImageProcessing):
         ]
 
     def run(self, workspace):
-        x = workspace.image_set.get_image(self.x_name.value)
 
-        if x.pixel_data.dtype == numpy.bool:
-            self.function = skimage.morphology.binary_closing
+        x = workspace.image_set.get_image(self.x_name.value)
+        is_strel_2D = self.structuring_element.value.ndim == 2
+        is_img_2D = x.pixel_data.ndim == 2
+
+        if is_strel_2D and not is_img_2D:
+            self.function = planewise_morphology_closing
+        elif not is_strel_2D and is_img_2D:
+            raise NotImplementedError("A 3D structuring element cannot be applied to a 2D image.")
         else:
-            self.function = skimage.morphology.closing
+            if x.pixel_data.dtype == numpy.bool:
+                self.function = skimage.morphology.binary_closing
+            else:
+                self.function = skimage.morphology.closing
 
         super(Closing, self).run(workspace)
+
+
+def planewise_morphology_closing(x_data, structuring_element):
+    y_data = numpy.zeros_like(x_data)
+
+    for index, plane in enumerate(x_data):
+        if x_data.dtype == numpy.bool:
+            y_data[index] = skimage.morphology.binary_closing(plane, structuring_element)
+        else:
+            y_data[index] = skimage.morphology.closing(plane, structuring_element)
+
+    return y_data


### PR DESCRIPTION
2D structuring elements applied to 3D images would throw an error. However, there is value to planewise application of the structuring element to a 3D image. This is especially true when the z-spacing in a voxel is greater than the x-y spacing. The edits to this file will apply a 2D structuring element planewise (in the z direction) to a 3D image.