### PR TITLE
Fix formatting for FilterObjects

### DIFF
--- a/cellprofiler/modules/filterobjects.py
+++ b/cellprofiler/modules/filterobjects.py
@@ -93,7 +93,6 @@ class FilterObjects(cellprofiler.module.Module):
     variable_revision_number = 7
 
     def create_settings(self):
-        '''Create the initial settings and name the module'''
         self.target_name = cellprofiler.setting.ObjectNameProvider(
             "Name the output objects",
             "FilteredBlue",
@@ -119,7 +118,7 @@ class FilterObjects(cellprofiler.module.Module):
         self.mode = cellprofiler.setting.Choice(
             "Select the filtering mode",
             [MODE_MEASUREMENTS, MODE_RULES, MODE_BORDER, MODE_CLASSIFIERS],
-            doc ="""
+            doc="""
             You can choose from the following options:
             <ul>
                 <li><i>{MODE_MEASUREMENTS}</i>: Specify a per-object measurement made by an upstream module in
@@ -458,7 +457,6 @@ class FilterObjects(cellprofiler.module.Module):
             )
         )
 
-
         group.append("divider", cellprofiler.setting.Divider(line=False))
 
         self.additional_objects.append(group)
@@ -502,8 +500,7 @@ class FilterObjects(cellprofiler.module.Module):
                 self.wants_outlines, self.outlines_name]
 
     def visible_settings(self):
-        result =[self.target_name, self.object_name,
-                 self.spacer_2, self.mode]
+        result = [self.target_name, self.object_name, self.spacer_2, self.mode]
 
         if self.mode == MODE_RULES or self.mode == MODE_CLASSIFIERS:
             result += [self.rules_file_name, self.rules_directory,
@@ -552,11 +549,9 @@ class FilterObjects(cellprofiler.module.Module):
 
     def validate_module(self, pipeline):
         '''Make sure that the user has selected some limits when filtering'''
-        if (self.mode == MODE_MEASUREMENTS and
-            self.filter_choice == FI_LIMITS):
+        if self.mode == MODE_MEASUREMENTS and self.filter_choice == FI_LIMITS:
             for group in self.measurements:
-                if (group.wants_minimum.value == False and
-                    group.wants_maximum.value == False):
+                if not (group.wants_minimum.value or group.wants_maximum.value):
                     raise cellprofiler.setting.ValidationError(
                         'Please enter a minimum and/or maximum limit for your measurement',
                         group.wants_minimum)
@@ -859,8 +854,7 @@ class FilterObjects(cellprofiler.module.Module):
             #
             fn = scipy.ndimage.maximum_position if wants_max else scipy.ndimage.minimum_position
             best_pos = fn(src_values, enclosing_labels, enclosing_range)
-            best_pos = numpy.array((best_pos,) if isinstance(best_pos, tuple)
-                                else best_pos)
+            best_pos = numpy.array((best_pos,) if isinstance(best_pos, tuple) else best_pos)
             best_pos = best_pos.astype(numpy.uint32)
             #
             # Get the label of the pixel at each location
@@ -919,10 +913,10 @@ class FilterObjects(cellprofiler.module.Module):
         # the following histogram has a value > 0 for any object
         # with a border pixel
         #
-        histogram = scipy.sparse.coo_matrix((numpy.ones(border_labels.shape),
-                                             (border_labels,
-                                           numpy.zeros(border_labels.shape))),
-                                            shape=(numpy.max(border_labeled_image) + 1, 1)).todense()
+        histogram = scipy.sparse.coo_matrix(
+            (numpy.ones(border_labels.shape), (border_labels, numpy.zeros(border_labels.shape))),
+            shape=(numpy.max(border_labeled_image) + 1, 1)
+        ).todense()
         histogram = numpy.array(histogram).flatten()
         if any(histogram[1:] > 0):
             histogram_image = histogram[border_labeled_image]
@@ -1126,11 +1120,10 @@ class FilterObjects(cellprofiler.module.Module):
         from_matlab - true if file was saved by Matlab CP
         '''
 
-        DIR_DEFAULT_INPUT = "Default input folder"
-        DIR_DEFAULT_OUTPUT = "Default output folder"
+        dir_default_input = "Default input folder"
+        dir_default_output = "Default output folder"
 
-        if (module_name == 'KeepLargestObject' and from_matlab
-            and variable_revision_number == 1):
+        if (module_name == 'KeepLargestObject' and from_matlab and variable_revision_number == 1):
             #
             # This is a specialized case:
             # The filtering method is FI_MAXIMAL_PER_OBJECT to pick out
@@ -1149,8 +1142,7 @@ class FilterObjects(cellprofiler.module.Module):
             from_matlab = False
             variable_revision_number = 1
             module_name = self.module_name
-        if (module_name == 'FilterByObjectMeasurement' and from_matlab and
-            variable_revision_number == 5):
+        if (module_name == 'FilterByObjectMeasurement' and from_matlab and variable_revision_number == 5):
             #
             # Swapped first two measurements
             #
@@ -1158,8 +1150,7 @@ class FilterObjects(cellprofiler.module.Module):
                               setting_values[2:])
             variable_revision_number = 6
 
-        if (module_name == 'FilterByObjectMeasurement' and from_matlab and
-            variable_revision_number == 6):
+        if (module_name == 'FilterByObjectMeasurement' and from_matlab and variable_revision_number == 6):
             # The measurement may not be correct here - it will display
             # as an error, though
             measurement = '_'.join((setting_values[2],
@@ -1191,8 +1182,7 @@ class FilterObjects(cellprofiler.module.Module):
             module_name = self.module_name
             from_matlab = False
             variable_revision_number = 1
-        if (from_matlab and module_name == 'FilterByObjectMeasurement' and
-            variable_revision_number == 7):
+        if (from_matlab and module_name == 'FilterByObjectMeasurement' and variable_revision_number == 7):
             #
             # Added rules file name and rules path name
             #
@@ -1208,13 +1198,13 @@ class FilterObjects(cellprofiler.module.Module):
             measurement = "_".join(parts)
             if rules_file_name == cellprofiler.setting.DO_NOT_USE:
                 rules_or_measurements = MODE_MEASUREMENTS
-                rules_directory_choice = DIR_DEFAULT_INPUT
+                rules_directory_choice = dir_default_input
             else:
                 rules_or_measurements = MODE_RULES
                 if rules_path_name == '.':
-                    rules_directory_choice = DIR_DEFAULT_OUTPUT
+                    rules_directory_choice = dir_default_output
                 elif rules_path_name == '&':
-                    rules_directory_choice = DIR_DEFAULT_INPUT
+                    rules_directory_choice = dir_default_input
                 else:
                     rules_directory_choice = DIR_CUSTOM
             if min_value1 == 'No minimum':
@@ -1259,7 +1249,7 @@ class FilterObjects(cellprofiler.module.Module):
             # Added CPA rules
             #
             setting_values = (setting_values[:11] +
-                              [MODE_MEASUREMENTS, DIR_DEFAULT_INPUT, "."] +
+                              [MODE_MEASUREMENTS, dir_default_input, "."] +
                               setting_values[11:])
             variable_revision_number = 2
         if (not from_matlab) and variable_revision_number == 2:
@@ -1325,9 +1315,9 @@ class FilterObjects(cellprofiler.module.Module):
                 [PO_BOTH] + setting_values[FIXED_SETTING_COUNT_V6:]
             variable_revision_number = 7
 
-        SLOT_DIRECTORY = 7
-        setting_values[SLOT_DIRECTORY] = cellprofiler.setting.DirectoryPath.upgrade_setting(
-            setting_values[SLOT_DIRECTORY])
+        slot_directory = 7
+        setting_values[slot_directory] = cellprofiler.setting.DirectoryPath.upgrade_setting(
+            setting_values[slot_directory])
 
         return setting_values, variable_revision_number, from_matlab
 

--- a/cellprofiler/modules/filterobjects.py
+++ b/cellprofiler/modules/filterobjects.py
@@ -1,33 +1,24 @@
-'''<b>Filter Objects</b> eliminates objects based on their measurements (e.g., area, shape,
-texture, intensity).
+"""
+<b>Filter Objects</b> eliminates objects based on their measurements (e.g., area, shape, texture, intensity).
 <hr>
 This module removes selected objects based on measurements produced by another module (e.g.,
-<b>MeasureObjectSizeShape</b>, <b>MeasureObjectIntensity</b>, <b>MeasureTexture</b>, etc).
-All objects that do not satisfy the specified parameters will be discarded.
-
-<p>This module also may remove objects touching the image border or edges of a mask. This is useful if
-you would like to unify images via <b>ReassignObjectNumbers</b> before deciding to discard these objects.</p>
-
-<p>Please note that the objects that pass the filtering step comprise a new object set, and hence do
-not inherit the measurements associated with the original objects. Any measurements on the new object
-set will need to be made post-filtering by the desired measurement modules.</p>
-
-<h4>Available measurements</h4>
-<b>Image measurements:</b>
+<b>MeasureObjectSizeShape</b>, <b>MeasureObjectIntensity</b>, <b>MeasureTexture</b>, etc). All objects that do not
+satisfy the specified parameters will be discarded.
+<p>This module also may remove objects touching the image border or edges of a mask. This is useful if you would like
+to unify images via <b>ReassignObjectNumbers</b> before deciding to discard these objects.</p>
+<p>Please note that the objects that pass the filtering step comprise a new object set, and hence do not inherit the
+measurements associated with the original objects. Any measurements on the new object set will need to be made
+post-filtering by the desired measurement modules.</p>
+<h4>Available measurements</h4><b>Image measurements:</b>
 <ul>
-<li><i>Count:</i> The number of objects remaining after filtering.</li>
-</ul>
-<b>Object measurements:</b>
+    <li><i>Count:</i> The number of objects remaining after filtering.</li>
+</ul><b>Object measurements:</b>
 <ul>
-<li><i>Parent:</i> The identity of the input object associated with each filtered
-object.</li>
-<li><i>Location_X, Location_Y:</i> The pixel (X,Y) coordinates of the center of
-mass of the remaining objects.</li>
-</ul>
-
-See also any of the <b>MeasureObject</b> modules, <b>MeasureTexture</b>,
-<b>MeasureCorrelation</b>, and <b>CalculateRatios</b>.
-'''
+    <li><i>Parent:</i> The identity of the input object associated with each filtered object.</li>
+    <li><i>Location_X, Location_Y:</i> The pixel (X,Y) coordinates of the center of mass of the remaining objects.</li>
+</ul>See also any of the <b>MeasureObject</b> modules, <b>MeasureTexture</b>, <b>MeasureCorrelation</b>, and
+<b>CalculateRatios</b>.
+"""
 
 import logging
 
@@ -71,8 +62,7 @@ FI_MAXIMAL_PER_OBJECT = "Maximal per object"
 '''Keep all objects whose values fall between set limits'''
 FI_LIMITS = "Limits"
 
-FI_ALL = [FI_MINIMAL, FI_MAXIMAL, FI_MINIMAL_PER_OBJECT,
-          FI_MAXIMAL_PER_OBJECT, FI_LIMITS]
+FI_ALL = [FI_MINIMAL, FI_MAXIMAL, FI_MINIMAL_PER_OBJECT, FI_MAXIMAL_PER_OBJECT, FI_LIMITS]
 
 '''The number of settings for this module in the pipeline if no additional objects'''
 FIXED_SETTING_COUNT = 13
@@ -108,123 +98,173 @@ class FilterObjects(cpm.Module):
     def create_settings(self):
         '''Create the initial settings and name the module'''
         self.target_name = cps.ObjectNameProvider(
-            'Name the output objects', 'FilteredBlue', doc="""
-            Enter a name for the collection of objects that are retained after applying the filter(s).""")
+            "Name the output objects",
+            "FilteredBlue",
+            doc="Enter a name for the collection of objects that are retained after applying the filter(s)."
+        )
 
         self.object_name = cps.ObjectNameSubscriber(
-            'Select the object to filter', cps.NONE, doc="""
+            "Select the object to filter",
+            cps.NONE,
+            doc="""
             Select the set of objects that you want to filter. This setting
             also controls which measurement choices appear for filtering:
             you can only filter based on measurements made on the object you select.
             If you intend to use a measurement
             calculated by the <b>CalculateMath</b> module to to filter objects, select
             the first operand's object here, because <b>CalculateMath</b> measurements
-            are stored with the first operand's object.""")
+            are stored with the first operand's object.
+            """
+        )
 
         self.spacer_1 = cps.Divider(line=False)
 
         self.mode = cps.Choice(
-            'Select the filtering mode',
+            "Select the filtering mode",
             [MODE_MEASUREMENTS, MODE_RULES, MODE_BORDER, MODE_CLASSIFIERS],
-            doc = """
+            doc ="""
             You can choose from the following options:
             <ul>
-            <li><i>%(MODE_MEASUREMENTS)s</i>: Specify a per-object measurement made by an upstream
-            module in the pipeline.</li>
-            <li><i>%(MODE_RULES)s</i>: Use a file containing rules generated by CellProfiler Analyst.
-            You will need to ensure that the measurements specified by the rules file are
-            produced by upstream modules in the pipeline.</li>
-            <li><i>%(MODE_BORDER)s</i>: Remove objects touching the border of the image and/or the
-            edges of an image mask.</li>
-            <li><i>%(MODE_CLASSIFIERS)s</i>: Use a file containing trained classifier from CellProfiler Analyst.
-            You will need to ensure that the measurements specified by the file are
-            produced by upstream modules in the pipeline.</li>
-            </ul>""" % globals())
+                <li><i>{MODE_MEASUREMENTS}</i>: Specify a per-object measurement made by an upstream module in
+                the pipeline.</li>
+                <li><i>{MODE_RULES}</i>: Use a file containing rules generated by CellProfiler Analyst. You
+                will need to ensure that the measurements specified by the rules file are produced by upstream
+                modules in the pipeline.</li>
+                <li><i>{MODE_BORDER}</i>: Remove objects touching the border of the image and/or the edges of
+                an image mask.</li>
+                <li><i>{MODE_CLASSIFIERS}</i>: Use a file containing trained classifier from CellProfiler
+                Analyst. You will need to ensure that the measurements specified by the file are produced by
+                upstream modules in the pipeline.</li>
+            </ul>
+            """.format(**{
+                "MODE_MEASUREMENTS": MODE_MEASUREMENTS,
+                "MODE_RULES": MODE_RULES,
+                "MODE_BORDER": MODE_BORDER,
+                "MODE_CLASSIFIERS": MODE_CLASSIFIERS
+            })
+        )
+
         self.spacer_2 = cps.Divider(line=False)
 
         self.measurements = []
-        self.measurement_count = cps.HiddenCount(self.measurements,
-                                                 "Measurement count")
+
+        self.measurement_count = cps.HiddenCount(self.measurements, "Measurement count")
+
         self.add_measurement(False)
+
         self.add_measurement_button = cps.DoSomething(
-            "", "Add another measurement", self.add_measurement)
+            "",
+            "Add another measurement",
+            self.add_measurement
+        )
+
         self.filter_choice = cps.Choice(
-            "Select the filtering method", FI_ALL, FI_LIMITS, doc="""
+            "Select the filtering method",
+            FI_ALL,
+            FI_LIMITS,
+            doc="""
             <i>(Used only if filtering using measurements)</i><br>
             There are five different ways to filter objects:
             <ul>
-            <li><i>%(FI_LIMITS)s:</i> Keep an object if its measurement value falls within a range you specify.</li>
-            <li><i>%(FI_MAXIMAL)s:</i> Keep the object with the maximum value for the measurement
-            of interest. If multiple objects share a maximal value, retain one object
-            selected arbitrarily per image.</li>
-            <li><i>%(FI_MINIMAL)s:</i> Keep the object with the minimum value for the measurement
-            of interest. If multiple objects share a minimal value, retain one object
-            selected arbitrarily per image.</li>
-            <li><i>%(FI_MAXIMAL_PER_OBJECT)s:</i> This option requires you to choose a parent object.
-            The parent object might contain several child objects of
-            choice (for instance, mitotic spindles within a cell or FISH
-            probe spots within a nucleus). Only the child object whose measurements equal the maximum child-measurement
-            value among that set of child objects will be kept
-            (for example, the longest spindle
-            in each cell).  You do not have to explicitly relate objects before using this module.</li>
-            <li><i>%(FI_MINIMAL_PER_OBJECT)s:</i> Same as <i>Maximal per object</i>, except filtering is based on the minimum value.</li>
-            </ul>""" % globals())
+                <li><i>{FI_LIMITS}:</i> Keep an object if its measurement value falls within a range you
+                specify.</li>
+                <li><i>{FI_MAXIMAL}:</i> Keep the object with the maximum value for the measurement of
+                interest. If multiple objects share a maximal value, retain one object selected arbitrarily per
+                image.</li>
+                <li><i>{FI_MINIMAL}:</i> Keep the object with the minimum value for the measurement of
+                interest. If multiple objects share a minimal value, retain one object selected arbitrarily per
+                image.</li>
+                <li><i>{FI_MAXIMAL_PER_OBJECT}:</i> This option requires you to choose a parent object. The
+                parent object might contain several child objects of choice (for instance, mitotic spindles
+                within a cell or FISH probe spots within a nucleus). Only the child object whose measurements
+                equal the maximum child-measurement value among that set of child objects will be kept (for
+                example, the longest spindle in each cell). You do not have to explicitly relate objects before
+                using this module.</li>
+                <li><i>{FI_MINIMAL_PER_OBJECT}:</i> Same as <i>Maximal per object</i>, except filtering is
+                based on the minimum value.</li>
+            </ul>
+            """.format(**{
+                "FI_LIMITS": FI_LIMITS,
+                "FI_MAXIMAL": FI_MAXIMAL,
+                "FI_MINIMAL": FI_MINIMAL,
+                "FI_MAXIMAL_PER_OBJECT": FI_MAXIMAL_PER_OBJECT,
+                "FI_MINIMAL_PER_OBJECT": FI_MINIMAL_PER_OBJECT
+            })
+        )
 
         self.per_object_assignment = cps.Choice(
-            "Assign overlapping child to", PO_ALL,
+            "Assign overlapping child to",
+            PO_ALL,
             doc="""
