### PR TITLE
Focus on running module in test mode.

### DIFF
--- a/cellprofiler/gui/pipelinelistview.py
+++ b/cellprofiler/gui/pipelinelistview.py
@@ -1470,6 +1470,10 @@ class PipelineListCtrl(wx.PyScrolledWindow):
                     text_color = text_color_selected
                 else:
                     text_color = text_color
+            if self.test_mode and index == self.running_item:
+                flags = wx.CONTROL_CURRENT | wx.CONTROL_FOCUSED
+
+                cellprofiler.gui.draw_item_selection_rect(self, dc, rectangle, flags)
             else:
                 text_color = text_color
 


### PR DESCRIPTION
Resolves #3062 

@DuaaAli and I figured out how to improve Test Mode visualization. The "running module" is the module that will run the next time "Step" is pressed. That module receives a blue/gray rectangle around it. You can select another module and it's highlighted in blue/gray (like normal), and the running module still gets a blue/gray box around it.

In this picture, we're in test mode. The running module is "IdentifyPrimaryObjects", but the module we're looking at is "Crop".

<img width="1072" alt="screen shot 2017-09-07 at 2 07 29 pm" src="https://user-images.githubusercontent.com/4721755/30178181-0c7bbd44-93d6-11e7-949a-e33b6f334587.png">

We've verified this functionality on Windows.
