### PR TITLE
addressing some  commandline switch problems

### DIFF
--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -56,16 +56,9 @@ def main(args=None):
 
     if any([any([arg.startswith(switch) for switch in switches]) for arg in args]):
         cellprofiler.preferences.set_headless()
-
         cellprofiler.worker.aw_parse_args()
-
         cellprofiler.worker.main()
-
         sys.exit(exit_code)
-
-    #if any([arg.startswith('--get-batch-commands') for arg in args]):    
-    #    cellprofiler.preferences.set_headless()
-
 
     options, args = parse_args(args)
 

--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -550,8 +550,6 @@ def get_batch_commands(filename):
     m = cellprofiler.measurement.Measurements(filename=path, mode="r")
 
     image_numbers = m.get_image_numbers()
-    print("has measurement image: ", ("no", "yes")[m.has_feature(cellprofiler.measurement.IMAGE,cellprofiler.measurement.GROUP_NUMBER)])
-
 
     if m.has_feature(cellprofiler.measurement.IMAGE, cellprofiler.measurement.GROUP_NUMBER):
         group_numbers = m[cellprofiler.measurement.IMAGE, cellprofiler.measurement.GROUP_NUMBER, image_numbers]
@@ -580,8 +578,6 @@ def get_batch_commands(filename):
 
             return
 
-    print("Image numbers")
-    print(image_numbers)
     metadata_tags = m.get_grouping_tags()
 
     groupings = m.get_groupings(metadata_tags)

--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -79,6 +79,7 @@ def main(args=None):
 
     if options.batch_commands_file is not None:
         get_batch_commands(options.batch_commands_file)
+        exit() # added by Volker, typically we do not want to run a pipeline when we call CellProfiler to create batch scripts. Exit, once the batch files have been created.
 
     if options.omero_credentials is not None:
         set_omero_credentials_from_string(options.omero_credentials)

--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -47,6 +47,7 @@ def main(args=None):
     if args is None:
         args = sys.argv
 
+
     cellprofiler.preferences.set_awt_headless(True)
 
     exit_code = 0
@@ -62,6 +63,10 @@ def main(args=None):
 
         sys.exit(exit_code)
 
+    #if any([arg.startswith('--get-batch-commands') for arg in args]):    
+    #    cellprofiler.preferences.set_headless()
+
+
     options, args = parse_args(args)
 
     if options.print_version:
@@ -72,6 +77,11 @@ def main(args=None):
 
         options.run_pipeline = True
 
+    if options.batch_commands_file:
+        cellprofiler.preferences.set_headless()
+        options.run_pipeline = False
+        options.show_gui = False
+
     set_log_level(options)
 
     if options.print_groups_file is not None:
@@ -79,7 +89,6 @@ def main(args=None):
 
     if options.batch_commands_file is not None:
         get_batch_commands(options.batch_commands_file)
-        exit() # added by Volker, typically we do not want to run a pipeline when we call CellProfiler to create batch scripts. Exit, once the batch files have been created.
 
     if options.omero_credentials is not None:
         set_omero_credentials_from_string(options.omero_credentials)

--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -47,7 +47,6 @@ def main(args=None):
     if args is None:
         args = sys.argv
 
-
     cellprofiler.preferences.set_awt_headless(True)
 
     exit_code = 0
@@ -312,7 +311,7 @@ def parse_args(args):
         "--get-batch-commands",
         dest="batch_commands_file",
         default=None,
-        help='Open the measurements file following the --get-batch-commands switch and print one line to the console per group. The measurements file should be generated using CreateBatchFiles and the image sets should be grouped into the units to be run. Each line is a command to invoke CellProfiler. You can use this option to generate a shell script that will invoke CellProfiler on a cluster by substituting "CellProfiler" ' "with your invocation command in the script's text, for instance: CellProfiler --get-batch-commands Batch_data.h5 | sed s/CellProfiler/farm_jobs.sh")
+        help='Open the measurements file following the --get-batch-commands switch and print one line to the console per group. The measurements file should be generated using CreateBatchFiles and the image sets should be grouped into the units to be run. Each line is a command to invoke CellProfiler. You can use this option to generate a shell script that will invoke CellProfiler on a cluster by substituting "CellProfiler" ' "with your invocation command in the script's text, for instance: CellProfiler --get-batch-commands Batch_data.h5 | sed s/CellProfiler/farm_jobs.sh. Note that CellProfiler will always run in headless mode when --get-batch-commands is present and will exit after generating the batch commands without processing any pipeline.")
 
     parser.add_option(
         "--data-file",
@@ -551,6 +550,8 @@ def get_batch_commands(filename):
     m = cellprofiler.measurement.Measurements(filename=path, mode="r")
 
     image_numbers = m.get_image_numbers()
+    print("has measurement image: ", ("no", "yes")[m.has_feature(cellprofiler.measurement.IMAGE,cellprofiler.measurement.GROUP_NUMBER)])
+
 
     if m.has_feature(cellprofiler.measurement.IMAGE, cellprofiler.measurement.GROUP_NUMBER):
         group_numbers = m[cellprofiler.measurement.IMAGE, cellprofiler.measurement.GROUP_NUMBER, image_numbers]
@@ -579,6 +580,8 @@ def get_batch_commands(filename):
 
             return
 
+    print("Image numbers")
+    print(image_numbers)
     metadata_tags = m.get_grouping_tags()
 
     groupings = m.get_groupings(metadata_tags)


### PR DESCRIPTION
`--get-batch-commands` did require a pipeline file and tried to run the pipeline after generating the batch commands. I don't see a use case for this behaviour.

Made some changes so that, if `--get-batch-commands` is present

- Cellprofiler will run headless, even if not explicitly asked for running headless by specifying `-c`
- No pipeline will be run
- No error message is thrown if `-p` is missing.