-            <i>(Used only if filtering per object)</i>
-            <br>A child object can overlap two parent objects and can have
-            the maximal/minimal measurement of all child objects in both parents.
-            This option controls how an overlapping maximal/minimal child
-            affects filtering of other children of its parents and to which
-            parent the maximal child is assigned. The choices are:
-            <br><ul>
-            <li><i>%(PO_BOTH)s</i>: The child will be assigned to both parents
-            and all other children of both parents will be filtered. Only the
-            maximal child per parent will be left, but if <b>RelateObjects</b>
-            is used to relate the maximal child to its parent, one or the other
-            of the overlapping parents will not have a child even though the
-            excluded parent may have other child objects. The maximal child
-            can still be assigned to both parents using a database join
-            via the relationships table if you are using <b>ExportToDatabase</b>
-            and separate object tables.</li>
-            <li><i>%(PO_PARENT_WITH_MOST_OVERLAP)s</i>: The child will be
-            assigned to the parent with the most overlap and a child with a
-            less maximal/minimal measurement, if available, will be assigned
-            to other parents. Use this option to ensure that parents with
-            an alternate non-overlapping child object are assigned some child
-            object by a subseequent <b>RelateObjects</b> module.</li></ul>
-            """ % globals())
+            <i>(Used only if filtering per object)</i><br>
+            A child object can overlap two parent objects and can have the maximal/minimal measurement of all
+            child objects in both parents. This option controls how an overlapping maximal/minimal child
+            affects filtering of other children of its parents and to which parent the maximal child is
+            assigned. The choices are:<br>
+            <ul>
+                <li><i>{PO_BOTH}</i>: The child will be assigned to both parents and all other children of both
+                parents will be filtered. Only the maximal child per parent will be left, but if
+                <b>RelateObjects</b> is used to relate the maximal child to its parent, one or the other of the
+                overlapping parents will not have a child even though the excluded parent may have other child
+                objects. The maximal child can still be assigned to both parents using a database join via the
+                relationships table if you are using <b>ExportToDatabase</b> and separate object tables.</li>
+                <li><i>{PO_PARENT_WITH_MOST_OVERLAP}</i>: The child will be assigned to the parent with the
+                most overlap and a child with a less maximal/minimal measurement, if available, will be
+                assigned to other parents. Use this option to ensure that parents with an alternate
+                non-overlapping child object are assigned some child object by a subsequent
+                <b>RelateObjects</b> module.</li>
+            </ul>
+            """.format(**{
+                "PO_BOTH": PO_BOTH,
+                "PO_PARENT_WITH_MOST_OVERLAP": PO_PARENT_WITH_MOST_OVERLAP
+            })
+        )
 
         self.enclosing_object_name = cps.ObjectNameSubscriber(
-            'Select the objects that contain the filtered objects', cps.NONE, doc="""
+            "Select the objects that contain the filtered objects",
+            cps.NONE,
+            doc="""
             <i>(Used only if a per-object filtering method is selected)</i><br>
-            This setting selects the container (i.e., parent) objects for the <i>%(FI_MAXIMAL_PER_OBJECT)s</i>
-            and <i>%(FI_MINIMAL_PER_OBJECT)s</i> filtering choices.""" % globals())
+            This setting selects the container (i.e., parent) objects for the <i>{FI_MAXIMAL_PER_OBJECT}</i>
+            and <i>{FI_MINIMAL_PER_OBJECT}</i> filtering choices.
+            """.format(**{
+                "FI_MAXIMAL_PER_OBJECT": FI_MAXIMAL_PER_OBJECT,
+                "FI_MINIMAL_PER_OBJECT": FI_MINIMAL_PER_OBJECT
+            })
+        )
 
         self.rules_directory = cps.DirectoryPath(
-            "Rules file location", doc="""
-            <i>(Used only when filtering using %(MODE_RULES)s)</i>
+            "Rules file location",
+            doc="""
+            <i>(Used only when filtering using {MODE_RULES})</i>
             <br>
             Select the location of the rules file that will be used for filtering.
-            %(IO_FOLDER_CHOICE_HELP_TEXT)s""" % globals())
+            {IO_FOLDER_CHOICE_HELP_TEXT}
+            """.format(**{
+                "MODE_RULES": MODE_RULES,
+                "IO_FOLDER_CHOICE_HELP_TEXT": IO_FOLDER_CHOICE_HELP_TEXT
+            })
+        )
 
         self.rules_class = cps.Choice(
             "Class number",
-            choices = ["1", "2"],
-            choices_fn = self.get_class_choices, doc ="""
-            <i>(Used only when filtering using %(MODE_RULES)s)</i><br>
-            Select which of the classes to keep when filtering. The
-            CellProfiler Analyst classifier user interface lists the names of
-            the classes in left-to-right order. <b>FilterObjects</b> uses the
+            choices=["1", "2"],
+            choices_fn=self.get_class_choices,
+            doc="""
+            <i>(Used only when filtering using {MODE_RULES})</i><br>
+            Select which of the classes to keep when filtering. The CellProfiler Analyst classifier user
+            interface lists the names of the classes in left-to-right order. <b>FilterObjects</b> uses the
             first class from CellProfiler Analyst if you choose "1", etc.
-            <p>Please note the following:
+            <p>Please note the following:</p>
             <ul>
-            <li>The object is retained if the object falls into the selected class.</li>
-            <li>You can make multiple class selections. If you do so, the module
-            will retain the object if the object falls into any of the selected classes.</li>
-            </ul></p>""" % globals())
+                <li>The object is retained if the object falls into the selected class.</li>
+                <li>You can make multiple class selections. If you do so, the module will retain the object if
+                the object falls into any of the selected classes.</li>
+            </ul>
+            """.format(**{
+                "MODE_RULES": MODE_RULES
+            })
+        )
 
         def get_directory_fn():
             '''Get the directory for the rules file name'''
