### PR TITLE
Issues/2837

### DIFF
--- a/cellprofiler/modules/closing.py
+++ b/cellprofiler/modules/closing.py
@@ -54,7 +54,9 @@ class Closing(cellprofiler.module.ImageProcessing):
             raise NotImplementedError("A 3D structuring element cannot be applied to a 2D image.")
         else:
             if x.pixel_data.dtype == numpy.bool:
-                self.function = skimage.morphology.binary_closing
+                # issue #2837
+                # self.function = skimage.morphology.binary_closing
+                self.function = skimage.morphology.closing
             else:
                 self.function = skimage.morphology.closing
 
@@ -66,7 +68,9 @@ def planewise_morphology_closing(x_data, structuring_element):
 
     for index, plane in enumerate(x_data):
         if x_data.dtype == numpy.bool:
-            y_data[index] = skimage.morphology.binary_closing(plane, structuring_element)
+            # issue #2837
+            # y_data[index] = skimage.morphology.binary_closing(plane, structuring_element)
+            y_data[index] = skimage.morphology.closing(plane, structuring_element)
         else:
             y_data[index] = skimage.morphology.closing(plane, structuring_element)
 

--- a/cellprofiler/modules/closing.py
+++ b/cellprofiler/modules/closing.py
@@ -71,12 +71,6 @@ def planewise_morphology_closing(x_data, structuring_element):
 
     for index, plane in enumerate(x_data):
 
-        if x_data.dtype == numpy.bool:
-
-            y_data[index] = skimage.morphology.closing(plane, structuring_element)
-
-        else:
-
-            y_data[index] = skimage.morphology.closing(plane, structuring_element)
+        y_data[index] = skimage.morphology.closing(plane, structuring_element)
 
     return y_data

--- a/cellprofiler/modules/closing.py
+++ b/cellprofiler/modules/closing.py
@@ -60,13 +60,7 @@ class Closing(cellprofiler.module.ImageProcessing):
 
         else:
 
-            if x.pixel_data.dtype == numpy.bool:
-
-                self.function = skimage.morphology.closing
-
-            else:
-
-                self.function = skimage.morphology.closing
+            self.function = skimage.morphology.closing
 
         super(Closing, self).run(workspace)
 

--- a/cellprofiler/modules/closing.py
+++ b/cellprofiler/modules/closing.py
@@ -45,33 +45,44 @@ class Closing(cellprofiler.module.ImageProcessing):
     def run(self, workspace):
 
         x = workspace.image_set.get_image(self.x_name.value)
+
         is_strel_2d = self.structuring_element.value.ndim == 2
+
         is_img_2d = x.pixel_data.ndim == 2
 
         if is_strel_2d and not is_img_2d:
+
             self.function = planewise_morphology_closing
+
         elif not is_strel_2d and is_img_2d:
+
             raise NotImplementedError("A 3D structuring element cannot be applied to a 2D image.")
+
         else:
+
             if x.pixel_data.dtype == numpy.bool:
-                # issue #2837
-                # self.function = skimage.morphology.binary_closing
+
                 self.function = skimage.morphology.closing
+
             else:
+
                 self.function = skimage.morphology.closing
 
         super(Closing, self).run(workspace)
 
 
 def planewise_morphology_closing(x_data, structuring_element):
+
     y_data = numpy.zeros_like(x_data)
 
     for index, plane in enumerate(x_data):
+
         if x_data.dtype == numpy.bool:
-            # issue #2837
-            # y_data[index] = skimage.morphology.binary_closing(plane, structuring_element)
+
             y_data[index] = skimage.morphology.closing(plane, structuring_element)
+
         else:
+
             y_data[index] = skimage.morphology.closing(plane, structuring_element)
 
     return y_data

--- a/cellprofiler/modules/dilation.py
+++ b/cellprofiler/modules/dilation.py
@@ -49,7 +49,9 @@ class Dilation(cellprofiler.module.ImageProcessing):
             raise NotImplementedError("A 3D structuring element cannot be applied to a 2D image.")
         else:
             if x.pixel_data.dtype == numpy.bool:
-                self.function = skimage.morphology.binary_dilation
+                # issue #2837
+                # self.function = skimage.morphology.binary_dilation
+                self.function = skimage.morphology.dilation
             else:
                 self.function = skimage.morphology.dilation
 
@@ -61,7 +63,9 @@ def planewise_morphology_dilation(x_data, structuring_element):
 
     for index, plane in enumerate(x_data):
         if x_data.dtype == numpy.bool:
