### PR TITLE
Don't raise exception when structuring element size is cleared.

### DIFF
--- a/cellprofiler/gui/moduleview.py
+++ b/cellprofiler/gui/moduleview.py
@@ -694,7 +694,8 @@ class ModuleView(object):
             )
 
             def on_set_size(event):
-                v.size = int(event.GetString())
+                size = event.GetString()
+                v.size = int(size) if size else ""
                 new_value = v.value_text
                 self.notify(SettingEditedEvent(v, self.__module, new_value, event))
 

--- a/cellprofiler/setting.py
+++ b/cellprofiler/setting.py
@@ -1709,11 +1709,23 @@ class StructuringElement(Setting):
 
     @property
     def size(self):
-        return int(self.value_text.split(",")[1])
+        _, size = self.value_text.split(",")
+
+        return int(size) if size else None
 
     @size.setter
     def size(self, value):
         self.value_text = ",".join((self.shape, str(value)))
+
+    def test_valid(self, pipeline):
+        if self.size is None:
+            raise ValidationError("Missing structuring element size. Please enter a positive integer.", self)
+
+        if self.size <= 0:
+            raise ValidationError(
+                "Structuring element size must be a positive integer. You provided {}.".format(self.size),
+                self
+            )
 
 
 class CustomChoice(Choice):


### PR DESCRIPTION
Additionally, validate the size is set and is a positive integer.

Resolves #2349 