@@ -232,46 +272,63 @@ class FilterObjects(cpm.Module):
 
         def set_directory_fn(path):
             dir_choice, custom_path = self.rules_directory.get_parts_from_path(path)
+
             self.rules_directory.join_parts(dir_choice, custom_path)
 
         self.rules_file_name = cps.FilenameText(
-            "Rules file name", "rules.txt",
+            "Rules file name",
+            "rules.txt",
             get_directory_fn=get_directory_fn,
-            set_directory_fn=set_directory_fn, doc="""
-            <i>(Used only when filtering using %(MODE_RULES)s)</i><br>
-            The name of the rules file. This file should be a plain text
-            file containing the complete set of rules.
-            <p>Each line of
-            this file should be a rule naming a measurement to be made
-            on the object you selected, for instance:
-            <pre>IF (Nuclei_AreaShape_Area &lt; 351.3, [0.79, -0.79], [-0.94, 0.94])</pre>
-            <br><br>
-            The above rule will score +0.79 for the positive category and -0.94
-            for the negative category for nuclei whose area is less than 351.3
-            pixels and will score the opposite for nuclei whose area is larger.
-            The filter adds positive and negative and keeps only objects whose
-            positive score is higher than the negative score.</p>""" %
-                                                                     globals())
+            set_directory_fn=set_directory_fn,
+            doc="""
+            <i>(Used only when filtering using {MODE_RULES})</i><br>
+            The name of the rules file. This file should be a plain text file containing the complete set of
+            rules.
+            <p>Each line of this file should be a rule naming a measurement to be made on the object you
+            selected, for instance:</p>
+            <pre>IF (Nuclei_AreaShape_Area &lt; 351.3, [0.79, -0.79], [-0.94, 0.94])</pre><br>
+            <br>
+            The above rule will score +0.79 for the positive category and -0.94 for the negative category for
+            nuclei whose area is less than 351.3 pixels and will score the opposite for nuclei whose area is
+            larger. The filter adds positive and negative and keeps only objects whose positive score is higher
+            than the negative score.
+            <p></p>
+            """.format(**{
+                "MODE_RULES": MODE_RULES
+            })
+        )
 
         self.wants_outlines = cps.Binary(
-            'Retain outlines of the identified objects?', False, doc="""
-            %(RETAINING_OUTLINES_HELP)s""" % globals())
+            "Retain outlines of the identified objects?",
+            False,
+            doc=RETAINING_OUTLINES_HELP
+        )
 
         self.outlines_name = cps.OutlineNameProvider(
-            'Name the outline image', 'FilteredObjects', doc="""
-            %(NAMING_OUTLINES_HELP)s""" % globals())
+            "Name the outline image",
+            "FilteredObjects",
+            doc=NAMING_OUTLINES_HELP
+        )
 
         self.additional_objects = []
-        self.additional_object_count = cps.HiddenCount(self.additional_objects,
-                                                       "Additional object count")
+
+        self.additional_object_count = cps.HiddenCount(
+            self.additional_objects,
+            "Additional object count"
+        )
+
         self.spacer_3 = cps.Divider(line=False)
 
         self.additional_object_button = cps.DoSomething(
-            'Relabel additional objects to match the filtered object?',
-            'Add an additional object', self.add_additional_object, doc="""
+            "Relabel additional objects to match the filtered object?",
+            "Add an additional object",
+            self.add_additional_object,
+            doc="""
             Click this button to add an object to receive the same post-filtering labels as
             the filtered object. This is useful in making sure that labeling is maintained
-            between related objects (e.g., primary and secondary objects) after filtering.""")
+            between related objects (e.g., primary and secondary objects) after filtering.
+            """
+        )
 
     def get_class_choices(self, pipeline):
         if self.mode == MODE_CLASSIFIERS:
@@ -292,54 +349,121 @@ class FilterObjects(cpm.Module):
     def add_measurement(self, can_delete=True):
         '''Add another measurement to the filter list'''
         group = cps.SettingsGroup()
-        group.append("measurement", cps.Measurement(
-            'Select the measurement to filter by',
-            self.object_name.get_value, "AreaShape_Area", doc="""
-            <i>(Used only if filtering using %(MODE_MEASUREMENTS)s)</i><br>
-            See the <b>Measurements</b> modules help pages
-            for more information on the features measured.""" % globals()))
 
-        group.append("wants_minimum", cps.Binary(
-            'Filter using a minimum measurement value?', True, doc="""
-            <i>(Used only if %(FI_LIMITS)s is selected for filtering method)</i><br>
-            Select <i>%(YES)s</i> to filter the objects based on a minimum acceptable object
-            measurement value. Objects which are greater than or equal to this value
-            will be retained.""" % globals()))
+        group.append(
+            "measurement",
+            cps.Measurement(
+                "Select the measurement to filter by",
+                self.object_name.get_value,
+                "AreaShape_Area",
+                doc="""
+                <i>(Used only if filtering using {MODE_MEASUREMENTS})</i><br>
+                See the <b>Measurements</b> modules help pages for more information on the features measured.
+                """.format(**{
+                    "MODE_MEASUREMENTS": MODE_MEASUREMENTS
+                })
+            )
+        )
+
+        group.append(
+            "wants_minimum",
+            cps.Binary(
+                'Filter using a minimum measurement value?',
+                True,
+                doc="""
+                <i>(Used only if {FI_LIMITS} is selected for filtering method)</i><br>
+                Select <i>{YES}</i> to filter the objects based on a minimum acceptable object measurement value.
+                Objects which are greater than or equal to this value will be retained.
+                """.format(**{
+                    "FI_LIMITS": FI_LIMITS,
+                    "YES": YES
+                })
+            )
+        )
 
         group.append("min_limit", cps.Float('Minimum value', 0))
 
-        group.append("wants_maximum", cps.Binary(
-            'Filter using a maximum measurement value?', True, doc="""
-            <i>(Used only if %(FI_LIMITS)s is selected for filtering method)</i><br>
-            Select <i>%(YES)s</i> to filter the objects based on a maximum acceptable object
-            measurement value. Objects which are less than or equal to this value
-            will be retained.""" % globals()))
+        group.append(
+            "wants_maximum",
+            cps.Binary(
+                'Filter using a maximum measurement value?',
+                True,
+                doc="""
+                <i>(Used only if {FI_LIMITS} is selected for filtering method)</i><br>
+                Select <i>{YES}</i> to filter the objects based on a maximum acceptable object
+                measurement value. Objects which are less than or equal to this value
+                will be retained.
+                """.format(**{
+                    "FI_LIMITS": FI_LIMITS,
+                    "YES": YES
+                })
+            )
+        )
 
         group.append("max_limit", cps.Float('Maximum value', 1))
+
         group.append("divider", cps.Divider())
+
         self.measurements.append(group)
+
         if can_delete:
-            group.append("remover", cps.RemoveSettingButton(
-                "", "Remove this measurement",
-                self.measurements, group))
+            group.append(
+                "remover",
+                cps.RemoveSettingButton(
+                    "",
+                    "Remove this measurement",
+                    self.measurements, group
+                )
+            )
 
     def add_additional_object(self):
         group = cps.SettingsGroup()
-        group.append("object_name",
-                     cps.ObjectNameSubscriber('Select additional object to relabel',
-                                              cps.NONE))
-        group.append("target_name",
-                     cps.ObjectNameProvider('Name the relabeled objects', 'FilteredGreen'))
 
-        group.append("wants_outlines",
-                     cps.Binary('Retain outlines of relabeled objects?', False))
+        group.append(
+            "object_name",
+            cps.ObjectNameSubscriber(
+                "Select additional object to relabel",
+                cps.NONE
+            )
+        )
 
-        group.append("outlines_name",
-                     cps.OutlineNameProvider('Name the outline image', 'OutlinesFilteredGreen'))
+        group.append(
+            "target_name",
+            cps.ObjectNameProvider(
+                "Name the relabeled objects",
+                "FilteredGreen"
+            )
+        )
 
-        group.append("remover",
-                     cps.RemoveSettingButton("", "Remove this additional object", self.additional_objects, group))
+        group.append(
+            "wants_outlines",
+            cps.Binary(
+                "Retain outlines of relabeled objects?",
+                False
+            )
+        )
+
+        group.append(
+            "outlines_name",
+            cps.OutlineNameProvider(
+                "Name the outline image",
+                "OutlinesFilteredGreen"
+            )
+        )
+
+        group.append(
+            "remover",
+            cps.RemoveSettingButton(
+                "",
+                "Remove this additional object",
+                self.additional_objects,
+                group
+            )
+        )
+
+
         group.append("divider", cps.Divider(line=False))
+
         self.additional_objects.append(group)
 
     def prepare_settings(self, setting_values):

--- a/tests/modules/test_filterobjects.py
+++ b/tests/modules/test_filterobjects.py
@@ -1,30 +1,21 @@
-'''test_filterbyobjectmeasurements.py: Test FilterByObjectMeasurements module'''
-
-import contextlib
 import StringIO
-import base64
 import cPickle
+import contextlib
 import os
 import tempfile
 import unittest
-import zlib
 
+import numpy
+
+import cellprofiler.image
 import cellprofiler.measurement
-import numpy as np
+import cellprofiler.modules.filterobjects
+import cellprofiler.object
+import cellprofiler.pipeline
+import cellprofiler.preferences
+import cellprofiler.workspace
 
-from cellprofiler.preferences import set_headless
-
-set_headless()
-
-import cellprofiler.workspace as cpw
-import cellprofiler.pipeline as cpp
-import cellprofiler.object as cpo
-import cellprofiler.image as cpi
-import cellprofiler.preferences as cpprefs
-import cellprofiler.measurement as cpm
-import cellprofiler.modules.filterobjects as F
-from cellprofiler.measurement import C_LOCATION, C_NUMBER, C_PARENT, C_CHILDREN, FTR_CENTER_X, M_LOCATION_CENTER_X, \
-    FTR_CENTER_Y, M_LOCATION_CENTER_Y, FTR_OBJECT_NUMBER, M_NUMBER_OBJECT_NUMBER, FF_COUNT, FF_CHILDREN_COUNT, FF_PARENT
+cellprofiler.preferences.set_headless()
 
 INPUT_IMAGE = "input_image"
 INPUT_OBJECTS = "input_objects"
@@ -36,21 +27,21 @@ TEST_FTR = "my_measurement"
 class TestFilterObjects(unittest.TestCase):
     def make_workspace(self, object_dict={}, image_dict={}):
         '''Make a workspace for testing FilterByObjectMeasurement'''
