### PR TITLE
Render module help in GUI

### DIFF
--- a/cellprofiler/module.py
+++ b/cellprofiler/module.py
@@ -214,6 +214,9 @@ class Module(object):
         return parts["body_pre_docinfo"] + parts["fragment"]
 
     def _get_setting_help(self, setting):
+        if isinstance(setting, cellprofiler.setting.HiddenCount):
+            return u""
+
         return u"""
         <div>
             <h4>{SETTING_NAME}</h4>

--- a/cellprofiler/module.py
+++ b/cellprofiler/module.py
@@ -1,17 +1,15 @@
-import os
-import re
 import sys
 import uuid
 
+import docutils.core
 import numpy
-import scipy.ndimage
+import skimage.color
 
 import cellprofiler.image
 import cellprofiler.measurement
 import cellprofiler.object
 import cellprofiler.setting as cps
 import pipeline as cpp
-import skimage.color
 
 
 class Module(object):
@@ -208,36 +206,47 @@ class Module(object):
            settings have been loaded or initialized"""
         pass
 
+    # https://wiki.python.org/moin/reStructuredText
+    @staticmethod
+    def _rst_to_html_fragment(source):
+        parts = docutils.core.publish_parts(source=source, writer_name="html")
+
+        return parts["body_pre_docinfo"] + parts["fragment"]
+
+    def _get_setting_help(self, setting):
+        return u"""
+        <div>
+            <h4>{SETTING_NAME}</h4>
+            <p>{SETTING_DOC}</p>
+        </div>
+        """.format(**{
+            "SETTING_DOC": self._rst_to_html_fragment(setting.doc),
+            "SETTING_NAME": setting.text
+        })
+
     def get_help(self):
         """Return help text for the module
 
         The default help is taken from your modules docstring and from
         the settings.
         """
-        if self.__doc__ is None:
-            doc = "<i>No help available for module</i>\n"
-        else:
-            doc = self.__doc__.decode("utf-8")
-        doc = doc.replace("\r", "").replace("\n\n", "<p>")
-        doc = doc.replace("\n", " ")
-        result = "<html style=""font-family:arial""><head><title>%s</title></head>" % self.module_name
-        result += "<body><h1>%s</h1><div>" % self.module_name + doc
-        first_setting_doc = True
-        seen_setting_docs = set()
-        for setting in self.help_settings():
-            if setting.doc is not None:
-                key = (setting.text, setting.doc)
-                if key not in seen_setting_docs:
-                    seen_setting_docs.add(key)
-                    if first_setting_doc:
-                        result = result + "</div><div><h2>Settings:</h2>"
-                        first_setting_doc = False
-                    setting_text = setting.text.decode("utf-8")
-                    setting_doc = setting.doc.decode("utf-8")
-                    result += "<h4>" + setting_text + "</h4><div>" + setting_doc + "</div>"
-        result += "</div>"
-        result += "</body></html>"
-        return result
+        return u"""
+        <html style="font-family:arial">
+            <body>
+                <div>
+                    {MODULE_DOC}
+                </div>
+                <div>
+                    <h2>Settings:</h2>
+                    {SETTINGS_DOC}
+                </div>
+            </body>
+        </html>
+        """.format(**{
+            "MODULE_DOC": self._rst_to_html_fragment(self.__doc__),
+            "SETTINGS_DOC": u"\n".join([self._get_setting_help(setting) for setting in self.help_settings()]),
+            "TITLE": self.module_name
+        })
 
     def save_to_handles(self, handles):
         module_idx = self.module_num - 1

--- a/cellprofiler/modules/images.py
+++ b/cellprofiler/modules/images.py
@@ -212,6 +212,12 @@ class Images(cpm.Module):
             that do not pass the current filter.
             """)
 
+    def help_settings(self):
+        return [
+            self.filter,
+            self.update_button
+        ]
+
     @staticmethod
     def modpath_to_url(modpath):
         if modpath[0] in ("http", "https", "ftp"):

--- a/cellprofiler/modules/measureobjectsizeshape.py
+++ b/cellprofiler/modules/measureobjectsizeshape.py
@@ -103,7 +103,7 @@ Following computer vision conventions, the origin of the X and Y axes is at the 
 left of the image rather than the bottom left; the orientation of objects whose topmost point
 is on their right (or are rotated counter-clockwise from the horizontal) will therefore
 have a negative orientation, while objects whose topmost point is on their left
- (or are rotated clockwise from the horizontal) will have a positive orientation.
+(or are rotated clockwise from the horizontal) will have a positive orientation.
 
 The Zernike features are computed within the minimum enclosing circle of
 the object, i.e., the circle of the smallest diameter that contains all

--- a/cellprofiler/modules/overlayoutlines.py
+++ b/cellprofiler/modules/overlayoutlines.py
@@ -63,12 +63,11 @@ class OverlayOutlines(cellprofiler.module.Module):
         self.blank_image = cellprofiler.setting.Binary(
             "Display outlines on a blank image?",
             False,
-            doc="""
-            Select *{YES}* to produce an image of the outlines on a black
-            background.
-            Select *{NO}*, the module will overlay the outlines on an image of your
-            choosing.
-            """.format(**{
+            doc="""\
+Select *{YES}* to produce an image of the outlines on a black background.
+
+Select *{NO}*, the module will overlay the outlines on an image of your choosing.
+""".format(**{
                 "YES": cellprofiler.setting.YES,
                 "NO": cellprofiler.setting.NO
             })
@@ -77,50 +76,51 @@ class OverlayOutlines(cellprofiler.module.Module):
         self.image_name = cellprofiler.setting.ImageNameSubscriber(
             "Select image on which to display outlines",
             cellprofiler.setting.NONE,
-            doc="""
-            *(Used only when a blank image has not been selected)*
-            Choose the image to serve as the background for the outlines. You can
-            choose from images that were loaded or created by modules previous to
-            this one.
-            """
+            doc="""\
+*(Used only when a blank image has not been selected)*
+
+Choose the image to serve as the background for the outlines. You can
+choose from images that were loaded or created by modules previous to
+this one.
+"""
         )
 
         self.line_mode = cellprofiler.setting.Choice(
             "How to outline",
             ["Inner", "Outer", "Thick"],
             value="Inner",
-            doc="""
-            Specify how to mark the boundaries around an object:
-            
-            -  *Inner:* outline the pixels just inside of objects, leaving
-               background pixels untouched.
-            -  *Outer:* outline pixels in the background around object boundaries.
-               When two objects touch, their boundary is also marked.
-            -  *Thick:* any pixel not completely surrounded by pixels of the same
-               label is marked as a boundary. This results in boundaries that are 2
-               pixels thick.
-            """
+            doc="""\
+Specify how to mark the boundaries around an object:
+
+-  *Inner:* outline the pixels just inside of objects, leaving
+   background pixels untouched.
+-  *Outer:* outline pixels in the background around object boundaries.
+   When two objects touch, their boundary is also marked.
+-  *Thick:* any pixel not completely surrounded by pixels of the same
+   label is marked as a boundary. This results in boundaries that are 2
+   pixels thick.
+"""
         )
 
         self.output_image_name = cellprofiler.setting.ImageNameProvider(
             "Name the output image",
             "OrigOverlay",
             doc="""
