### PR TITLE
Change default for "Fill holes in identified objects"

### DIFF
--- a/cellprofiler/modules/identifyprimaryobjects.py
+++ b/cellprofiler/modules/identifyprimaryobjects.py
@@ -533,7 +533,7 @@ class IdentifyPrimaryObjects(identify.Identify):
         self.fill_holes = cellprofiler.setting.Choice(
             'Fill holes in identified objects?',
             FH_ALL,
-            value=FH_THRESHOLDING,
+            value=FH_DECLUMP,
             doc="""
             This option controls how holes are filled in:
             <ul>


### PR DESCRIPTION
Make "After declumping only" default for "Fill holes in identified
objects