### PR TITLE
Don't save object outlines in object processing modules

### DIFF
--- a/cellprofiler/modules/expandorshrinkobjects.py
+++ b/cellprofiler/modules/expandorshrinkobjects.py
@@ -40,7 +40,6 @@ See also **Identify** modules.
 """
 
 import centrosome.cpmorphology
-import centrosome.outline
 import numpy
 import scipy.ndimage
 
@@ -50,7 +49,6 @@ import cellprofiler.module
 import cellprofiler.modules.identify
 import cellprofiler.object
 import cellprofiler.setting
-import _help
 
 
 O_SHRINK_INF = "Shrink objects to a point"
@@ -66,7 +64,7 @@ O_ALL = [O_SHRINK_INF, O_EXPAND_INF, O_DIVIDE, O_SHRINK, O_EXPAND, O_SKELETONIZE
 class ExpandOrShrinkObjects(cellprofiler.module.Module):
     module_name = "ExpandOrShrinkObjects"
     category = "Object Processing"
-    variable_revision_number = 1
+    variable_revision_number = 2
 
     def create_settings(self):
         self.object_name = cellprofiler.setting.ObjectNameSubscriber(
@@ -144,27 +142,13 @@ order to keep from breaking up the object or breaking the hole.
             })
         )
 
-        self.wants_outlines = cellprofiler.setting.Binary(
-            "Retain the outlines of the identified objects?",
-            False,
-            doc=_help.RETAINING_OUTLINES_HELP
-        )
-
-        self.outlines_name = cellprofiler.setting.OutlineNameProvider(
-            "Name the outline image",
-            "ShrunkenNucleiOutlines",
-            doc=_help.NAMING_OUTLINES_HELP
-        )
-
     def settings(self):
         return [
             self.object_name,
             self.output_object_name,
             self.operation,
             self.iterations,
-            self.wants_fill_holes,
-            self.wants_outlines,
-            self.outlines_name
+            self.wants_fill_holes
         ]
 
     def visible_settings(self):
@@ -179,11 +163,6 @@ order to keep from breaking up the object or breaking the hole.
 
         if self.operation in [O_SHRINK, O_SHRINK_INF]:
             result += [self.wants_fill_holes]
-
-        result += [self.wants_outlines]
-
-        if self.wants_outlines.value:
-            result += [self.outlines_name]
 
         return result
 
@@ -214,14 +193,6 @@ order to keep from breaking up the object or breaking the hole.
             self.output_object_name.value,
             output_objects.segmented
         )
-
-        if self.wants_outlines.value:
-            outline_image = cellprofiler.image.Image(
-                centrosome.outline.outline(output_objects.segmented) > 0,
-                parent_image=input_objects.parent_image
-            )
-
-            workspace.image_set.add(self.outlines_name.value, outline_image)
 
         if self.show_window:
             workspace.display_data.input_objects_segmented = input_objects.segmented
@@ -328,6 +299,11 @@ order to keep from breaking up the object or breaking the hole.
             from_matlab = False
 
             variable_revision_number = 1
+
+        if variable_revision_number == 1:
+            setting_values = setting_values[:-2]
+
+            variable_revision_number = 2
 
         return setting_values, variable_revision_number, from_matlab
 

--- a/cellprofiler/modules/filterobjects.py
+++ b/cellprofiler/modules/filterobjects.py
@@ -42,8 +42,6 @@ See also any of the **MeasureObject** modules, **MeasureTexture**,
 import logging
 import os
 
-import centrosome.cpmorphology
-import centrosome.outline
 import numpy
 import scipy
 import scipy.ndimage

--- a/cellprofiler/modules/identifysecondaryobjects.py
+++ b/cellprofiler/modules/identifysecondaryobjects.py
@@ -148,7 +148,6 @@ See also the other **Identify** modules.
 """
 
 import centrosome.cpmorphology
-import centrosome.outline
 import centrosome.propagate
 import numpy
 import scipy.ndimage
@@ -161,7 +160,6 @@ import cellprofiler.measurement
 import cellprofiler.module
 import cellprofiler.object
 import cellprofiler.setting
-import _help
 
 
 M_PROPAGATION = "Propagation"
@@ -171,7 +169,7 @@ M_DISTANCE_N = "Distance - N"
 M_DISTANCE_B = "Distance - B"
 
 '''# of setting values other than thresholding ones'''
-N_SETTING_VALUES = 14
+N_SETTING_VALUES = 10
 
 '''Parent (seed) relationship of input objects to output objects'''
 R_PARENT = "Parent"