-            Enter the name of the output image with the outlines overlaid. This
-            image can be selected in later modules (for instance, **SaveImages**).
-            """
+Enter the name of the output image with the outlines overlaid. This
+image can be selected in later modules (for instance, **SaveImages**).
+"""
         )
 
         self.wants_color = cellprofiler.setting.Choice(
             "Outline display mode",
             [WANTS_COLOR, WANTS_GRAYSCALE],
             doc="""
-            Specify how to display the outline contours around your objects. Color
-            outlines produce a clearer display for images where the cell borders
-            have a high intensity, but take up more space in memory. Grayscale
-            outlines are displayed with either the highest possible intensity or the
-            same intensity as the brightest pixel in the image.
-            """
+Specify how to display the outline contours around your objects. Color
+outlines produce a clearer display for images where the cell borders
+have a high intensity, but take up more space in memory. Grayscale
+outlines are displayed with either the highest possible intensity or the
+same intensity as the brightest pixel in the image.
+"""
         )
 
         self.spacer = cellprofiler.setting.Divider(line=False)
@@ -129,19 +129,20 @@ class OverlayOutlines(cellprofiler.module.Module):
             "Select method to determine brightness of outlines",
             [MAX_IMAGE, MAX_POSSIBLE],
             doc="""
-            | *(Used only when outline display mode is grayscale)*
-            | The following options are possible for setting the intensity
-              (brightness) of the outlines:
-            
-            -  *{MAX_IMAGE}:* Set the brighness to the the same as the brightest
-               point in the image.
-            -  *{MAX_POSSIBLE}:* Set to the maximum possible value for this image
-               format.
-            
-            If your image is quite dim, then putting bright white lines onto it may
-            not be useful. It may be preferable to make the outlines equal to the
-            maximal brightness already occurring in the image.
-            """.format(**{
+*(Used only when outline display mode is grayscale)*
+
+The following options are possible for setting the intensity
+(brightness) of the outlines:
+
+-  *{MAX_IMAGE}:* Set the brighness to the the same as the brightest
+   point in the image.
+-  *{MAX_POSSIBLE}:* Set to the maximum possible value for this image
+   format.
+
+If your image is quite dim, then putting bright white lines onto it may
+not be useful. It may be preferable to make the outlines equal to the
+maximal brightness already occurring in the image.
+""".format(**{
                 "MAX_IMAGE": MAX_IMAGE,
                 "MAX_POSSIBLE": MAX_POSSIBLE
             })

--- a/cellprofiler/setting.py
+++ b/cellprofiler/setting.py
@@ -71,7 +71,7 @@ class Setting(object):
     #
     save_to_pipeline = True
 
-    def __init__(self, text, value, doc=None, reset_view=False):
+    def __init__(self, text, value, doc="", reset_view=False):
         """Initialize a setting with the enclosing module and its string value
 
         text   - the explanatory text for the setting
@@ -1678,10 +1678,14 @@ class Choice(Setting):
 
 
 class StructuringElement(Setting):
-    def __init__(self, text="Structuring element", value="disk,1", doc=None, allow_planewise=False):
+    def __init__(self, text="Structuring element",
+                 value="disk,1",
+                 allow_planewise=False,
+                 *args,
+                 **kwargs):
         self.__allow_planewise = allow_planewise
 
-        super(StructuringElement, self).__init__(text, value, doc=doc)
+        super(StructuringElement, self).__init__(text, value, *args, **kwargs)
 
     @staticmethod
     def get_choices():

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setuptools.setup(
     },
     install_requires=[
         "centrosome",
+        "docutils",
         "h5py",
         "inflect",
         "javabridge",


### PR DESCRIPTION
Resolves #2860 (modules only)

![screen shot 2017-08-28 at 1 44 34 pm](https://user-images.githubusercontent.com/4721755/29785861-18076686-8bf7-11e7-913b-88399cc9d175.png)

Included is an example of how to format the module settings. Note that the documentation strings are not indented.

I will add support for the remaining help GUI elements in #2840 