### PR TITLE
Warn when selecting an incompatible structuring element.

### DIFF
--- a/cellprofiler/gui/moduleview.py
+++ b/cellprofiler/gui/moduleview.py
@@ -2106,9 +2106,12 @@ class ModuleView(object):
     def __on_radiobox_change(self, event, setting, control):
         if not self.__handle_change:
             return
+
         setting.on_event_fired(control.GetStringSelection() == "Yes")
-        self.on_value_change(
-            setting, control, control.GetStringSelection(), event)
+
+        self.on_value_change(setting, control, control.GetStringSelection(), event)
+
+        self.__module.on_setting_changed(setting, self.__pipeline)
 
     def __on_combobox_change(self, event, setting, control):
         if not self.__handle_change:
@@ -4455,7 +4458,7 @@ class ValidationRequest(object):
         module - module in question
         callback - call this callback if there is an error. Do it on the GUI thread
         """
-        self.pipeline = cache_pipeline(pipeline)
+        self.pipeline = pipeline
         self.module_num = module.module_num
         self.test_mode = pipeline.test_mode
         self.callback = callback
@@ -4464,18 +4467,21 @@ class ValidationRequest(object):
     def cancel(self):
         self.cancelled = True
 
-
-def cache_pipeline(pipeline):
-    """Return a single cached copy of a pipeline to limit the # of copies"""
-    d = getattr(request_pipeline_cache, "d", None)
-    if d is None:
-        d = weakref.WeakValueDictionary()
-        setattr(request_pipeline_cache, "d", d)
-    settings_hash = pipeline.settings_hash()
-    result = d.get(settings_hash)
-    if result is None:
-        result = d[settings_hash] = pipeline.copy(False)
-    return result
+#
+# Cacheing is not compatible with the current pattern of sharing state between GUI components. E.g., the pipeline object
+# stored in the ModuleView constructor will never be updated, yet it is used to validate current state.
+#
+# def cache_pipeline(pipeline):
+#     """Return a single cached copy of a pipeline to limit the # of copies"""
+#     d = getattr(request_pipeline_cache, "d", None)
+#     if d is None:
+#         d = weakref.WeakValueDictionary()
+#         setattr(request_pipeline_cache, "d", d)
+#     settings_hash = pipeline.settings_hash()
+#     result = d.get(settings_hash)
+#     if result is None:
+#         result = d[settings_hash] = pipeline.copy(False)
+#     return result
 
 
 def validate_module(pipeline, module_num, test_mode, callback):

--- a/cellprofiler/modules/closing.py
+++ b/cellprofiler/modules/closing.py
@@ -26,7 +26,7 @@ class Closing(cellprofiler.module.ImageProcessing):
     def create_settings(self):
         super(Closing, self).create_settings()
 
-        self.structuring_element = cellprofiler.setting.StructuringElement()
+        self.structuring_element = cellprofiler.setting.StructuringElement(allow_planewise=True)
 
     def settings(self):
         __settings__ = super(Closing, self).settings()

--- a/cellprofiler/modules/dilation.py
+++ b/cellprofiler/modules/dilation.py
@@ -22,7 +22,7 @@ class Dilation(cellprofiler.module.ImageProcessing):
     def create_settings(self):
         super(Dilation, self).create_settings()
 
-        self.structuring_element = cellprofiler.setting.StructuringElement()
+        self.structuring_element = cellprofiler.setting.StructuringElement(allow_planewise=True)
 
     def settings(self):
         __settings__ = super(Dilation, self).settings()

--- a/cellprofiler/modules/erosion.py
+++ b/cellprofiler/modules/erosion.py
@@ -22,7 +22,7 @@ class Erosion(cellprofiler.module.ImageProcessing):
     def create_settings(self):
         super(Erosion, self).create_settings()
 
-        self.structuring_element = cellprofiler.setting.StructuringElement()
+        self.structuring_element = cellprofiler.setting.StructuringElement(allow_planewise=True)
 
     def settings(self):
         __settings__ = super(Erosion, self).settings()

--- a/cellprofiler/modules/opening.py
+++ b/cellprofiler/modules/opening.py
@@ -23,7 +23,7 @@ class Opening(cellprofiler.module.ImageProcessing):
     def create_settings(self):
         super(Opening, self).create_settings()
 
-        self.structuring_element = cellprofiler.setting.StructuringElement()
+        self.structuring_element = cellprofiler.setting.StructuringElement(allow_planewise=True)
 
     def settings(self):
         __settings__ = super(Opening, self).settings()

--- a/cellprofiler/setting.py
+++ b/cellprofiler/setting.py
@@ -1595,7 +1595,7 @@ class Binary(Setting):
         """
         str_value = (value and YES) or NO
         super(Binary, self).__init__(text, str_value, *args, **kwargs)
-        self.__callback = callback
+        self.callback = callback
 
     def set_value(self, value):
         """When setting, translate true and false into yes and no"""
@@ -1621,8 +1621,8 @@ class Binary(Setting):
         return self.value
 
     def on_event_fired(self, selection):
-        if self.__callback is not None:
-            self.__callback(selection)
+        if self.callback is not None:
+            self.callback(selection)
 
 
 class Choice(Setting):
@@ -1678,7 +1678,9 @@ class Choice(Setting):
 
 
 class StructuringElement(Setting):
-    def __init__(self, text="Structuring element", value="disk,1", doc=None):
+    def __init__(self, text="Structuring element", value="disk,1", doc=None, allow_planewise=False):
+        self.__allow_planewise = allow_planewise
+
         super(StructuringElement, self).__init__(text, value, doc=doc)
 
     @staticmethod
@@ -1726,6 +1728,21 @@ class StructuringElement(Setting):
                 "Structuring element size must be a positive integer. You provided {}.".format(self.size),
                 self
             )
+
+        if pipeline.volumetric():
+            if self.shape in ["diamond", "disk", "square", "star"] and not self.__allow_planewise:
+                raise ValidationError(
+                    "A 3 dimensional struturing element is required. You selected {}."
+                    " Please select one of \"ball\", \"cube\", or \"octahedron\".".format(self.shape),
+                    self
+                )
+        else:
+            if self.shape in ["ball", "cube", "octahedron"]:
+                raise ValidationError(
+                    "A 2 dimensional structuring element is required. You selected {}."
+                    " Please select one of \"diamond\", \"disk\", \"square\", \"star\".".format(self.shape),
+                    self
+                )
 
 
 class CustomChoice(Choice):


### PR DESCRIPTION
Resolves #2351 

Generate a validation warning when a structuring element of an incompatible dimensionality is selected. E.g., when a 3D structuring element is configured for a 2D pipeline:
![screen shot 2017-08-21 at 4 00 39 pm](https://user-images.githubusercontent.com/4721755/29536075-60925c98-868a-11e7-8052-f4fd27261877.png)

...or a 2D structuring element is selected for a 3D pipeline and the module does not support planewise operations.
![screen shot 2017-08-21 at 4 00 12 pm](https://user-images.githubusercontent.com/4721755/29536074-609261ac-868a-11e7-9a4a-348f2e1a6fa3.png)