@@ -180,7 +178,7 @@ R_PARENT = "Parent"
 class IdentifySecondaryObjects(cellprofiler.module.ObjectProcessing):
     module_name = "IdentifySecondaryObjects"
 
-    variable_revision_number = 9
+    variable_revision_number = 10
 
     category = "Object Processing"
 
@@ -336,18 +334,6 @@ balance between these two considerations:
             })
         )
 
-        self.use_outlines = cellprofiler.setting.Binary(
-            "Retain outlines of the identified secondary objects?",
-            False,
-            doc=_help.RETAINING_OUTLINES_HELP
-        )
-
-        self.outlines_name = cellprofiler.setting.OutlineNameProvider(
-            "Name the outline image",
-            "SecondaryOutlines",
-            doc=_help.NAMING_OUTLINES_HELP
-        )
-
         self.wants_discard_edge = cellprofiler.setting.Binary(
             "Discard secondary objects touching the border of the image?",
             False,
@@ -407,28 +393,6 @@ touches the edge will be retained in memory as an “unedited object”;
 this allows them to be considered in downstream modules that modify the
 segmentation.""")
 
-        self.wants_primary_outlines = cellprofiler.setting.Binary(
-            "Retain outlines of the new primary objects?",
-            False,
-            doc=u"""\
-*(Used only if associated primary objects are discarded)*
-
-{RETAINING_OUTLINES_HELP:s}""".format(**{
-                "RETAINING_OUTLINES_HELP": _help.RETAINING_OUTLINES_HELP
-            })
-        )
-
-        self.new_primary_outlines_name = cellprofiler.setting.OutlineNameProvider(
-            "Name the new primary object outlines",
-            "FilteredNucleiOutlines",
-            doc="""\
-*(Used only if associated primary objects are discarded and saving
-outlines of new primary objects)*
-
-Enter a name for the outlines of the identified objects. The outlined
-image can be selected in downstream modules by selecting them from any
-drop-down image list.""")
-
         self.threshold_setting_version = cellprofiler.setting.Integer(
             "Threshold setting version",
             value=self.apply_threshold.variable_revision_number
@@ -446,13 +410,9 @@ drop-down image list.""")
             self.image_name,
             self.distance_to_dilate,
             self.regularization_factor,
-            self.outlines_name,
-            self.use_outlines,
             self.wants_discard_edge,
             self.wants_discard_primary,
             self.new_primary_objects_name,
-            self.wants_primary_outlines,
-            self.new_primary_outlines_name,
             self.fill_holes
         ] + [self.threshold_setting_version] + self.apply_threshold.settings()[2:]
 
@@ -480,18 +440,7 @@ drop-down image list.""")
             visible_settings += [self.wants_discard_primary]
 
             if self.wants_discard_primary:
-                visible_settings += [
-                    self.new_primary_objects_name,
-                    self.wants_primary_outlines
-                ]
-
-                if self.wants_primary_outlines:
-                    visible_settings += [self.new_primary_outlines_name]
-
-        visible_settings+= [self.use_outlines]
-
-        if self.use_outlines.value:
-            visible_settings += [self.outlines_name]
+                visible_settings += [self.new_primary_objects_name]
 
         return visible_settings
 
@@ -511,11 +460,7 @@ drop-down image list.""")
             self.fill_holes,
             self.wants_discard_edge,
             self.wants_discard_primary,
-            self.new_primary_objects_name,
-            self.wants_primary_outlines,
-            self.new_primary_outlines_name,
-            self.use_outlines,
-            self.outlines_name
+            self.new_primary_objects_name
         ]
 
         return help_settings
@@ -526,6 +471,11 @@ drop-down image list.""")
 
         if variable_revision_number < 9:
             raise NotImplementedError("Automatic upgrade for this module is not supported in CellProfiler 3.0.")
+
+        if variable_revision_number == 9:
+            setting_values = setting_values[:6] + setting_values[8:11] + setting_values[13:]
+
+            variable_revision_number = 10
 
         threshold_setting_values = setting_values[N_SETTING_VALUES:]
 
@@ -703,15 +653,6 @@ drop-down image list.""")
             if objects.has_small_removed_segmented:
                 new_objects.small_removed_segmented = objects.small_removed_segmented
             new_objects.parent_image = objects.parent_image
-            primary_outline = centrosome.outline.outline(segmented_labels)
-            if self.wants_primary_outlines:
-                out_img = cellprofiler.image.Image(primary_outline.astype(bool),
-                                                   parent_image=image)
-                workspace.image_set.add(self.new_primary_outlines_name.value,
-                                        out_img)
-        else:
-            primary_outline = centrosome.outline.outline(objects.segmented)
-        secondary_outline = centrosome.outline.outline(segmented_out)
 
         #
         # Add the objects to the object set