-            y_data[index] = skimage.morphology.binary_dilation(plane, structuring_element)
+            # issue #2837
+            # y_data[index] = skimage.morphology.binary_dilation(plane, structuring_element)
+            y_data[index] = skimage.morphology.dilation(plane, structuring_element)
         else:
             y_data[index] = skimage.morphology.dilation(plane, structuring_element)
 

--- a/cellprofiler/modules/dilation.py
+++ b/cellprofiler/modules/dilation.py
@@ -56,13 +56,7 @@ class Dilation(cellprofiler.module.ImageProcessing):
 
         else:
 
-            if x.pixel_data.dtype == numpy.bool:
-
-                self.function = skimage.morphology.dilation
-
-            else:
-
-                self.function = skimage.morphology.dilation
+            self.function = skimage.morphology.dilation
 
         super(Dilation, self).run(workspace)
 

--- a/cellprofiler/modules/dilation.py
+++ b/cellprofiler/modules/dilation.py
@@ -67,12 +67,6 @@ def planewise_morphology_dilation(x_data, structuring_element):
 
     for index, plane in enumerate(x_data):
 
-        if x_data.dtype == numpy.bool:
-
-            y_data[index] = skimage.morphology.dilation(plane, structuring_element)
-
-        else:
-
-            y_data[index] = skimage.morphology.dilation(plane, structuring_element)
+        y_data[index] = skimage.morphology.dilation(plane, structuring_element)
 
     return y_data

--- a/cellprofiler/modules/dilation.py
+++ b/cellprofiler/modules/dilation.py
@@ -39,34 +39,46 @@ class Dilation(cellprofiler.module.ImageProcessing):
         ]
 
     def run(self, workspace):
+
         x = workspace.image_set.get_image(self.x_name.value)
+
         is_strel_2d = self.structuring_element.value.ndim == 2
+
         is_img_2d = x.pixel_data.ndim == 2
 
         if is_strel_2d and not is_img_2d:
+
             self.function = planewise_morphology_dilation
+
         elif not is_strel_2d and is_img_2d:
+
             raise NotImplementedError("A 3D structuring element cannot be applied to a 2D image.")
+
         else:
+
             if x.pixel_data.dtype == numpy.bool:
-                # issue #2837
-                # self.function = skimage.morphology.binary_dilation
+
                 self.function = skimage.morphology.dilation
+
             else:
+
                 self.function = skimage.morphology.dilation
 
         super(Dilation, self).run(workspace)
 
 
 def planewise_morphology_dilation(x_data, structuring_element):
+
     y_data = numpy.zeros_like(x_data)
 
     for index, plane in enumerate(x_data):
+
         if x_data.dtype == numpy.bool:
-            # issue #2837
-            # y_data[index] = skimage.morphology.binary_dilation(plane, structuring_element)
+
             y_data[index] = skimage.morphology.dilation(plane, structuring_element)
+
         else:
+
             y_data[index] = skimage.morphology.dilation(plane, structuring_element)
 
     return y_data

--- a/cellprofiler/modules/erosion.py
+++ b/cellprofiler/modules/erosion.py
@@ -39,34 +39,46 @@ class Erosion(cellprofiler.module.ImageProcessing):
         ]
 
     def run(self, workspace):
+
         x = workspace.image_set.get_image(self.x_name.value)
+
         is_strel_2d = self.structuring_element.value.ndim == 2
+
         is_img_2d = x.pixel_data.ndim == 2
 
         if is_strel_2d and not is_img_2d:
+
             self.function = planewise_morphology_erosion
+
         elif not is_strel_2d and is_img_2d:
+
             raise NotImplementedError("A 3D structuring element cannot be applied to a 2D image.")
+
         else:
+
             if x.pixel_data.dtype == numpy.bool:
-                # issue #2837
-                # self.function = skimage.morphology.binary_erosion
+
                 self.function = skimage.morphology.erosion
+
             else:
+
                 self.function = skimage.morphology.erosion
 
         super(Erosion, self).run(workspace)
 
 
 def planewise_morphology_erosion(x_data, structuring_element):
+
     y_data = numpy.zeros_like(x_data)
 
     for index, plane in enumerate(x_data):
+
         if x_data.dtype == numpy.bool:
-            # issue #2837
-            # y_data[index] = skimage.morphology.binary_erosion(plane, structuring_element)
+
             y_data[index] = skimage.morphology.erosion(plane, structuring_element)
+
         else:
+            
             y_data[index] = skimage.morphology.erosion(plane, structuring_element)
 
     return y_data

--- a/cellprofiler/modules/erosion.py
+++ b/cellprofiler/modules/erosion.py
@@ -56,13 +56,7 @@ class Erosion(cellprofiler.module.ImageProcessing):
 
         else:
 
