### PR TITLE
@mcquin FTW. CP :goat:

### DIFF
--- a/cellprofiler/object.py
+++ b/cellprofiler/object.py
@@ -996,7 +996,7 @@ def _colors(labels):
         cmap=matplotlib.cm.get_cmap(cellprofiler.preferences.get_default_colormap())
     )
 
-    colors = mappable.to_rgba(numpy.unique(labels)[1:])[:, :3]
+    colors = mappable.to_rgba(unique_labels)[:, :3]
 
     numpy.random.shuffle(colors)
 


### PR DESCRIPTION
There was an error that was created with modules that displayed label images, like this...

```
File "cellprofiler\gui\pipelinecontroller.py", line 2890, in do_step
    module.display(workspace, fig)
  File "cellprofiler\module.py", line 1076, in display
    y=0
  File "cellprofiler\gui\figure.py", line 180, in wrapper
    return fn(*args, **kwargs)
  File "cellprofiler\gui\figure.py", line 1518, in subplot_imshow_labels
    pixel_data=background_image
  File "cellprofiler\object.py", line 973, in overlay_labels
    colors=colors[unique_labels - 1],
IndexError: index 153 is out of bounds for axis 0 with size 153
```
@mcquin fixed #3049 