@@ -723,10 +664,6 @@ drop-down image list.""")
         objects_out.parent_image = image
         objname = self.y_name.value
         workspace.object_set.add_objects(objects_out, objname)
-        if self.use_outlines.value:
-            out_img = cellprofiler.image.Image(secondary_outline.astype(bool),
-                                               parent_image=image)
-            workspace.image_set.add(self.outlines_name.value, out_img)
         object_count = numpy.max(segmented_out)
         #
         # Add measurements

--- a/cellprofiler/modules/identifytertiaryobjects.py
+++ b/cellprofiler/modules/identifytertiaryobjects.py
@@ -96,7 +96,7 @@ R_REMOVED = "Removed"
 
 class IdentifyTertiaryObjects(cpm.Module):
     module_name = "IdentifyTertiaryObjects"
-    variable_revision_number = 2
+    variable_revision_number = 3
     category = "Object Processing"
 
     def create_settings(self):
@@ -133,41 +133,21 @@ objects with no area. Measurements can still be made on such objects,
 but the results will be zero or not-a-number (NaN).
 """ % globals())
 
-        self.use_outlines = cps.Binary("Retain outlines of the tertiary objects?", False, doc=RETAINING_OUTLINES_HELP
-% globals())
-
-        self.outlines_name = cps.OutlineNameProvider(
-                "Name the outline image", "CytoplasmOutlines", doc=NAMING_OUTLINES_HELP
-% globals())
-
     def settings(self):
-        """All of the settings to be loaded and saved in the pipeline file
-
-        Returns a list of the settings in the order that they should be
-        saved or loaded in the pipeline file.
-        """
-        return [self.secondary_objects_name, self.primary_objects_name,
-                self.subregion_objects_name, self.outlines_name,
-                self.use_outlines, self.shrink_primary]
+        return [
+            self.secondary_objects_name,
+            self.primary_objects_name,
+            self.subregion_objects_name,
+            self.shrink_primary
+        ]
 
     def visible_settings(self):
-        """The settings that should be visible on-screen
-
-        Returns the list of settings in the order that they should be
-        displayed in the module setting editor. These can be tailored
-        to only display relevant settings (see use_outlines/outlines_name
-        below)
-        """
-        result = [self.secondary_objects_name, self.primary_objects_name,
-                  self.subregion_objects_name, self.shrink_primary,
-                  self.use_outlines]
-        #
-        # display the name of the outlines image only if the user
-        # has asked to use outlines
-        #
-        if self.use_outlines.value:
-            result.append(self.outlines_name)
-        return result
+        return [
+            self.secondary_objects_name,
+            self.primary_objects_name,
+            self.subregion_objects_name,
+            self.shrink_primary
+        ]
 
     def run(self, workspace):
         """Run the module on the current data set
@@ -322,13 +302,6 @@ but the results will be zero or not-a-number (NaN).
         cpmi.add_object_location_measurements(workspace.measurements,
                                               self.subregion_objects_name.value,
                                               tertiary_labels)
-        #
-        # The outlines
-        #
-        if self.use_outlines.value:
-            out_img = cpi.Image(tertiary_outlines.astype(bool),
-                                parent_image=tertiary_image)
-            workspace.image_set.add(self.outlines_name.value, out_img)
 
         if self.show_window:
             workspace.display_data.primary_labels = primary_labels
@@ -422,6 +395,11 @@ but the results will be zero or not-a-number (NaN).
         if (not from_matlab) and variable_revision_number == 1:
             setting_values = setting_values + [cps.YES]
             variable_revision_number = 2
+
+        if variable_revision_number == 2:
+            setting_values = setting_values[:3] + setting_values[5:]
+
+            variable_revision_number = 3
 
         return setting_values, variable_revision_number, from_matlab
 

--- a/cellprofiler/modules/maskobjects.py
+++ b/cellprofiler/modules/maskobjects.py
@@ -88,7 +88,7 @@ def s_lookup(x):
 class MaskObjects(I.Identify):
     category = "Object Processing"
     module_name = "MaskObjects"
-    variable_revision_number = 2
+    variable_revision_number = 3
 
     def create_settings(self):
         '''Create the settings that control this module'''
@@ -233,33 +233,26 @@ controls how remaining objects are associated with their predecessors:
 """ % globals()
         )
 