-        module = F.FilterByObjectMeasurement()
-        pipeline = cpp.Pipeline()
-        object_set = cpo.ObjectSet()
-        image_set_list = cpi.ImageSetList()
+        module = cellprofiler.modules.filterobjects.FilterByObjectMeasurement()
+        pipeline = cellprofiler.pipeline.Pipeline()
+        object_set = cellprofiler.object.ObjectSet()
+        image_set_list = cellprofiler.image.ImageSetList()
         image_set = image_set_list.get_image_set(0)
-        workspace = cpw.Workspace(pipeline,
-                                  module,
-                                  image_set,
-                                  object_set,
-                                  cpm.Measurements(),
-                                  image_set_list)
+        workspace = cellprofiler.workspace.Workspace(pipeline,
+                                                     module,
+                                                     image_set,
+                                                     object_set,
+                                                     cellprofiler.measurement.Measurements(),
+                                                     image_set_list)
         for key in image_dict.keys():
-            image_set.add(key, cpi.Image(image_dict[key]))
+            image_set.add(key, cellprofiler.image.Image(image_dict[key]))
         for key in object_dict.keys():
-            o = cpo.Objects()
+            o = cellprofiler.object.Objects()
             o.segmented = object_dict[key]
             object_set.add_objects(o, key)
         return workspace, module
@@ -64,9 +55,9 @@ class TestFilterObjects(unittest.TestCase):
                         name = "Classifier",
                         feature_names = ["Foo_"+TEST_FTR]):
         '''Returns the filename of the classifier pickle'''
-        assert isinstance(module, F.FilterObjects)
+        assert isinstance(module, cellprofiler.modules.filterobjects.FilterObjects)
         if classes is None:
-            classes = np.arange(1, np.max(answers)+1)
+            classes = numpy.arange(1, numpy.max(answers) + 1)
         if class_names is None:
             class_names = ["Class%d" for _ in classes]
         if rules_class is None:
@@ -77,7 +68,7 @@ class TestFilterObjects(unittest.TestCase):
         os.write(fd, s)
         os.close(fd)
 
-        module.mode.value = F.MODE_CLASSIFIERS
+        module.mode.value = cellprofiler.modules.filterobjects.MODE_CLASSIFIERS
         module.rules_class.value = rules_class
         module.rules_directory.set_custom_path(os.path.dirname(filename))
         module.rules_file_name.value = os.path.split(filename)[1]
@@ -89,51 +80,51 @@ class TestFilterObjects(unittest.TestCase):
 
     def test_00_01_zeros_single(self):
         '''Test keep single object on an empty labels matrix'''
-        workspace, module = self.make_workspace({INPUT_OBJECTS: np.zeros((10, 10), int)})
+        workspace, module = self.make_workspace({INPUT_OBJECTS: numpy.zeros((10, 10), int)})
         module.object_name.value = INPUT_OBJECTS
         module.target_name.value = OUTPUT_OBJECTS
         module.measurements[0].measurement.value = TEST_FTR
-        module.filter_choice.value = F.FI_MAXIMAL
+        module.filter_choice.value = cellprofiler.modules.filterobjects.FI_MAXIMAL
         m = workspace.measurements
-        m.add_measurement(INPUT_OBJECTS, TEST_FTR, np.zeros((0,)))
+        m.add_measurement(INPUT_OBJECTS, TEST_FTR, numpy.zeros((0,)))
         module.run(workspace)
         labels = workspace.object_set.get_objects(OUTPUT_OBJECTS)
-        self.assertTrue(np.all(labels.segmented == 0))
+        self.assertTrue(numpy.all(labels.segmented == 0))
 
     def test_00_02_zeros_per_object(self):
         '''Test keep per object filtering on an empty labels matrix'''
         workspace, module = self.make_workspace(
-                {INPUT_OBJECTS: np.zeros((10, 10), int),
-                 ENCLOSING_OBJECTS: np.zeros((10, 10), int)})
+                {INPUT_OBJECTS: numpy.zeros((10, 10), int),
+                 ENCLOSING_OBJECTS: numpy.zeros((10, 10), int)})
         module.object_name.value = INPUT_OBJECTS
         module.target_name.value = OUTPUT_OBJECTS
         module.enclosing_object_name.value = ENCLOSING_OBJECTS
         module.measurements[0].measurement.value = TEST_FTR
-        module.filter_choice.value = F.FI_MAXIMAL_PER_OBJECT
+        module.filter_choice.value = cellprofiler.modules.filterobjects.FI_MAXIMAL_PER_OBJECT
         m = workspace.measurements
-        m.add_measurement(INPUT_OBJECTS, TEST_FTR, np.zeros((0,)))
+        m.add_measurement(INPUT_OBJECTS, TEST_FTR, numpy.zeros((0,)))
         module.run(workspace)
         labels = workspace.object_set.get_objects(OUTPUT_OBJECTS)
-        self.assertTrue(np.all(labels.segmented == 0))
+        self.assertTrue(numpy.all(labels.segmented == 0))
 
     def test_00_03_zeros_filter(self):
         '''Test object filtering on an empty labels matrix'''
-        workspace, module = self.make_workspace({INPUT_OBJECTS: np.zeros((10, 10), int)})
+        workspace, module = self.make_workspace({INPUT_OBJECTS: numpy.zeros((10, 10), int)})
         module.object_name.value = INPUT_OBJECTS
         module.target_name.value = OUTPUT_OBJECTS
         module.measurements[0].measurement.value = TEST_FTR
-        module.filter_choice.value = F.FI_LIMITS
+        module.filter_choice.value = cellprofiler.modules.filterobjects.FI_LIMITS
         module.measurements[0].min_limit.value = 0
         module.measurements[0].max_limit.value = 1000
         m = workspace.measurements
-        m.add_measurement(INPUT_OBJECTS, TEST_FTR, np.zeros((0,)))
+        m.add_measurement(INPUT_OBJECTS, TEST_FTR, numpy.zeros((0,)))
         module.run(workspace)
         labels = workspace.object_set.get_objects(OUTPUT_OBJECTS)
-        self.assertTrue(np.all(labels.segmented == 0))
+        self.assertTrue(numpy.all(labels.segmented == 0))
 
     def test_01_01_keep_single_min(self):
         '''Keep a single object (min) from among two'''
-        labels = np.zeros((10, 10), int)
+        labels = numpy.zeros((10, 10), int)
         labels[2:4, 3:5] = 1
         labels[6:9, 5:8] = 2
         expected = labels.copy()
@@ -143,18 +134,18 @@ class TestFilterObjects(unittest.TestCase):
         module.object_name.value = INPUT_OBJECTS
         module.target_name.value = OUTPUT_OBJECTS
         module.measurements[0].measurement.value = TEST_FTR
-        module.filter_choice.value = F.FI_MINIMAL
+        module.filter_choice.value = cellprofiler.modules.filterobjects.FI_MINIMAL
         m = workspace.measurements
-        m.add_measurement(INPUT_OBJECTS, TEST_FTR, np.array([2, 1]))
+        m.add_measurement(INPUT_OBJECTS, TEST_FTR, numpy.array([2, 1]))
         module.run(workspace)
         labels = workspace.object_set.get_objects(OUTPUT_OBJECTS)
-        self.assertTrue(np.all(labels.segmented == expected))
+        self.assertTrue(numpy.all(labels.segmented == expected))
         parents = m.get_current_measurement(
-                OUTPUT_OBJECTS, FF_PARENT % INPUT_OBJECTS)
+                OUTPUT_OBJECTS, cellprofiler.measurement.FF_PARENT % INPUT_OBJECTS)
         self.assertEqual(len(parents), 1)
         self.assertEqual(parents[0], 2)
         self.assertEqual(m.get_current_image_measurement(
-                FF_COUNT % OUTPUT_OBJECTS), 1)
+            cellprofiler.measurement.FF_COUNT % OUTPUT_OBJECTS), 1)
         feature = cellprofiler.measurement.FF_CHILDREN_COUNT % OUTPUT_OBJECTS
         child_count = m.get_current_measurement(INPUT_OBJECTS, feature)
         self.assertEqual(len(child_count), 2)
@@ -163,7 +154,7 @@ class TestFilterObjects(unittest.TestCase):
 
     def test_01_02_keep_single_max(self):
         '''Keep a single object (max) from among two'''
-        labels = np.zeros((10, 10), int)
+        labels = numpy.zeros((10, 10), int)
         labels[2:4, 3:5] = 1
         labels[6:9, 5:8] = 2
         expected = labels.copy()
@@ -173,21 +164,21 @@ class TestFilterObjects(unittest.TestCase):
         module.object_name.value = INPUT_OBJECTS
         module.target_name.value = OUTPUT_OBJECTS
         module.measurements[0].measurement.value = TEST_FTR
-        module.filter_choice.value = F.FI_MAXIMAL
+        module.filter_choice.value = cellprofiler.modules.filterobjects.FI_MAXIMAL
         m = workspace.measurements
-        m.add_measurement(INPUT_OBJECTS, TEST_FTR, np.array([1, 2]))
+        m.add_measurement(INPUT_OBJECTS, TEST_FTR, numpy.array([1, 2]))
         module.run(workspace)
         labels = workspace.object_set.get_objects(OUTPUT_OBJECTS)
-        self.assertTrue(np.all(labels.segmented == expected))
+        self.assertTrue(numpy.all(labels.segmented == expected))
 
     def test_02_01_keep_one_min(self):
         '''Keep two sub-objects (min) from among four enclosed by two'''
-        sub_labels = np.zeros((20, 20), int)
-        expected = np.zeros((20, 20), int)
+        sub_labels = numpy.zeros((20, 20), int)
+        expected = numpy.zeros((20, 20), int)
         for i, j, k, e in ((0, 0, 1, 0), (10, 0, 2, 1), (0, 10, 3, 2), (10, 10, 4, 0)):
             sub_labels[i + 2:i + 5, j + 3:j + 7] = k
             expected[i + 2:i + 5, j + 3:j + 7] = e