-            if x.pixel_data.dtype == numpy.bool:
-
-                self.function = skimage.morphology.erosion
-
-            else:
-
-                self.function = skimage.morphology.erosion
+            self.function = skimage.morphology.erosion
 
         super(Erosion, self).run(workspace)
 

--- a/cellprofiler/modules/erosion.py
+++ b/cellprofiler/modules/erosion.py
@@ -49,7 +49,9 @@ class Erosion(cellprofiler.module.ImageProcessing):
             raise NotImplementedError("A 3D structuring element cannot be applied to a 2D image.")
         else:
             if x.pixel_data.dtype == numpy.bool:
-                self.function = skimage.morphology.binary_erosion
+                # issue #2837
+                # self.function = skimage.morphology.binary_erosion
+                self.function = skimage.morphology.erosion
             else:
                 self.function = skimage.morphology.erosion
 
@@ -61,7 +63,9 @@ def planewise_morphology_erosion(x_data, structuring_element):
 
     for index, plane in enumerate(x_data):
         if x_data.dtype == numpy.bool:
-            y_data[index] = skimage.morphology.binary_erosion(plane, structuring_element)
+            # issue #2837
+            # y_data[index] = skimage.morphology.binary_erosion(plane, structuring_element)
+            y_data[index] = skimage.morphology.erosion(plane, structuring_element)
         else:
             y_data[index] = skimage.morphology.erosion(plane, structuring_element)
 

--- a/cellprofiler/modules/erosion.py
+++ b/cellprofiler/modules/erosion.py
@@ -67,12 +67,6 @@ def planewise_morphology_erosion(x_data, structuring_element):
 
     for index, plane in enumerate(x_data):
 
-        if x_data.dtype == numpy.bool:
-
-            y_data[index] = skimage.morphology.erosion(plane, structuring_element)
-
-        else:
-            
-            y_data[index] = skimage.morphology.erosion(plane, structuring_element)
+        y_data[index] = skimage.morphology.erosion(plane, structuring_element)
 
     return y_data

--- a/cellprofiler/modules/filterobjects.py
+++ b/cellprofiler/modules/filterobjects.py
@@ -838,7 +838,7 @@ class FilterObjects(cellprofiler.module.ObjectProcessing):
         '''
         labels = src_objects.segmented
 
-        interior_pixels = skimage.morphology.erosion(numpy.ones_like(labels))
+        interior_pixels = skimage.morphology.binary_erosion(numpy.ones_like(labels))
 
         border_pixels = numpy.logical_not(interior_pixels)
 
@@ -854,7 +854,7 @@ class FilterObjects(cellprofiler.module.ObjectProcessing):
             # is the border + formerly masked-out pixels.
             mask = src_objects.parent_image.mask
 
-            interior_pixels = skimage.morphology.erosion(mask)
+            interior_pixels = skimage.morphology.binary_erosion(mask)
 
             border_pixels = numpy.logical_not(interior_pixels)
 

--- a/cellprofiler/modules/filterobjects.py
+++ b/cellprofiler/modules/filterobjects.py
@@ -838,8 +838,6 @@ class FilterObjects(cellprofiler.module.ObjectProcessing):
         '''
         labels = src_objects.segmented
 
-        # issue #2837
-        # interior_pixels = skimage.morphology.binary_erosion(numpy.ones_like(labels))
         interior_pixels = skimage.morphology.erosion(numpy.ones_like(labels))
 
         border_pixels = numpy.logical_not(interior_pixels)
@@ -856,8 +854,6 @@ class FilterObjects(cellprofiler.module.ObjectProcessing):
             # is the border + formerly masked-out pixels.
             mask = src_objects.parent_image.mask
 
-            # issue #2837
-            # interior_pixels = skimage.morphology.binary_erosion(mask)
             interior_pixels = skimage.morphology.erosion(mask)
 
             border_pixels = numpy.logical_not(interior_pixels)

