### PR TITLE
Allow multiprocessing on Windows after freeze

### DIFF
--- a/CellProfiler.py
+++ b/CellProfiler.py
@@ -1,4 +1,8 @@
+import multiprocessing
+
 import cellprofiler.__main__
 
 if __name__ == "__main__":
+    # allows multiprocessing on Windows after freeze
+    multiprocessing.freeze_support()
     cellprofiler.__main__.main()


### PR DESCRIPTION
The easiest way for parallelization is to use multiprocessing Process. However it is not working on Windows when module is loaded by executable version of CellProfiler.

For example If we load module as plugin in CellProfiler 2.2 and try to use multiprocessing it tries to call CellProfiler.exe with --multiprocessing-fork which fails. 

It seems that the solution is very simple and safe, just call multiprocessing.freeze_support after == '__main__' check in CellProfiler.py to handle the additional parameter (see https://docs.python.org/2/library/multiprocessing.html)