-        labels = np.zeros((20, 20), int)
+        labels = numpy.zeros((20, 20), int)
         labels[:, :10] = 1
         labels[:, 10:] = 2
         workspace, module = self.make_workspace({INPUT_OBJECTS: sub_labels,
@@ -196,21 +187,21 @@ class TestFilterObjects(unittest.TestCase):
         module.target_name.value = OUTPUT_OBJECTS
         module.enclosing_object_name.value = ENCLOSING_OBJECTS
         module.measurements[0].measurement.value = TEST_FTR
-        module.filter_choice.value = F.FI_MINIMAL_PER_OBJECT
+        module.filter_choice.value = cellprofiler.modules.filterobjects.FI_MINIMAL_PER_OBJECT
         m = workspace.measurements
-        m.add_measurement(INPUT_OBJECTS, TEST_FTR, np.array([2, 1, 3, 4]))
+        m.add_measurement(INPUT_OBJECTS, TEST_FTR, numpy.array([2, 1, 3, 4]))
         module.run(workspace)
         labels = workspace.object_set.get_objects(OUTPUT_OBJECTS)
-        self.assertTrue(np.all(labels.segmented == expected))
+        self.assertTrue(numpy.all(labels.segmented == expected))
 
     def test_02_02_keep_one_max(self):
         '''Keep two sub-objects (max) from among four enclosed by two'''
-        sub_labels = np.zeros((20, 20), int)
-        expected = np.zeros((20, 20), int)
+        sub_labels = numpy.zeros((20, 20), int)
+        expected = numpy.zeros((20, 20), int)
         for i, j, k, e in ((0, 0, 1, 0), (10, 0, 2, 1), (0, 10, 3, 2), (10, 10, 4, 0)):
             sub_labels[i + 2:i + 5, j + 3:j + 7] = k
             expected[i + 2:i + 5, j + 3:j + 7] = e
-        labels = np.zeros((20, 20), int)
+        labels = numpy.zeros((20, 20), int)
         labels[:, :10] = 1
         labels[:, 10:] = 2
         workspace, module = self.make_workspace({INPUT_OBJECTS: sub_labels,
@@ -219,18 +210,18 @@ class TestFilterObjects(unittest.TestCase):
         module.target_name.value = OUTPUT_OBJECTS
         module.enclosing_object_name.value = ENCLOSING_OBJECTS
         module.measurements[0].measurement.value = TEST_FTR
-        module.filter_choice.value = F.FI_MAXIMAL_PER_OBJECT
+        module.filter_choice.value = cellprofiler.modules.filterobjects.FI_MAXIMAL_PER_OBJECT
         m = workspace.measurements
-        m.add_measurement(INPUT_OBJECTS, TEST_FTR, np.array([1, 2, 4, 3]))
+        m.add_measurement(INPUT_OBJECTS, TEST_FTR, numpy.array([1, 2, 4, 3]))
         module.run(workspace)
         labels = workspace.object_set.get_objects(OUTPUT_OBJECTS)
-        self.assertTrue(np.all(labels.segmented == expected))
+        self.assertTrue(numpy.all(labels.segmented == expected))
 
     def test_02_03_keep_maximal_most_overlap(self):
-        labels = np.zeros((10, 20), int)
+        labels = numpy.zeros((10, 20), int)
         labels[:, :10] = 1
         labels[:, 10:] = 2
-        sub_labels = np.zeros((10, 20), int)
+        sub_labels = numpy.zeros((10, 20), int)
         sub_labels[2, 4] = 1
         sub_labels[4:6, 8:15] = 2
         sub_labels[8, 15] = 3
@@ -241,19 +232,19 @@ class TestFilterObjects(unittest.TestCase):
         module.target_name.value = OUTPUT_OBJECTS
         module.enclosing_object_name.value = ENCLOSING_OBJECTS
         module.measurements[0].measurement.value = TEST_FTR
-        module.filter_choice.value = F.FI_MAXIMAL_PER_OBJECT
-        module.per_object_assignment.value = F.PO_PARENT_WITH_MOST_OVERLAP
+        module.filter_choice.value = cellprofiler.modules.filterobjects.FI_MAXIMAL_PER_OBJECT
+        module.per_object_assignment.value = cellprofiler.modules.filterobjects.PO_PARENT_WITH_MOST_OVERLAP
         m = workspace.measurements
-        m.add_measurement(INPUT_OBJECTS, TEST_FTR, np.array([1, 4, 2]))
+        m.add_measurement(INPUT_OBJECTS, TEST_FTR, numpy.array([1, 4, 2]))
         module.run(workspace)
         labels = workspace.object_set.get_objects(OUTPUT_OBJECTS)
-        self.assertTrue(np.all(labels.segmented == expected))
+        self.assertTrue(numpy.all(labels.segmented == expected))
 
     def test_02_04_keep_minimal_most_overlap(self):
-        labels = np.zeros((10, 20), int)
+        labels = numpy.zeros((10, 20), int)
         labels[:, :10] = 1
         labels[:, 10:] = 2
-        sub_labels = np.zeros((10, 20), int)
+        sub_labels = numpy.zeros((10, 20), int)
         sub_labels[2, 4] = 1
         sub_labels[4:6, 8:15] = 2
         sub_labels[8, 15] = 3
@@ -264,26 +255,26 @@ class TestFilterObjects(unittest.TestCase):
         module.target_name.value = OUTPUT_OBJECTS
         module.enclosing_object_name.value = ENCLOSING_OBJECTS
         module.measurements[0].measurement.value = TEST_FTR
-        module.filter_choice.value = F.FI_MINIMAL_PER_OBJECT
-        module.per_object_assignment.value = F.PO_PARENT_WITH_MOST_OVERLAP
+        module.filter_choice.value = cellprofiler.modules.filterobjects.FI_MINIMAL_PER_OBJECT
+        module.per_object_assignment.value = cellprofiler.modules.filterobjects.PO_PARENT_WITH_MOST_OVERLAP
         m = workspace.measurements
-        m.add_measurement(INPUT_OBJECTS, TEST_FTR, np.array([4, 2, 3]))
+        m.add_measurement(INPUT_OBJECTS, TEST_FTR, numpy.array([4, 2, 3]))
         module.run(workspace)
         labels = workspace.object_set.get_objects(OUTPUT_OBJECTS)
-        self.assertTrue(np.all(labels.segmented == expected))
+        self.assertTrue(numpy.all(labels.segmented == expected))
 
     def test_03_01_filter(self):
         '''Filter objects by limits'''
         n = 40
-        labels = np.zeros((10, n * 10), int)
+        labels = numpy.zeros((10, n * 10), int)
         for i in range(40):
             labels[2:5, i * 10 + 3:i * 10 + 7] = i + 1
-        np.random.seed(0)
-        values = np.random.uniform(size=n)
+        numpy.random.seed(0)
+        values = numpy.random.uniform(size=n)
         idx = 1
         my_min = .3
         my_max = .7
-        expected = np.zeros(labels.shape, int)
+        expected = numpy.zeros(labels.shape, int)
         for i, value in zip(range(n), values):
             if value >= my_min and value <= my_max:
                 expected[labels == i + 1] = idx
@@ -292,7 +283,7 @@ class TestFilterObjects(unittest.TestCase):
         module.object_name.value = INPUT_OBJECTS
         module.target_name.value = OUTPUT_OBJECTS
         module.measurements[0].measurement.value = TEST_FTR
-        module.filter_choice.value = F.FI_LIMITS
+        module.filter_choice.value = cellprofiler.modules.filterobjects.FI_LIMITS
         module.measurements[0].wants_minimum.value = True
         module.measurements[0].min_limit.value = my_min
         module.measurements[0].wants_maximum.value = True
@@ -301,19 +292,19 @@ class TestFilterObjects(unittest.TestCase):
         m.add_measurement(INPUT_OBJECTS, TEST_FTR, values)
         module.run(workspace)
         labels = workspace.object_set.get_objects(OUTPUT_OBJECTS)
-        self.assertTrue(np.all(labels.segmented == expected))
+        self.assertTrue(numpy.all(labels.segmented == expected))
 
     def test_03_02_filter(self):
         '''Filter objects by min limits'''
         n = 40
-        labels = np.zeros((10, n * 10), int)
+        labels = numpy.zeros((10, n * 10), int)
         for i in range(40):
             labels[2:5, i * 10 + 3:i * 10 + 7] = i + 1
-        np.random.seed(0)
-        values = np.random.uniform(size=n)
+        numpy.random.seed(0)
+        values = numpy.random.uniform(size=n)
         idx = 1
         my_min = .3
-        expected = np.zeros(labels.shape, int)
+        expected = numpy.zeros(labels.shape, int)
         for i, value in zip(range(n), values):
             if value >= my_min:
                 expected[labels == i + 1] = idx
@@ -322,7 +313,7 @@ class TestFilterObjects(unittest.TestCase):
         module.object_name.value = INPUT_OBJECTS
         module.target_name.value = OUTPUT_OBJECTS
         module.measurements[0].measurement.value = TEST_FTR
-        module.filter_choice.value = F.FI_LIMITS
+        module.filter_choice.value = cellprofiler.modules.filterobjects.FI_LIMITS
         module.measurements[0].min_limit.value = my_min
         module.measurements[0].max_limit.value = .7
         module.measurements[0].wants_maximum.value = False
@@ -330,19 +321,19 @@ class TestFilterObjects(unittest.TestCase):
         m.add_measurement(INPUT_OBJECTS, TEST_FTR, values)
         module.run(workspace)
         labels = workspace.object_set.get_objects(OUTPUT_OBJECTS)
-        self.assertTrue(np.all(labels.segmented == expected))
+        self.assertTrue(numpy.all(labels.segmented == expected))
 
     def test_03_03_filter(self):
         '''Filter objects by maximum limits'''
         n = 40
-        labels = np.zeros((10, n * 10), int)
+        labels = numpy.zeros((10, n * 10), int)
         for i in range(40):
             labels[2:5, i * 10 + 3:i * 10 + 7] = i + 1
-        np.random.seed(0)
-        values = np.random.uniform(size=n)
+        numpy.random.seed(0)
+        values = numpy.random.uniform(size=n)
         idx = 1
         my_max = .7
-        expected = np.zeros(labels.shape, int)
+        expected = numpy.zeros(labels.shape, int)
         for i, value in zip(range(n), values):
             if value <= my_max:
                 expected[labels == i + 1] = idx
@@ -351,7 +342,7 @@ class TestFilterObjects(unittest.TestCase):
         module.object_name.value = INPUT_OBJECTS
         module.target_name.value = OUTPUT_OBJECTS
         module.measurements[0].measurement.value = TEST_FTR
-        module.filter_choice.value = F.FI_LIMITS
+        module.filter_choice.value = cellprofiler.modules.filterobjects.FI_LIMITS
         module.measurements[0].min_limit.value = .3
         module.measurements[0].wants_minimum.value = False
         module.measurements[0].max_limit.value = my_max
@@ -359,20 +350,20 @@ class TestFilterObjects(unittest.TestCase):
         m.add_measurement(INPUT_OBJECTS, TEST_FTR, values)
         module.run(workspace)
         labels = workspace.object_set.get_objects(OUTPUT_OBJECTS)
-        self.assertTrue(np.all(labels.segmented == expected))
+        self.assertTrue(numpy.all(labels.segmented == expected))
 
     def test_03_04_filter_two(self):
         '''Filter objects by two measurements'''
         n = 40
-        labels = np.zeros((10, n * 10), int)
+        labels = numpy.zeros((10, n * 10), int)
         for i in range(40):
             labels[2:5, i * 10 + 3:i * 10 + 7] = i + 1
-        np.random.seed(0)
-        values = np.zeros((n, 2))
-        values = np.random.uniform(size=(n, 2))
+        numpy.random.seed(0)
+        values = numpy.zeros((n, 2))
+        values = numpy.random.uniform(size=(n, 2))
         idx = 1
-        my_max = np.array([.7, .5])
-        expected = np.zeros(labels.shape, int)
+        my_max = numpy.array([.7, .5])
+        expected = numpy.zeros(labels.shape, int)
         for i, v1, v2 in zip(range(n), values[:, 0], values[:, 1]):
             if v1 <= my_max[0] and v2 <= my_max[1]:
                 expected[labels == i + 1] = idx
@@ -385,30 +376,30 @@ class TestFilterObjects(unittest.TestCase):
         for i in range(2):
             measurement_name = "measurement%d" % (i + 1)
             module.measurements[i].measurement.value = measurement_name
-            module.filter_choice.value = F.FI_LIMITS
+            module.filter_choice.value = cellprofiler.modules.filterobjects.FI_LIMITS
             module.measurements[i].min_limit.value = .3
             module.measurements[i].wants_minimum.value = False
             module.measurements[i].max_limit.value = my_max[i]
             m.add_measurement(INPUT_OBJECTS, measurement_name, values[:, i])
         module.run(workspace)
         labels = workspace.object_set.get_objects(OUTPUT_OBJECTS)
-        self.assertTrue(np.all(labels.segmented == expected))
+        self.assertTrue(numpy.all(labels.segmented == expected))
 
     def test_04_01_renumber_other(self):
         '''Renumber an associated object'''
         n = 40
-        labels = np.zeros((10, n * 10), int)
-        alternates = np.zeros((10, n * 10), int)
+        labels = numpy.zeros((10, n * 10), int)
+        alternates = numpy.zeros((10, n * 10), int)
         for i in range(40):
             labels[2:5, i * 10 + 3:i * 10 + 7] = i + 1
             alternates[3:7, i * 10 + 2:i * 10 + 5] = i + 1
-        np.random.seed(0)
-        values = np.random.uniform(size=n)
+        numpy.random.seed(0)
+        values = numpy.random.uniform(size=n)
         idx = 1
         my_min = .3
         my_max = .7
-        expected = np.zeros(labels.shape, int)
-        expected_alternates = np.zeros(alternates.shape, int)
+        expected = numpy.zeros(labels.shape, int)
+        expected_alternates = numpy.zeros(alternates.shape, int)
         for i, value in zip(range(n), values):
             if value >= my_min and value <= my_max:
                 expected[labels == i + 1] = idx
@@ -419,7 +410,7 @@ class TestFilterObjects(unittest.TestCase):
         module.object_name.value = INPUT_OBJECTS
         module.target_name.value = OUTPUT_OBJECTS
         module.measurements[0].measurement.value = TEST_FTR
-        module.filter_choice.value = F.FI_LIMITS
+        module.filter_choice.value = cellprofiler.modules.filterobjects.FI_LIMITS
         module.measurements[0].min_limit.value = my_min
         module.measurements[0].max_limit.value = my_max
         module.add_additional_object()
@@ -430,8 +421,8 @@ class TestFilterObjects(unittest.TestCase):
         module.run(workspace)
         labels = workspace.object_set.get_objects(OUTPUT_OBJECTS)
         alternates = workspace.object_set.get_objects("my_additional_result")
-        self.assertTrue(np.all(labels.segmented == expected))
-        self.assertTrue(np.all(alternates.segmented == expected_alternates))
+        self.assertTrue(numpy.all(labels.segmented == expected))
+        self.assertTrue(numpy.all(alternates.segmented == expected_alternates))
 
     def test_05_00_load_matlab_v5(self):
         data = """CellProfiler Pipeline: http://www.cellprofiler.org
@@ -450,20 +441,20 @@ FilterByObjectMeasurement:[module_num:1|svn_version:\'8913\'|variable_revision_n
     Maximum value allowed:0.85
     What do you want to call the outlines of the identified objects (optional)?:MyOutlines
 """
-        pipeline = cpp.Pipeline()
+        pipeline = cellprofiler.pipeline.Pipeline()
 
         def callback(caller, event):
-            self.assertFalse(isinstance(event, cpp.LoadExceptionEvent))
+            self.assertFalse(isinstance(event, cellprofiler.pipeline.LoadExceptionEvent))
 
         pipeline.add_listener(callback)
         pipeline.load(StringIO.StringIO(data))
         self.assertEqual(len(pipeline.modules()), 1)
         module = pipeline.modules()[0]
-        self.assertTrue(isinstance(module, F.FilterByObjectMeasurement))
+        self.assertTrue(isinstance(module, cellprofiler.modules.filterobjects.FilterByObjectMeasurement))
         self.assertEqual(module.object_name, "MyObjects")
         self.assertEqual(module.target_name, "MyFilteredObjects")
         self.assertEqual(module.measurements[0].measurement, "Texture_Granulectomy")
-        self.assertEqual(module.filter_choice, F.FI_LIMITS)
+        self.assertEqual(module.filter_choice, cellprofiler.modules.filterobjects.FI_LIMITS)
         self.assertAlmostEqual(module.measurements[0].max_limit.value, 0.85)
         self.assertEqual(module.outlines_name, "MyOutlines")
 
@@ -489,24 +480,24 @@ FilterObjects:[module_num:1|svn_version:\'8955\'|variable_revision_number:3|show
     Rules folder name:.
     Rules file name:myrules.txt
 """
-        pipeline = cpp.Pipeline()
+        pipeline = cellprofiler.pipeline.Pipeline()
 
         def callback(caller, event):
-            self.assertFalse(isinstance(event, cpp.LoadExceptionEvent))
+            self.assertFalse(isinstance(event, cellprofiler.pipeline.LoadExceptionEvent))
 
         pipeline.add_listener(callback)
         pipeline.load(StringIO.StringIO(data))
         self.assertEqual(len(pipeline.modules()), 1)
         module = pipeline.modules()[-1]
-        self.assertTrue(isinstance(module, F.FilterObjects))
+        self.assertTrue(isinstance(module, cellprofiler.modules.filterobjects.FilterObjects))
         self.assertEqual(module.object_name, "Things")
         self.assertEqual(module.target_name, "FilteredThings")
-        self.assertEqual(module.mode, F.MODE_MEASUREMENTS)
+        self.assertEqual(module.mode, cellprofiler.modules.filterobjects.MODE_MEASUREMENTS)
         self.assertEqual(module.rules_directory.dir_choice,
-                         cpprefs.DEFAULT_OUTPUT_FOLDER_NAME)
+                         cellprofiler.preferences.DEFAULT_OUTPUT_FOLDER_NAME)
         self.assertEqual(module.rules_file_name, "myrules.txt")
         self.assertEqual(module.measurements[0].measurement, "Intensity_MeanIntensity_DNA")
-        self.assertEqual(module.filter_choice, F.FI_MINIMAL)
+        self.assertEqual(module.filter_choice, cellprofiler.modules.filterobjects.FI_MINIMAL)
 
     def test_05_06_load_v4(self):
         data = r"""CellProfiler Pipeline: http://www.cellprofiler.org
@@ -545,21 +536,21 @@ FilterObjects:[module_num:1|svn_version:\'9000\'|variable_revision_number:4|show
     Save outlines of relabeled objects?:No
     Name the outline image:OutlinesFilteredCytoplasm
 """
-        pipeline = cpp.Pipeline()
+        pipeline = cellprofiler.pipeline.Pipeline()
 
         def callback(caller, event):
-            self.assertFalse(isinstance(event, cpp.LoadExceptionEvent))
+            self.assertFalse(isinstance(event, cellprofiler.pipeline.LoadExceptionEvent))
 
         pipeline.add_listener(callback)
         pipeline.load(StringIO.StringIO(data))
         self.assertEqual(len(pipeline.modules()), 1)
         module = pipeline.modules()[-1]
-        self.assertTrue(isinstance(module, F.FilterObjects))
+        self.assertTrue(isinstance(module, cellprofiler.modules.filterobjects.FilterObjects))
         self.assertEqual(module.target_name, "MyFilteredObjects")
         self.assertEqual(module.object_name, "MyObjects")
-        self.assertEqual(module.mode, F.MODE_MEASUREMENTS)
-        self.assertEqual(module.filter_choice, F.FI_LIMITS)
-        self.assertEqual(module.rules_directory.dir_choice, cpprefs.DEFAULT_INPUT_FOLDER_NAME)
+        self.assertEqual(module.mode, cellprofiler.modules.filterobjects.MODE_MEASUREMENTS)
+        self.assertEqual(module.filter_choice, cellprofiler.modules.filterobjects.FI_LIMITS)
+        self.assertEqual(module.rules_directory.dir_choice, cellprofiler.preferences.DEFAULT_INPUT_FOLDER_NAME)
         self.assertEqual(module.rules_directory.custom_path, "./rules")
         self.assertEqual(module.rules_file_name, "myrules.txt")
         self.assertEqual(module.measurement_count.value, 2)
@@ -618,21 +609,21 @@ FilterObjects:[module_num:6|svn_version:\'9000\'|variable_revision_number:5|show
     Save outlines of relabeled objects?:No
     Name the outline image:OutlinesFilteredCytoplasm
 """
-        pipeline = cpp.Pipeline()
+        pipeline = cellprofiler.pipeline.Pipeline()
 
         def callback(caller, event):
-            self.assertFalse(isinstance(event, cpp.LoadExceptionEvent))
+            self.assertFalse(isinstance(event, cellprofiler.pipeline.LoadExceptionEvent))
 
         pipeline.add_listener(callback)
         pipeline.load(StringIO.StringIO(data))
         self.assertEqual(len(pipeline.modules()), 1)
         module = pipeline.modules()[-1]
-        self.assertTrue(isinstance(module, F.FilterObjects))
+        self.assertTrue(isinstance(module, cellprofiler.modules.filterobjects.FilterObjects))
         self.assertEqual(module.target_name, "MyFilteredObjects")
         self.assertEqual(module.object_name, "MyObjects")
-        self.assertEqual(module.mode, F.MODE_MEASUREMENTS)
-        self.assertEqual(module.filter_choice, F.FI_LIMITS)
-        self.assertEqual(module.rules_directory.dir_choice, cpprefs.DEFAULT_INPUT_FOLDER_NAME)
+        self.assertEqual(module.mode, cellprofiler.modules.filterobjects.MODE_MEASUREMENTS)
+        self.assertEqual(module.filter_choice, cellprofiler.modules.filterobjects.FI_LIMITS)
+        self.assertEqual(module.rules_directory.dir_choice, cellprofiler.preferences.DEFAULT_INPUT_FOLDER_NAME)
         self.assertEqual(module.rules_directory.custom_path, "./rules")
         self.assertEqual(module.rules_file_name, "myrules.txt")
         self.assertEqual(module.rules_class, "1")
@@ -693,22 +684,22 @@ FilterObjects:[module_num:6|svn_version:\'9000\'|variable_revision_number:5|show
         Save outlines of relabeled objects?:No
         Name the outline image:OutlinesFilteredCytoplasm
     """
-        pipeline = cpp.Pipeline()
+        pipeline = cellprofiler.pipeline.Pipeline()
 
         def callback(caller, event):
-            self.assertFalse(isinstance(event, cpp.LoadExceptionEvent))
+            self.assertFalse(isinstance(event, cellprofiler.pipeline.LoadExceptionEvent))
 
         pipeline.add_listener(callback)
         pipeline.load(StringIO.StringIO(data))
         self.assertEqual(len(pipeline.modules()), 1)
         module = pipeline.modules()[-1]
-        self.assertTrue(isinstance(module, F.FilterObjects))
+        self.assertTrue(isinstance(module, cellprofiler.modules.filterobjects.FilterObjects))
         self.assertEqual(module.target_name, "MyFilteredObjects")
         self.assertEqual(module.object_name, "MyObjects")
-        self.assertEqual(module.mode, F.MODE_MEASUREMENTS)
-        self.assertEqual(module.filter_choice, F.FI_LIMITS)
-        self.assertEqual(module.per_object_assignment, F.PO_BOTH)
-        self.assertEqual(module.rules_directory.dir_choice, cpprefs.DEFAULT_INPUT_FOLDER_NAME)
+        self.assertEqual(module.mode, cellprofiler.modules.filterobjects.MODE_MEASUREMENTS)
+        self.assertEqual(module.filter_choice, cellprofiler.modules.filterobjects.FI_LIMITS)
+        self.assertEqual(module.per_object_assignment, cellprofiler.modules.filterobjects.PO_BOTH)
+        self.assertEqual(module.rules_directory.dir_choice, cellprofiler.preferences.DEFAULT_INPUT_FOLDER_NAME)
         self.assertEqual(module.rules_directory.custom_path, "./rules")
         self.assertEqual(module.rules_file_name, "myrules.txt")
         self.assertEqual(module.rules_class, "1")
@@ -770,22 +761,22 @@ FilterObjects:[module_num:6|svn_version:\'9000\'|variable_revision_number:5|show
         Save outlines of relabeled objects?:No
         Name the outline image:OutlinesFilteredCytoplasm
     """
-        pipeline = cpp.Pipeline()
+        pipeline = cellprofiler.pipeline.Pipeline()
 
         def callback(caller, event):
-            self.assertFalse(isinstance(event, cpp.LoadExceptionEvent))
+            self.assertFalse(isinstance(event, cellprofiler.pipeline.LoadExceptionEvent))
 
         pipeline.add_listener(callback)
         pipeline.load(StringIO.StringIO(data))
         self.assertEqual(len(pipeline.modules()), 1)
         module = pipeline.modules()[-1]
-        self.assertTrue(isinstance(module, F.FilterObjects))
+        self.assertTrue(isinstance(module, cellprofiler.modules.filterobjects.FilterObjects))
         self.assertEqual(module.target_name, "MyFilteredObjects")
         self.assertEqual(module.object_name, "MyObjects")
-        self.assertEqual(module.mode, F.MODE_MEASUREMENTS)
-        self.assertEqual(module.filter_choice, F.FI_LIMITS)
-        self.assertEqual(module.per_object_assignment, F.PO_PARENT_WITH_MOST_OVERLAP)
-        self.assertEqual(module.rules_directory.dir_choice, cpprefs.DEFAULT_INPUT_FOLDER_NAME)
+        self.assertEqual(module.mode, cellprofiler.modules.filterobjects.MODE_MEASUREMENTS)
+        self.assertEqual(module.filter_choice, cellprofiler.modules.filterobjects.FI_LIMITS)
+        self.assertEqual(module.per_object_assignment, cellprofiler.modules.filterobjects.PO_PARENT_WITH_MOST_OVERLAP)
+        self.assertEqual(module.rules_directory.dir_choice, cellprofiler.preferences.DEFAULT_INPUT_FOLDER_NAME)
         self.assertEqual(module.rules_directory.custom_path, "./rules")
         self.assertEqual(module.rules_file_name, "myrules.txt")
         self.assertEqual(module.rules_class, "1")
@@ -811,21 +802,21 @@ FilterObjects:[module_num:6|svn_version:\'9000\'|variable_revision_number:5|show
 
     def test_06_01_get_measurement_columns(self):
         '''Test the get_measurement_columns function'''
-        workspace, module = self.make_workspace({INPUT_OBJECTS: np.zeros((10, 10), int)})
+        workspace, module = self.make_workspace({INPUT_OBJECTS: numpy.zeros((10, 10), int)})
         module.object_name.value = INPUT_OBJECTS
         module.target_name.value = OUTPUT_OBJECTS
         module.measurements[0].measurement.value = TEST_FTR
-        module.filter_choice.value = F.FI_MAXIMAL
+        module.filter_choice.value = cellprofiler.modules.filterobjects.FI_MAXIMAL
         m = workspace.measurements
-        m.add_measurement(INPUT_OBJECTS, TEST_FTR, np.zeros((0,)))
+        m.add_measurement(INPUT_OBJECTS, TEST_FTR, numpy.zeros((0,)))
         module.run(workspace)
-        image_features = m.get_feature_names(cpm.IMAGE)
+        image_features = m.get_feature_names(cellprofiler.measurement.IMAGE)
         result_features = m.get_feature_names(OUTPUT_OBJECTS)
         object_features = m.get_feature_names(INPUT_OBJECTS)
         columns = module.get_measurement_columns(workspace.pipeline)
         self.assertEqual(len(columns), 6)
         for feature in image_features:
-            self.assertTrue(any([(column[0] == cpm.IMAGE and
+            self.assertTrue(any([(column[0] == cellprofiler.measurement.IMAGE and
                                   column[1] == feature)
                                  for column in columns]))
         for feature in result_features:
@@ -839,33 +830,33 @@ FilterObjects:[module_num:6|svn_version:\'9000\'|variable_revision_number:5|show
                                      for column in columns]))
 
         for column in columns:
-            self.assertTrue(column[0] in (cpm.IMAGE, OUTPUT_OBJECTS, INPUT_OBJECTS))
-            if column[0] == cpm.IMAGE:
+            self.assertTrue(column[0] in (cellprofiler.measurement.IMAGE, OUTPUT_OBJECTS, INPUT_OBJECTS))
+            if column[0] == cellprofiler.measurement.IMAGE:
                 self.assertTrue(column[1] in image_features)
             elif column[0] == OUTPUT_OBJECTS:
                 self.assertTrue(column[1] in result_features)
 
         for feature, coltype in (
-                (M_LOCATION_CENTER_X, cpm.COLTYPE_FLOAT),
-                (M_LOCATION_CENTER_Y, cpm.COLTYPE_FLOAT),
-                (M_NUMBER_OBJECT_NUMBER, cpm.COLTYPE_INTEGER),
-                (FF_PARENT % INPUT_OBJECTS, cpm.COLTYPE_INTEGER),
-                (FF_CHILDREN_COUNT % OUTPUT_OBJECTS, cpm.COLTYPE_INTEGER),
-                (FF_COUNT % OUTPUT_OBJECTS, cpm.COLTYPE_INTEGER)):
+                (cellprofiler.measurement.M_LOCATION_CENTER_X, cellprofiler.measurement.COLTYPE_FLOAT),
+                (cellprofiler.measurement.M_LOCATION_CENTER_Y, cellprofiler.measurement.COLTYPE_FLOAT),
+                (cellprofiler.measurement.M_NUMBER_OBJECT_NUMBER, cellprofiler.measurement.COLTYPE_INTEGER),
+                (cellprofiler.measurement.FF_PARENT % INPUT_OBJECTS, cellprofiler.measurement.COLTYPE_INTEGER),
+                (cellprofiler.measurement.FF_CHILDREN_COUNT % OUTPUT_OBJECTS, cellprofiler.measurement.COLTYPE_INTEGER),
+                (cellprofiler.measurement.FF_COUNT % OUTPUT_OBJECTS, cellprofiler.measurement.COLTYPE_INTEGER)):
             fcolumns = [x for x in columns if x[1] == feature]
             self.assertEqual(
                     len(fcolumns), 1, "Missing or duplicate column: %s" % feature)
             self.assertEqual(fcolumns[0][2], coltype)
 
         m_output_objects_count = \
-            (FF_CHILDREN_COUNT % OUTPUT_OBJECTS).partition("_")[-1]
+            (cellprofiler.measurement.FF_CHILDREN_COUNT % OUTPUT_OBJECTS).partition("_")[-1]
         for object_name, category in (
-                (cpm.IMAGE, dict(Count=[OUTPUT_OBJECTS])),
-                (INPUT_OBJECTS, {C_CHILDREN: [m_output_objects_count]}),
+                (cellprofiler.measurement.IMAGE, dict(Count=[OUTPUT_OBJECTS])),
+                (INPUT_OBJECTS, {cellprofiler.measurement.C_CHILDREN: [m_output_objects_count]}),
                 (OUTPUT_OBJECTS, {
-                    C_LOCATION: [FTR_CENTER_X, FTR_CENTER_Y],
-                    C_PARENT: [INPUT_OBJECTS],
-                    C_NUMBER: [FTR_OBJECT_NUMBER]})):
+                    cellprofiler.measurement.C_LOCATION: [cellprofiler.measurement.FTR_CENTER_X, cellprofiler.measurement.FTR_CENTER_Y],
+                    cellprofiler.measurement.C_PARENT: [INPUT_OBJECTS],
+                    cellprofiler.measurement.C_NUMBER: [cellprofiler.measurement.FTR_OBJECT_NUMBER]})):
             categories = module.get_categories(None, object_name)
             for c in category.keys():
                 self.assertTrue(c in categories)
@@ -874,15 +865,15 @@ FilterObjects:[module_num:6|svn_version:\'9000\'|variable_revision_number:5|show
                     self.assertTrue(f in category[c])
 
     def test_08_01_filter_by_rule(self):
-        labels = np.zeros((10, 20), int)
+        labels = numpy.zeros((10, 20), int)
         labels[3:5, 4:9] = 1
         labels[7:9, 6:12] = 2
         labels[4:9, 14:18] = 3
         workspace, module = self.make_workspace({"MyObjects": labels})
-        self.assertTrue(isinstance(module, F.FilterByObjectMeasurement))
+        self.assertTrue(isinstance(module, cellprofiler.modules.filterobjects.FilterByObjectMeasurement))
         m = workspace.measurements
         m.add_measurement("MyObjects", "MyMeasurement",
-                          np.array([1.5, 2.3, 1.8]))
+                          numpy.array([1.5, 2.3, 1.8]))
         rules_file_contents = "IF (MyObjects_MyMeasurement > 2.0, [1.0,-1.0], [-1.0,1.0])\n"
         rules_path = tempfile.mktemp()
         fd = open(rules_path, 'wt')
@@ -891,16 +882,16 @@ FilterObjects:[module_num:6|svn_version:\'9000\'|variable_revision_number:5|show
             fd.close()
             rules_dir, rules_file = os.path.split(rules_path)
             module.object_name.value = "MyObjects"
-            module.mode.value = F.MODE_RULES
+            module.mode.value = cellprofiler.modules.filterobjects.MODE_RULES
             module.rules_file_name.value = rules_file
-            module.rules_directory.dir_choice = cpprefs.ABSOLUTE_FOLDER_NAME
+            module.rules_directory.dir_choice = cellprofiler.preferences.ABSOLUTE_FOLDER_NAME
             module.rules_directory.custom_path = rules_dir
             module.target_name.value = "MyTargetObjects"
             module.run(workspace)
             target_objects = workspace.object_set.get_objects("MyTargetObjects")
             target_labels = target_objects.segmented
-            self.assertTrue(np.all(target_labels[labels == 2] > 0))
-            self.assertTrue(np.all(target_labels[labels != 2] == 0))
+            self.assertTrue(numpy.all(target_labels[labels == 2] > 0))
+            self.assertTrue(numpy.all(target_labels[labels != 2] == 0))
         finally:
             os.remove(rules_path)
 
@@ -915,20 +906,20 @@ FilterObjects:[module_num:6|svn_version:\'9000\'|variable_revision_number:5|show
         fd.close()
         try:
             for rules_class in ("1", "2", "3"):
-                labels = np.zeros((10, 20), int)
+                labels = numpy.zeros((10, 20), int)
                 labels[3:5, 4:9] = 1
                 labels[7:9, 6:12] = 2
                 labels[4:9, 14:18] = 3
                 workspace, module = self.make_workspace({"MyObjects": labels})
-                self.assertTrue(isinstance(module, F.FilterByObjectMeasurement))
+                self.assertTrue(isinstance(module, cellprofiler.modules.filterobjects.FilterByObjectMeasurement))
                 m = workspace.measurements
                 m.add_measurement("MyObjects", "MyMeasurement",
-                                  np.array([1.5, 2.3, 1.8]))
+                                  numpy.array([1.5, 2.3, 1.8]))
                 rules_dir, rules_file = os.path.split(rules_path)
                 module.object_name.value = "MyObjects"
-                module.mode.value = F.MODE_RULES
+                module.mode.value = cellprofiler.modules.filterobjects.MODE_RULES
                 module.rules_file_name.value = rules_file
-                module.rules_directory.dir_choice = cpprefs.ABSOLUTE_FOLDER_NAME
+                module.rules_directory.dir_choice = cellprofiler.preferences.ABSOLUTE_FOLDER_NAME
                 module.rules_directory.custom_path = rules_dir
                 module.rules_class.value = rules_class
                 module.target_name.value = "MyTargetObjects"
@@ -936,44 +927,44 @@ FilterObjects:[module_num:6|svn_version:\'9000\'|variable_revision_number:5|show
                 target_objects = workspace.object_set.get_objects("MyTargetObjects")
                 target_labels = target_objects.segmented
                 kept = expected_class.index(rules_class)
-                self.assertTrue(np.all(target_labels[labels == kept] > 0))
-                self.assertTrue(np.all(target_labels[labels != kept] == 0))
+                self.assertTrue(numpy.all(target_labels[labels == kept] > 0))
+                self.assertTrue(numpy.all(target_labels[labels != kept] == 0))
         finally:
             os.remove(rules_path)
 
     def test_09_01_discard_border_objects(self):
         '''Test the mode to discard border objects'''
-        labels = np.zeros((10, 10), int)
+        labels = numpy.zeros((10, 10), int)
         labels[1:4, 0:3] = 1
         labels[4:8, 1:5] = 2
         labels[:, 9] = 3
 
-        expected = np.zeros((10, 10), int)
+        expected = numpy.zeros((10, 10), int)
         expected[4:8, 1:5] = 1
 
         workspace, module = self.make_workspace({INPUT_OBJECTS: labels})
         module.object_name.value = INPUT_OBJECTS
         module.target_name.value = OUTPUT_OBJECTS
-        module.mode.value = F.MODE_BORDER
+        module.mode.value = cellprofiler.modules.filterobjects.MODE_BORDER
         module.run(workspace)
         output_objects = workspace.object_set.get_objects(OUTPUT_OBJECTS)
-        self.assertTrue(np.all(expected == output_objects.segmented))
+        self.assertTrue(numpy.all(expected == output_objects.segmented))
 
     def test_09_02_discard_mask_objects(self):
         '''Test discarding objects that touch the mask of objects parent img'''
-        mask = np.ones((10, 10), bool)
+        mask = numpy.ones((10, 10), bool)
         mask[5, 5] = False
-        labels = np.zeros((10, 10), int)
+        labels = numpy.zeros((10, 10), int)
         labels[1:4, 1:4] = 1
         labels[5:8, 5:8] = 2
         expected = labels.copy()
         expected[expected == 2] = 0
 
         workspace, module = self.make_workspace({})
-        parent_image = cpi.Image(np.zeros((10, 10)), mask=mask)
+        parent_image = cellprofiler.image.Image(numpy.zeros((10, 10)), mask=mask)
         workspace.image_set.add(INPUT_IMAGE, parent_image)
 
-        input_objects = cpo.Objects()
+        input_objects = cellprofiler.object.Objects()
         input_objects.segmented = labels
         input_objects.parent_image = parent_image
 
@@ -981,38 +972,38 @@ FilterObjects:[module_num:6|svn_version:\'9000\'|variable_revision_number:5|show
 
         module.object_name.value = INPUT_OBJECTS
         module.target_name.value = OUTPUT_OBJECTS
-        module.mode.value = F.MODE_BORDER
+        module.mode.value = cellprofiler.modules.filterobjects.MODE_BORDER
         module.run(workspace)
         output_objects = workspace.object_set.get_objects(OUTPUT_OBJECTS)
-        self.assertTrue(np.all(expected == output_objects.segmented))
+        self.assertTrue(numpy.all(expected == output_objects.segmented))
 
     def test_10_01_unedited_segmented(self):
         # Test transferral of unedited segmented segmentation
         # from source to target
 
-        unedited = np.zeros((10, 10), dtype=int)
+        unedited = numpy.zeros((10, 10), dtype=int)
         unedited[0:4, 0:4] = 1
         unedited[6:8, 0:4] = 2
         unedited[6:8, 6:8] = 3
-        segmented = np.zeros((10, 10), dtype=int)
+        segmented = numpy.zeros((10, 10), dtype=int)
         segmented[6:8, 6:8] = 1
         segmented[6:8, 0:4] = 2
 
         workspace, module = self.make_workspace({})
-        input_objects = cpo.Objects()
+        input_objects = cellprofiler.object.Objects()
         workspace.object_set.add_objects(input_objects, INPUT_OBJECTS)
         input_objects.segmented = segmented
         input_objects.unedited_segmented = unedited
         module.object_name.value = INPUT_OBJECTS
         module.target_name.value = OUTPUT_OBJECTS
-        module.mode.value = F.MODE_MEASUREMENTS
+        module.mode.value = cellprofiler.modules.filterobjects.MODE_MEASUREMENTS
         module.measurements[0].measurement.value = TEST_FTR
-        module.filter_choice.value = F.FI_MINIMAL
+        module.filter_choice.value = cellprofiler.modules.filterobjects.FI_MINIMAL
         m = workspace.measurements
-        m[INPUT_OBJECTS, TEST_FTR] = np.array([2, 1])
+        m[INPUT_OBJECTS, TEST_FTR] = numpy.array([2, 1])
         module.run(workspace)
         output_objects = workspace.object_set.get_objects(OUTPUT_OBJECTS)
-        np.testing.assert_equal(output_objects.unedited_segmented, unedited)
+        numpy.testing.assert_equal(output_objects.unedited_segmented, unedited)
 
     def test_10_02_small_removed_segmented(self):
         # Test output objects' small_removed_segmented
@@ -1020,72 +1011,72 @@ FilterObjects:[module_num:6|svn_version:\'9000\'|variable_revision_number:5|show
         # It should be the small_removed_segmented of the
         # source minus the filtered
 
-        unedited = np.zeros((10, 10), dtype=int)
+        unedited = numpy.zeros((10, 10), dtype=int)
         unedited[0:4, 0:4] = 1
         unedited[6:8, 0:4] = 2
         unedited[6:8, 6:8] = 3
-        segmented = np.zeros((10, 10), dtype=int)
+        segmented = numpy.zeros((10, 10), dtype=int)
         segmented[6:8, 6:8] = 1
         segmented[6:8, 0:4] = 2
 
         workspace, module = self.make_workspace({})
-        input_objects = cpo.Objects()
+        input_objects = cellprofiler.object.Objects()
         input_objects.segmented = segmented
         input_objects.unedited_segmented = unedited
         workspace.object_set.add_objects(input_objects, INPUT_OBJECTS)
         module.object_name.value = INPUT_OBJECTS
         module.target_name.value = OUTPUT_OBJECTS
-        module.mode.value = F.MODE_MEASUREMENTS
+        module.mode.value = cellprofiler.modules.filterobjects.MODE_MEASUREMENTS
         module.measurements[0].measurement.value = TEST_FTR
-        module.filter_choice.value = F.FI_MINIMAL
+        module.filter_choice.value = cellprofiler.modules.filterobjects.FI_MINIMAL
         m = workspace.measurements
-        m[INPUT_OBJECTS, TEST_FTR] = np.array([2, 1])
+        m[INPUT_OBJECTS, TEST_FTR] = numpy.array([2, 1])
         module.run(workspace)
         output_objects = workspace.object_set.get_objects(OUTPUT_OBJECTS)
         small_removed = output_objects.small_removed_segmented
         mask = (unedited != 3) & (unedited != 0)
-        self.assertTrue(np.all(small_removed[mask] != 0))
-        self.assertTrue(np.all(small_removed[~mask] == 0))
+        self.assertTrue(numpy.all(small_removed[mask] != 0))
+        self.assertTrue(numpy.all(small_removed[~mask] == 0))
 
     def test_11_00_classify_none(self):
         workspace, module = self.make_workspace(
-            {INPUT_OBJECTS : np.zeros((10, 10), int)})
+            {INPUT_OBJECTS : numpy.zeros((10, 10), int)})
         module.object_name.value = INPUT_OBJECTS
         module.target_name.value = OUTPUT_OBJECTS
-        with self.make_classifier(module, np.zeros(0, int), classes = [1]):
-            workspace.measurements[INPUT_OBJECTS, TEST_FTR] = np.zeros(0)
+        with self.make_classifier(module, numpy.zeros(0, int), classes = [1]):
+            workspace.measurements[INPUT_OBJECTS, TEST_FTR] = numpy.zeros(0)
             module.run(workspace)
             output_objects = workspace.object_set.get_objects(OUTPUT_OBJECTS)
             self.assertEqual(output_objects.count, 0)
 
     def test_11_01_classify_true(self):
-        labels = np.zeros((10, 10), int)
+        labels = numpy.zeros((10, 10), int)
         labels[4:7, 4:7] = 1
         workspace, module = self.make_workspace(
             {INPUT_OBJECTS : labels})
         module.object_name.value = INPUT_OBJECTS
         module.target_name.value = OUTPUT_OBJECTS
-        with self.make_classifier(module, np.ones(1, int), classes = [1, 2]):
-            workspace.measurements[INPUT_OBJECTS, TEST_FTR] = np.zeros(1)
+        with self.make_classifier(module, numpy.ones(1, int), classes = [1, 2]):
+            workspace.measurements[INPUT_OBJECTS, TEST_FTR] = numpy.zeros(1)
             module.run(workspace)
             output_objects = workspace.object_set.get_objects(OUTPUT_OBJECTS)
             self.assertEqual(output_objects.count, 1)
 
     def test_11_02_classify_false(self):
-        labels = np.zeros((10, 10), int)
+        labels = numpy.zeros((10, 10), int)
         labels[4:7, 4:7] = 1
         workspace, module = self.make_workspace(
             {INPUT_OBJECTS : labels})
         module.object_name.value = INPUT_OBJECTS
         module.target_name.value = OUTPUT_OBJECTS
-        with self.make_classifier(module, np.ones(1, int)*2, classes = [1, 2]):
-            workspace.measurements[INPUT_OBJECTS, TEST_FTR] = np.zeros(1)
+        with self.make_classifier(module, numpy.ones(1, int)*2, classes = [1, 2]):
+            workspace.measurements[INPUT_OBJECTS, TEST_FTR] = numpy.zeros(1)
             module.run(workspace)
             output_objects = workspace.object_set.get_objects(OUTPUT_OBJECTS)
             self.assertEqual(output_objects.count, 0)
 
     def test_11_03_classify_many(self):
-        labels = np.zeros((10, 10), int)
+        labels = numpy.zeros((10, 10), int)
         labels[1:4, 1:4] = 1
         labels[5:7, 5:7] = 2
         workspace, module = self.make_workspace(
@@ -1093,14 +1084,14 @@ FilterObjects:[module_num:6|svn_version:\'9000\'|variable_revision_number:5|show
         module.object_name.value = INPUT_OBJECTS
         module.target_name.value = OUTPUT_OBJECTS
         with self.make_classifier(
-            module, np.array([1, 2]), classes = [1, 2]):
-            workspace.measurements[INPUT_OBJECTS, TEST_FTR] = np.zeros(2)
+            module, numpy.array([1, 2]), classes = [1, 2]):
+            workspace.measurements[INPUT_OBJECTS, TEST_FTR] = numpy.zeros(2)
             module.run(workspace)
             output_objects = workspace.object_set.get_objects(OUTPUT_OBJECTS)
             self.assertEqual(output_objects.count, 1)
             labels_out = output_objects.get_labels()[0][0]
-            np.testing.assert_array_equal(labels_out[1:4, 1:4], 1)
-            np.testing.assert_array_equal(labels_out[5:7, 5:7], 0)
+            numpy.testing.assert_array_equal(labels_out[1:4, 1:4], 1)
+            numpy.testing.assert_array_equal(labels_out[5:7, 5:7], 0)
 
 class FakeClassifier(object):
     def __init__(self, answers, classes):


### PR DESCRIPTION
* Don't use `globals()` in string formatting.
* Remove import aliases and optimize imports.
* PEP 08 compliance.