--- a/cellprofiler/modules/filterobjects.py
+++ b/cellprofiler/modules/filterobjects.py
@@ -838,7 +838,9 @@ class FilterObjects(cellprofiler.module.ObjectProcessing):
         '''
         labels = src_objects.segmented
 
-        interior_pixels = skimage.morphology.binary_erosion(numpy.ones_like(labels))
+        # issue #2837
+        # interior_pixels = skimage.morphology.binary_erosion(numpy.ones_like(labels))
+        interior_pixels = skimage.morphology.erosion(numpy.ones_like(labels))
 
         border_pixels = numpy.logical_not(interior_pixels)
 
@@ -854,7 +856,9 @@ class FilterObjects(cellprofiler.module.ObjectProcessing):
             # is the border + formerly masked-out pixels.
             mask = src_objects.parent_image.mask
 
-            interior_pixels = skimage.morphology.binary_erosion(mask)
+            # issue #2837
+            # interior_pixels = skimage.morphology.binary_erosion(mask)
+            interior_pixels = skimage.morphology.erosion(mask)
 
             border_pixels = numpy.logical_not(interior_pixels)
 

--- a/cellprofiler/modules/opening.py
+++ b/cellprofiler/modules/opening.py
@@ -68,12 +68,6 @@ def planewise_morphology_opening(x_data, structuring_element):
 
     for index, plane in enumerate(x_data):
 
-        if x_data.dtype == numpy.bool:
-
-            y_data[index] = skimage.morphology.opening(plane, structuring_element)
-
-        else:
-
-            y_data[index] = skimage.morphology.opening(plane, structuring_element)
+        y_data[index] = skimage.morphology.opening(plane, structuring_element)
 
     return y_data

--- a/cellprofiler/modules/opening.py
+++ b/cellprofiler/modules/opening.py
@@ -50,7 +50,9 @@ class Opening(cellprofiler.module.ImageProcessing):
             raise NotImplementedError("A 3D structuring element cannot be applied to a 2D image.")
         else:
             if x.pixel_data.dtype == numpy.bool:
-                self.function = skimage.morphology.binary_opening
+                # issue #2837
+                # self.function = skimage.morphology.binary_opening
+                self.function = skimage.morphology.opening
             else:
                 self.function = skimage.morphology.opening
 
@@ -62,7 +64,9 @@ def planewise_morphology_opening(x_data, structuring_element):
 
     for index, plane in enumerate(x_data):
         if x_data.dtype == numpy.bool:
-            y_data[index] = skimage.morphology.binary_opening(plane, structuring_element)
+            # issue #2837
+            # y_data[index] = skimage.morphology.binary_opening(plane, structuring_element)
+            y_data[index] = skimage.morphology.opening(plane, structuring_element)
         else:
             y_data[index] = skimage.morphology.opening(plane, structuring_element)
 

--- a/cellprofiler/modules/opening.py
+++ b/cellprofiler/modules/opening.py
@@ -57,13 +57,7 @@ class Opening(cellprofiler.module.ImageProcessing):
 
         else:
 
-            if x.pixel_data.dtype == numpy.bool:
-
-                self.function = skimage.morphology.opening
-
-            else:
-
-                self.function = skimage.morphology.opening
+            self.function = skimage.morphology.opening
 
         super(Opening, self).run(workspace)
 

--- a/cellprofiler/modules/opening.py
+++ b/cellprofiler/modules/opening.py
@@ -40,34 +40,46 @@ class Opening(cellprofiler.module.ImageProcessing):
         ]
 
     def run(self, workspace):
+
         x = workspace.image_set.get_image(self.x_name.value)
+
         is_strel_2d = self.structuring_element.value.ndim == 2
+
         is_img_2d = x.pixel_data.ndim == 2
 
         if is_strel_2d and not is_img_2d:
+
             self.function = planewise_morphology_opening
+
         elif not is_strel_2d and is_img_2d:
+
             raise NotImplementedError("A 3D structuring element cannot be applied to a 2D image.")
+
         else:
+
             if x.pixel_data.dtype == numpy.bool:
-                # issue #2837
-                # self.function = skimage.morphology.binary_opening
+
                 self.function = skimage.morphology.opening
+
             else:
+
                 self.function = skimage.morphology.opening
 
         super(Opening, self).run(workspace)
 
 
 def planewise_morphology_opening(x_data, structuring_element):
+
     y_data = numpy.zeros_like(x_data)
 
     for index, plane in enumerate(x_data):
+
         if x_data.dtype == numpy.bool:
-            # issue #2837
-            # y_data[index] = skimage.morphology.binary_opening(plane, structuring_element)
+
             y_data[index] = skimage.morphology.opening(plane, structuring_element)
+
         else:
+
             y_data[index] = skimage.morphology.opening(plane, structuring_element)
 
     return y_data


### PR DESCRIPTION
The *binary* versions or dilation, erosion, opening, and closing within skimage.morphology introduced a border of *False* values around the perimeter of an image. This is in contrast to the *non-binary* versions of dilation, erosion, opening, and closing that do not introduce this artifact. Since the non-binary versions of these morphological operations still work on boolean images the binary versions were replaced.

This is related to https://github.com/CellProfiler/CellProfiler/issues/2837