-        self.wants_outlines = cps.Binary(
-            "Retain outlines of the resulting objects?",
-            False,
-            doc=RETAINING_OUTLINES_HELP
-        )
-
-        self.outlines_name = cps.OutlineNameProvider(
-            "Name the outline image",
-            "MaskedOutlines",
-            doc=NAMING_OUTLINES_HELP
-        )
-
     def settings(self):
         '''The settings as they appear in the pipeline'''
-        return [self.object_name, self.remaining_objects, self.mask_choice,
-                self.masking_objects, self.masking_image, self.overlap_choice,
-                self.overlap_fraction, self.retain_or_renumber,
-                self.wants_outlines, self.outlines_name,
-                self.wants_inverted_mask]
+        return [
+            self.object_name,
+            self.remaining_objects,
+            self.mask_choice,
+            self.masking_objects,
+            self.masking_image,
+            self.overlap_choice,
+            self.overlap_fraction,
+            self.retain_or_renumber,
+            self.wants_inverted_mask
+        ]
 
     def help_settings(self):
         '''The settings as they appear in the pipeline'''
         return [self.object_name, self.remaining_objects, self.mask_choice,
                 self.masking_objects, self.masking_image,
                 self.wants_inverted_mask,
-                self.overlap_choice, self.overlap_fraction, self.retain_or_renumber,
-                self.wants_outlines, self.outlines_name]
+                self.overlap_choice, self.overlap_fraction, self.retain_or_renumber]
 
     def visible_settings(self):
         '''The settings as they appear in the UI'''
@@ -271,9 +264,8 @@ controls how remaining objects are associated with their predecessors:
         if self.overlap_choice == P_REMOVE_PERCENTAGE:
             result += [self.overlap_fraction]
 
-        result += [self.retain_or_renumber, self.wants_outlines]
-        if self.wants_outlines.value:
-            result += [self.outlines_name]
+        result += [self.retain_or_renumber]
+
         return result
 
     def run(self, workspace):
@@ -370,13 +362,6 @@ controls how remaining objects are associated with their predecessors:
         I.add_object_count_measurements(m, remaining_object_name,
                                         remaining_object_count)
         I.add_object_location_measurements(m, remaining_object_name, labels)
-        #
-        # Add an outline if asked to do so
-        #
-        if self.wants_outlines.value:
-            outline_image = cpi.Image(outline(labels) > 0,
-                                      parent_image=original_objects.parent_image)
-            workspace.image_set.add(self.outlines_name.value, outline_image)
         #
         # Save the input, mask and output images for display
         #
@@ -497,6 +482,11 @@ controls how remaining objects are associated with their predecessors:
             # Added "wants_inverted_mask"
             setting_values = setting_values + [cps.NO]
             variable_revision_number = 2
+
+        if variable_revision_number == 2:
+            setting_values = setting_values[:-3] + setting_values[-1:]
+
+            variable_revision_number = 3
 
         setting_values = list(setting_values)
         setting_values[5] = s_lookup(setting_values[5])

