### PR TITLE
Scale sigma by 1/spacing when enhancing neurites. 

### DIFF
--- a/tests/modules/test_enhanceorsuppressfeatures.py
+++ b/tests/modules/test_enhanceorsuppressfeatures.py
@@ -468,6 +468,8 @@ def test_enhance_neurites_tubeness_positive(image, module, workspace):
 
     expected = -expected[:, :, 0] * (expected[:, :, 0] < 0)
 
+    expected = skimage.exposure.rescale_intensity(expected)
+
     numpy.testing.assert_array_almost_equal(expected, actual)
 
 
@@ -500,7 +502,9 @@ def test_enhance_neurites_tubeness_negative(image, module, workspace):
 
     expected = -expected[:, :, 0] * (expected[:, :, 0] < 0)
 
-    numpy.testing.assert_array_almost_equal(expected, actual)
+    expected = skimage.exposure.rescale_intensity(expected)
+
+    numpy.testing.assert_array_almost_equal(expected, actual, decimal=5)
 
 
 def test_enhance_neurites_tubeness_positive_volume(image, module, workspace):
@@ -538,6 +542,8 @@ def test_enhance_neurites_tubeness_positive_volume(image, module, workspace):
         )
 
         expected[index] = -hessian[:, :, 0] * (hessian[:, :, 0] < 0)
+
+    expected = skimage.exposure.rescale_intensity(expected)
 
     numpy.testing.assert_array_almost_equal(expected, actual)
 
@@ -578,7 +584,9 @@ def test_enhance_neurites_tubeness_negative_volume(image, module, workspace):
 
         expected[index] = -hessian[:, :, 0] * (hessian[:, :, 0] < 0)
 
-    numpy.testing.assert_array_almost_equal(expected, actual)
+    expected = skimage.exposure.rescale_intensity(1.0 * expected)
+
+    numpy.testing.assert_array_almost_equal(expected, actual, decimal=5)
 
 
 def test_enhance_circles(image, module, workspace):


### PR DESCRIPTION
Additionally, rescale intensity in [0, 1].

Before sigma scaling:
![before](https://cloud.githubusercontent.com/assets/4721755/24059913/3ef718a0-0b27-11e7-9c60-c6f86575481c.png)

After sigma scaling:
![after](https://cloud.githubusercontent.com/assets/4721755/24059916/4334e76c-0b27-11e7-84a4-8ac575d4afaf.png)