--- a/tests/modules/test_editobjectsmanually.py
+++ b/tests/modules/test_editobjectsmanually.py
@@ -49,8 +49,6 @@ EditObjectsManually:[module_num:1|svn_version:\'1\'|variable_revision_number:1|s
         self.assertTrue(isinstance(module, E.EditObjectsManually))
         self.assertEqual(module.object_name, "Nuclei")
         self.assertEqual(module.filtered_objects, "EditedNuclei")
-        self.assertTrue(module.wants_outlines)
-        self.assertEqual(module.outlines_name, "EditedNucleiOutlines")
         self.assertEqual(module.renumber_choice, E.R_RENUMBER)
         self.assertFalse(module.wants_image_display)
 
@@ -80,7 +78,6 @@ EditObjectsManually:[module_num:1|svn_version:\'10039\'|variable_revision_number
         self.assertTrue(isinstance(module, E.EditObjectsManually))
         self.assertEqual(module.object_name, "Nuclei")
         self.assertEqual(module.filtered_objects, "EditedNuclei")
-        self.assertFalse(module.wants_outlines)
         self.assertEqual(module.renumber_choice, E.R_RETAIN)
         self.assertTrue(module.wants_image_display)
         self.assertEqual(module.image_name, "DNA")
@@ -113,11 +110,42 @@ EditObjectsManually:[module_num:1|svn_version:\'10039\'|variable_revision_number
         self.assertTrue(isinstance(module, E.EditObjectsManually))
         self.assertEqual(module.object_name, "Nuclei")
         self.assertEqual(module.filtered_objects, "EditedNuclei")
-        self.assertFalse(module.wants_outlines)
         self.assertEqual(module.renumber_choice, E.R_RETAIN)
         self.assertTrue(module.wants_image_display)
         self.assertEqual(module.image_name, "DNA")
         self.assertTrue(module.allow_overlap)
+
+    def test_01_04_load_v4(self):
+        data = r"""CellProfiler Pipeline: http://www.cellprofiler.org
+Version:3
+DateRevision:20150319195827
+GitHash:d8289bf
+ModuleCount:1
+HasImagePlaneDetails:False
+
+EditObjectsManually:[module_num:1|svn_version:\'Unknown\'|variable_revision_number:4|show_window:True|notes:\x5B\x5D|batch_state:array(\x5B\x5D, dtype=uint8)|enabled:True|wants_pause:False]
+    Select the objects to be edited:IdentifyPrimaryObjects
+    Name the edited objects:EditedObjects
+    Numbering of the edited objects:Renumber
+    Display a guiding image?:Yes
+    Select the guiding image:DNA
+    Allow overlapping objects?:No
+    """
+        pipeline = cpp.Pipeline()
+
+        def callback(caller, event):
+            self.assertFalse(isinstance(event, cpp.LoadExceptionEvent))
+
+        pipeline.add_listener(callback)
+        pipeline.loadtxt(StringIO(data))
+        module = pipeline.modules()[0]
+
+        assert module.object_name.value == "IdentifyPrimaryObjects"
+        assert module.filtered_objects.value == "EditedObjects"
+        assert module.renumber_choice.value == "Renumber"
+        assert module.wants_image_display.value
+        assert module.image_name.value == "DNA"
+        assert not module.allow_overlap.value
 
     def test_02_02_measurements(self):
         module = E.EditObjectsManually()

--- a/tests/modules/test_expandorshrinkobjects.py
+++ b/tests/modules/test_expandorshrinkobjects.py
@@ -34,10 +34,8 @@ class TestExpandOrShrinkObjects(unittest.TestCase):
         module = cellprofiler.modules.expandorshrinkobjects.ExpandOrShrink()
         module.object_name.value = INPUT_NAME
         module.output_object_name.value = OUTPUT_NAME
-        module.outlines_name.value = OUTLINES_NAME
         module.operation.value = operation
         module.iterations.value = iterations
-        module.wants_outlines.value = wants_outlines
         module.wants_fill_holes.value = wants_fill_holes
         module.module_num = 1
         pipeline = cellprofiler.pipeline.Pipeline()
@@ -176,19 +174,3 @@ class TestExpandOrShrinkObjects(unittest.TestCase):
         module.run(workspace)
         objects = workspace.object_set.get_objects(OUTPUT_NAME)
         self.assertTrue(numpy.all(objects.segmented == expected))
-
-    def test_07_01_outlines(self):
-        '''Create an outline of the resulting objects'''
-        labels = numpy.zeros((10, 10), int)
-        labels[4, 4] = 1
-        i, j = numpy.mgrid[0:10, 0:10] - 4
-        expected = (i ** 2 + j ** 2 <= 4).astype(int)
-        expected_outlines = centrosome.outline.outline(expected)
-        workspace, module = self.make_workspace(labels, cellprofiler.modules.expandorshrinkobjects.O_EXPAND, 2,
-                                                wants_outlines=True)
-        module.run(workspace)
-        objects = workspace.object_set.get_objects(OUTPUT_NAME)
-        self.assertTrue(numpy.all(objects.segmented == expected))
-        self.assertTrue(OUTLINES_NAME in workspace.image_set.names)
-        outlines = workspace.image_set.get_image(OUTLINES_NAME).pixel_data
-        self.assertTrue(numpy.all(outlines == expected_outlines))

--- a/tests/modules/test_identifysecondaryobjects.py
+++ b/tests/modules/test_identifysecondaryobjects.py
@@ -117,13 +117,9 @@ IdentifySecondaryObjects:[module_num:5|svn_version:\'Unknown\'|variable_revision
         self.assertEqual(module.method, cellprofiler.modules.identifysecondaryobjects.M_PROPAGATION)
         self.assertEqual(module.distance_to_dilate, 11)
         self.assertEqual(module.regularization_factor, .125)
-        self.assertEqual(module.outlines_name, "CookieEdges")
-        self.assertFalse(module.use_outlines)
         self.assertTrue(module.wants_discard_edge)
         self.assertFalse(module.wants_discard_primary)
         self.assertEqual(module.new_primary_objects_name, "FilteredChocolateChips")
-        self.assertFalse(module.wants_primary_outlines)
-        self.assertEqual(module.new_primary_outlines_name, "FilteredChocolateChipOutlines")
         self.assertTrue(module.fill_holes)
         self.assertEqual(module.apply_threshold.threshold_scope, cellprofiler.modules.identify.TS_GLOBAL)
         self.assertEqual(module.apply_threshold.global_operation.value, cellprofiler.modules.threshold.TM_LI)
@@ -136,6 +132,63 @@ IdentifySecondaryObjects:[module_num:5|svn_version:\'Unknown\'|variable_revision
         self.assertEqual(module.apply_threshold.two_class_otsu, cellprofiler.modules.identify.O_TWO_CLASS)
         self.assertEqual(module.apply_threshold.assign_middle_to_foreground, cellprofiler.modules.identify.O_FOREGROUND)
         self.assertEqual(module.apply_threshold.adaptive_window_size, 9)
+
+    def test_01_10_load_v10(self):
+        data = r"""CellProfiler Pipeline: http://www.cellprofiler.org
+Version:3
+DateRevision:20150319195827
+GitHash:d8289bf
+ModuleCount:1
+HasImagePlaneDetails:False
+
+IdentifySecondaryObjects:[module_num:1|svn_version:\'Unknown\'|variable_revision_number:10|show_window:True|notes:\x5B\x5D|batch_state:array(\x5B\x5D, dtype=uint8)|enabled:True|wants_pause:False]
+    Select the input objects:IdentifyPrimaryObjects
+    Name the objects to be identified:IdentifySecondaryObjects
+    Select the method to identify the secondary objects:Propagation
+    Select the input image:DNA
+    Number of pixels by which to expand the primary objects:10
+    Regularization factor:0.05
+    Discard secondary objects touching the border of the image?:No
+    Discard the associated primary objects?:No
+    Name the new primary objects:FilteredNuclei
+    Fill holes in identified objects?:Yes
+    Threshold setting version:10
+    Threshold strategy:Global
+    Thresholding method:Minimum cross entropy
+    Threshold smoothing scale:0.0
+    Threshold correction factor:1.0
+    Lower and upper bounds on threshold:0.0,1.0
+    Manual threshold:0.0
+    Select the measurement to threshold with:None
+    Two-class or three-class thresholding?:Two classes
+    Assign pixels in the middle intensity class to the foreground or the background?:Foreground
+    Size of adaptive window:50
+    Lower outlier fraction:0.05
+    Upper outlier fraction:0.05
+    Averaging method:Mean
+    Variance method:Standard deviation
+    # of deviations:2.0
+    Thresholding method:Otsu
+"""
+        pipeline = cellprofiler.pipeline.Pipeline()
+
+        def callback(caller, event):
+            self.assertFalse(isinstance(event, cellprofiler.pipeline.LoadExceptionEvent))
+
+        pipeline.add_listener(callback)
+        pipeline.load(StringIO.StringIO(data))
+        module = pipeline.modules()[0]
+
+        assert module.x_name.value == "IdentifyPrimaryObjects"
+        assert module.y_name.value == "IdentifySecondaryObjects"
+        assert module.method.value == "Propagation"
+        assert module.image_name.value == "DNA"
+        assert module.distance_to_dilate.value == 10
+        assert module.regularization_factor.value == 0.05
+        assert not module.wants_discard_edge.value
+        assert not module.wants_discard_primary.value
+        assert module.new_primary_objects_name.value == "FilteredNuclei"
+        assert module.fill_holes.value
 
     def make_workspace(self, image, segmented, unedited_segmented=None,
                        small_removed_segmented=None):
@@ -162,8 +215,6 @@ IdentifySecondaryObjects:[module_num:5|svn_version:\'Unknown\'|variable_revision
         module.x_name.value = INPUT_OBJECTS_NAME
         module.y_name.value = OUTPUT_OBJECTS_NAME
         module.image_name.value = IMAGE_NAME
-        module.use_outlines.value = False
-        module.outlines_name.value = "my_outlines"
         module.module_num = 1
         p.add_module(module)
         workspace = cellprofiler.workspace.Workspace(p, module, i_s, o_s, m, i_l)
@@ -744,104 +795,6 @@ IdentifySecondaryObjects:[module_num:5|svn_version:\'Unknown\'|variable_revision
             for y in (2, 6):
                 expected[x, y] = 0
         self.assertTrue(numpy.all(objects_out.segmented == expected))
-
-    def test_06_01_save_outlines(self):
-        '''Test the "save_outlines" feature'''
-        p = cellprofiler.pipeline.Pipeline()
-        o_s = cellprofiler.object.ObjectSet()
-        i_l = cellprofiler.image.ImageSetList()
-        img = numpy.zeros((10, 10))
-        img[2:7, 2:7] = .5
-        image = cellprofiler.image.Image(img)
-        objects = cellprofiler.object.Objects()
-        labels = numpy.zeros((10, 10), int)
-        labels[3:6, 3:6] = 1
-        objects.unedited_segmented = labels
-        objects.small_removed_segmented = labels
-        objects.segmented = labels
-        o_s.add_objects(objects, INPUT_OBJECTS_NAME)
-        i_s = i_l.get_image_set(0)
-        i_s.add(IMAGE_NAME, image)
-        m = cellprofiler.measurement.Measurements()
-        module = cellprofiler.modules.identifysecondaryobjects.IdentifySecondaryObjects()
-        module.x_name.value = INPUT_OBJECTS_NAME
-        module.y_name.value = OUTPUT_OBJECTS_NAME
-        module.image_name.value = IMAGE_NAME
-        module.use_outlines.value = True
-        module.outlines_name.value = "my_outlines"
-        module.method.value = cellprofiler.modules.identifysecondaryobjects.M_WATERSHED_I
-        module.apply_threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
-        module.apply_threshold.global_operation.value = centrosome.threshold.TM_OTSU
-        module.module_num = 1
-        p.add_module(module)
-        workspace = cellprofiler.workspace.Workspace(p, module, i_s, o_s, m, i_l)
-        module.run(workspace)
-        self.assertTrue(OUTPUT_OBJECTS_NAME in m.get_object_names())
-        self.assertTrue("Image" in m.get_object_names())
-        self.assertTrue("Count_%s" % OUTPUT_OBJECTS_NAME in m.get_feature_names("Image"))
-        counts = m.get_current_measurement("Image", "Count_%s" % OUTPUT_OBJECTS_NAME)
-        self.assertEqual(numpy.product(counts.shape), 1)
-        self.assertEqual(counts, 1)
-        objects_out = o_s.get_objects(OUTPUT_OBJECTS_NAME)
-        outlines_out = workspace.image_set.get_image("my_outlines",
-                                                     must_be_binary=True).pixel_data
-        expected = numpy.zeros((10, 10), int)
-        expected[2:7, 2:7] = 1
-        outlines = expected == 1
-        outlines[3:6, 3:6] = False
-        self.assertTrue(numpy.all(objects_out.segmented == expected))
-        self.assertTrue(numpy.all(outlines == outlines_out))
-
-    def test_06_02_save_primary_outlines(self):
-        '''Test saving new primary outlines'''
-        p = cellprofiler.pipeline.Pipeline()
-        o_s = cellprofiler.object.ObjectSet()
-        i_l = cellprofiler.image.ImageSetList()
-        img = numpy.zeros((10, 10))
-        img[2:7, 2:7] = .5
-        image = cellprofiler.image.Image(img)
-        objects = cellprofiler.object.Objects()
-        labels = numpy.zeros((10, 10), int)
-        labels[3:6, 3:6] = 1
-        objects.unedited_segmented = labels
-        objects.small_removed_segmented = labels
-        objects.segmented = labels
-        o_s.add_objects(objects, INPUT_OBJECTS_NAME)
-        i_s = i_l.get_image_set(0)
-        i_s.add(IMAGE_NAME, image)
-        m = cellprofiler.measurement.Measurements()
-        module = cellprofiler.modules.identifysecondaryobjects.IdentifySecondaryObjects()
-        module.x_name.value = INPUT_OBJECTS_NAME
-        module.y_name.value = OUTPUT_OBJECTS_NAME
-        module.image_name.value = IMAGE_NAME
-        module.use_outlines.value = True
-        module.outlines_name.value = "my_outlines"
-        module.wants_discard_edge.value = True
-        module.wants_discard_primary.value = True
-        module.wants_primary_outlines.value = True
-        module.new_primary_objects_name.value = NEW_OBJECTS_NAME
-        module.new_primary_outlines_name.value = "newprimaryoutlines"
-        module.method.value = cellprofiler.modules.identifysecondaryobjects.M_WATERSHED_I
-        module.apply_threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
-        module.apply_threshold.global_operation.value = centrosome.threshold.TM_OTSU
-        module.module_num = 1
-        p.add_module(module)
-        workspace = cellprofiler.workspace.Workspace(p, module, i_s, o_s, m, i_l)
-        module.run(workspace)
-        self.assertTrue(OUTPUT_OBJECTS_NAME in m.get_object_names())
-        self.assertTrue("Image" in m.get_object_names())
-        count_feature = "Count_%s" % OUTPUT_OBJECTS_NAME
-        self.assertTrue(count_feature in m.get_feature_names("Image"))
-        counts = m.get_current_measurement("Image", count_feature)
-        self.assertEqual(numpy.product(counts.shape), 1)
-        self.assertEqual(counts, 1)
-        objects_out = o_s.get_objects(OUTPUT_OBJECTS_NAME)
-        outlines_out = workspace.image_set.get_image("newprimaryoutlines",
-                                                     must_be_binary=True)
-        expected = numpy.zeros((10, 10), bool)
-        expected[3:6, 3:6] = True
-        expected[4, 4] = False
-        self.assertTrue(numpy.all(outlines_out.pixel_data == expected))
 
     def test_07_01_measurements_no_new_primary(self):
         module = cellprofiler.modules.identifysecondaryobjects.IdentifySecondaryObjects()

--- a/tests/modules/test_identifytertiaryobjects.py
+++ b/tests/modules/test_identifytertiaryobjects.py
@@ -198,14 +198,9 @@ class TestIdentifyTertiaryObjects(unittest.TestCase):
         workspace = self.make_workspace(primary_labels, secondary_labels)
         module = workspace.module
         self.assertTrue(isinstance(module, cpmit.IdentifyTertiarySubregion))
-        module.use_outlines.value = True
-        module.outlines_name.value = OUTLINES
         module.run(workspace)
         measurements = workspace.measurements
         output_labels = workspace.object_set.get_objects(TERTIARY).segmented
-        output_outlines = workspace.image_set.get_image(OUTLINES,
-                                                        must_be_binary=True)
-        self.assertTrue(np.all(output_labels[output_outlines.pixel_data] > 0))
         for parent_name, parent_labels in ((PRIMARY, expected_primary_parents),
                                            (SECONDARY, expected_secondary_parents)):
             parents_of_feature = ("Parent_%s" % parent_name)
@@ -237,14 +232,7 @@ class TestIdentifyTertiaryObjects(unittest.TestCase):
         workspace = self.make_workspace(primary_labels, secondary_labels)
         module = workspace.module
         self.assertTrue(isinstance(module, cpmit.IdentifyTertiarySubregion))
-        module.use_outlines.value = True
-        module.outlines_name.value = OUTLINES
         module.run(workspace)
-        measurements = workspace.measurements
-        output_labels = workspace.object_set.get_objects(TERTIARY).segmented
-        output_outlines = workspace.image_set.get_image(OUTLINES,
-                                                        must_be_binary=True)
-        self.assertTrue(np.all(output_labels[output_outlines.pixel_data] > 0))
 
     def test_03_01_get_measurement_columns(self):
         '''Test the get_measurement_columns method'''
@@ -431,3 +419,31 @@ class TestIdentifyTertiaryObjects(unittest.TestCase):
                 self.assertEqual(result[cpm.R_SECOND_IMAGE_NUMBER][i], 1)
                 self.assertEqual(result[cpm.R_FIRST_OBJECT_NUMBER][i], i + 1)
                 self.assertEqual(result[cpm.R_SECOND_OBJECT_NUMBER][i], i + 1)
+
+    def test_06_01_load_v3(self):
+        data = r"""CellProfiler Pipeline: http://www.cellprofiler.org
+Version:3
+DateRevision:20150319195827
+GitHash:d8289bf
+ModuleCount:1
+HasImagePlaneDetails:False
+
+IdentifyTertiaryObjects:[module_num:1|svn_version:\'Unknown\'|variable_revision_number:3|show_window:True|notes:\x5B\x5D|batch_state:array(\x5B\x5D, dtype=uint8)|enabled:True|wants_pause:False]
+    Select the larger identified objects:IdentifySecondaryObjects
+    Select the smaller identified objects:IdentifyPrimaryObjects
+    Name the tertiary objects to be identified:IdentifyTertiaryObjects
+    Shrink smaller object prior to subtraction?:Yes
+"""
+        pipeline = cpp.Pipeline()
+
+        def callback(caller, event):
+            self.assertFalse(isinstance(event, cpp.LoadExceptionEvent))
+
+        pipeline.add_listener(callback)
+        pipeline.loadtxt(StringIO(data))
+        module = pipeline.modules()[0]
+
+        assert module.secondary_objects_name.value == "IdentifySecondaryObjects"
+        assert module.primary_objects_name.value == "IdentifyPrimaryObjects"
+        assert module.subregion_objects_name.value == "IdentifyTertiaryObjects"
+        assert module.shrink_primary.value


### PR DESCRIPTION
Resolves #3035 

Users should use **OverlayOutlines** and **SaveImages** to create and save outline images.