### PR TITLE
Don't retain object outlines.

### DIFF
--- a/cellprofiler/modules/_help.py
+++ b/cellprofiler/modules/_help.py
@@ -152,15 +152,6 @@ metadata tags for which all images in each individual image set have the same va
     "DEFAULT_OUTPUT_SUBFOLDER_NAME": DEFAULT_OUTPUT_SUBFOLDER_NAME
 })
 
-NAMING_OUTLINES_HELP = """\
-*(Used only if the outline image is to be retained for later use in the
-pipeline)*
-
-Enter a name for the outlines of the identified objects. The outlined
-image can be selected in downstream modules by selecting them from any
-drop-down image list.
-"""
-
 ####################
 #
 # ICONS
@@ -189,16 +180,6 @@ PROTIP_RECOMEND_ICON = __image_resource("thumb-up.png")
 PROTIP_AVOID_ICON = __image_resource("thumb-down.png")
 
 TECH_NOTE_ICON = __image_resource("gear.png")
-
-RETAINING_OUTLINES_HELP = """\
-Select *{YES}* to retain the outlines of the new objects for later use
-in the pipeline. For example, a common use is for quality control
-purposes by overlaying them on your image of choice using the
-**OverlayOutlines** module and then saving the overlay image with the
-**SaveImages** module.
-""".format(**{
-    "YES": cellprofiler.setting.YES
-})
 
 USING_METADATA_GROUPING_HELP_REF = """\
 Please see the **Groups** module for more details on the proper use of

--- a/cellprofiler/modules/identifyobjectsmanually.py
+++ b/cellprofiler/modules/identifyobjectsmanually.py
@@ -32,7 +32,6 @@ import cellprofiler.object as cpo
 import cellprofiler.preferences as cpprefs
 import cellprofiler.setting as cps
 import identify as I
-from cellprofiler.modules._help import NAMING_OUTLINES_HELP, RETAINING_OUTLINES_HELP
 
 TOOL_OUTLINE = "Outline"
 TOOL_ZOOM_IN = "Zoom in"

--- a/cellprofiler/modules/identifytertiaryobjects.py
+++ b/cellprofiler/modules/identifytertiaryobjects.py
@@ -87,7 +87,6 @@ import cellprofiler.object as cpo
 import cellprofiler.preferences as cpprefs
 import cellprofiler.setting as cps
 import identify as cpmi
-from cellprofiler.modules._help import NAMING_OUTLINES_HELP, RETAINING_OUTLINES_HELP
 from cellprofiler.setting import YES, NO
 
 '''The parent object relationship points to the secondary / larger objects'''

--- a/cellprofiler/modules/maskobjects.py
+++ b/cellprofiler/modules/maskobjects.py
@@ -48,7 +48,6 @@ import cellprofiler.object as cpo
 import cellprofiler.preferences as cpprefs
 import cellprofiler.setting as cps
 import identify as I
-from cellprofiler.modules._help import NAMING_OUTLINES_HELP, RETAINING_OUTLINES_HELP
 from cellprofiler.setting import YES, NO
 
 MC_OBJECTS = "Objects"

--- a/cellprofiler/modules/namesandtypes.py
+++ b/cellprofiler/modules/namesandtypes.py
@@ -222,7 +222,7 @@ You can specify how these images should be treated:
    pixel intensities will be averaged to produce a single intensity
    value.
 -  *{LOAD_AS_COLOR_IMAGE}:* An image in which each pixel repesents a
-   red, green and blue (RGB) triplet of intensity values OR which contains 
+   red, green and blue (RGB) triplet of intensity values OR which contains
    multiple individual grayscale channels. Please note
    that the object detection modules such as **IdentifyPrimaryObjects**
    expect a grayscale image, so if you want to identify objects, you
@@ -259,7 +259,7 @@ You can specify how these images should be treated:
    immediately without needing to insert an **Identify** module to
    extract them first. See **IdentifyPrimaryObjects** for more details.
    This option can load objects created by using the **ConvertObjectsToImage**
-   module followed by the **SaveImages** module. These objects can take two 
+   module followed by the **SaveImages** module. These objects can take two
    forms, with different considerations for each:
 
    -  *Non-overlapping* objects are stored as a label matrix. This
@@ -366,7 +366,7 @@ The choices are:
 -  *{ASSIGN_RULES}*: Give images one of several names depending on the
    file name, directory and metadata. This is the appropriate choice if
    more than one image was acquired from each imaging site (ie if multiple
-   channels were acquired at each site). You will be asked for distinctive 
+   channels were acquired at each site). You will be asked for distinctive
    criteria for each image and will be able to assign each category of image
    a name that can be referred to in downstream modules.
 """.format(**{
@@ -572,7 +572,7 @@ You can match corresponding channels to each other in one of two ways:
    | Site           | (None)          |
    +----------------+-----------------+
 
-   This sort of matching can also be useful in timelapse movies where you wish to 
+   This sort of matching can also be useful in timelapse movies where you wish to
    measure the properties of a particular ROI over time:
 
    +----------------+----------------+-----------------+
@@ -951,7 +951,7 @@ requests an object selection.
             ]
 
         return result
-    
+
     def help_settings(self):
         result = [
             self.assignment_method,
@@ -969,8 +969,7 @@ requests an object selection.
         assignment = self.assignments[0]
         result += [assignment.rule_filter, assignment.image_name,
                    assignment.object_name, assignment.load_as_choice,
-                   assignment.rescale, assignment.should_save_outlines,
-                   assignment.save_outlines, assignment.manual_rescale]
+                   assignment.rescale, assignment.manual_rescale]
         return result
 
     def visible_settings(self):

--- a/cellprofiler/modules/namesandtypes.py
+++ b/cellprofiler/modules/namesandtypes.py
@@ -18,7 +18,6 @@ import cellprofiler.image as cpi
 import cellprofiler.measurement as cpmeas
 import cellprofiler.pipeline as cpp
 import cellprofiler.setting as cps
-import centrosome.outline
 import cellprofiler.preferences as cpprefs
 from cellprofiler.modules.images import FilePredicate
 from cellprofiler.modules.images import ExtensionPredicate
@@ -26,8 +25,7 @@ from cellprofiler.modules.images import ImagePredicate
 from cellprofiler.modules.images import DirectoryPredicate
 from cellprofiler.modules.loadimages import LoadImagesImageProviderURL
 from cellprofiler.modules.loadimages import convert_image_to_objects
-from cellprofiler.modules._help import FILTER_RULES_BUTTONS_HELP, NAMING_OUTLINES_HELP, RETAINING_OUTLINES_HELP, \
-    USING_METADATA_HELP_REF,PROTIP_RECOMEND_ICON
+from cellprofiler.modules._help import FILTER_RULES_BUTTONS_HELP, USING_METADATA_HELP_REF,PROTIP_RECOMEND_ICON
 from bioformats import get_omexml_metadata, load_image
 import bioformats.omexml as OME
 import javabridge as J
@@ -283,27 +281,33 @@ IDX_ASSIGNMENTS_COUNT_V2 = 5
 IDX_ASSIGNMENTS_COUNT_V3 = 6
 IDX_ASSIGNMENTS_COUNT_V5 = 6
 IDX_ASSIGNMENTS_COUNT_V6 = 6
+IDX_ASSIGNMENTS_COUNT_V7 = 6
 IDX_ASSIGNMENTS_COUNT = 6
 
 IDX_SINGLE_IMAGES_COUNT_V5 = 7
 IDX_SINGLE_IMAGES_COUNT_V6 = 7
+IDX_SINGLE_IMAGES_COUNT_V7 = 7
 IDX_SINGLE_IMAGES_COUNT = 7
 
 IDX_FIRST_ASSIGNMENT_V3 = 7
 IDX_FIRST_ASSIGNMENT_V4 = 7
 IDX_FIRST_ASSIGNMENT_V5 = 8
 IDX_FIRST_ASSIGNMENT_V6 = 9
-IDX_FIRST_ASSIGNMENT = 9
+IDX_FIRST_ASSIGNMENT_V7 = 13
+IDX_FIRST_ASSIGNMENT = 13
 
 NUM_ASSIGNMENT_SETTINGS_V2 = 4
 NUM_ASSIGNMENT_SETTINGS_V3 = 5
 NUM_ASSIGNMENT_SETTINGS_V5 = 7
 NUM_ASSIGNMENT_SETTINGS_V6 = 8
-NUM_ASSIGNMENT_SETTINGS = 8
+NUM_ASSIGNMENT_SETTINGS_V7 = 8
+NUM_ASSIGNMENT_SETTINGS = 6
 
 NUM_SINGLE_IMAGE_SETTINGS_V5 = 7
 NUM_SINGLE_IMAGE_SETTINGS_V6 = 8
-NUM_SINGLE_IMAGE_SETTINGS = 8
+NUM_SINGLE_IMAGE_SETTINGS_V7 = 8
+NUM_SINGLE_IMAGE_SETTINGS = 6
+
 
 OFF_LOAD_AS_CHOICE_V5 = 3
 OFF_LOAD_AS_CHOICE = 3
@@ -326,7 +330,7 @@ M_IMAGE_SET = "ImageSet_ImageSet"
 
 
 class NamesAndTypes(cpm.Module):
-    variable_revision_number = 7
+    variable_revision_number = 8
     module_name = "NamesAndTypes"
     category = "File Processing"
 
@@ -725,24 +729,6 @@ requests an object selection.
             )
         )
 
-        group.append(
-            "should_save_outlines",
-            cps.Binary(
-                "Retain outlines of loaded objects?",
-                False,
-                doc=RETAINING_OUTLINES_HELP
-            )
-        )
-
-        group.append(
-            "save_outlines",
-            cps.OutlineNameProvider(
-                "Name the outline image",
-                "LoadedOutlines",
-                doc=NAMING_OUTLINES_HELP
-            )
-        )
-
         def copy_assignment(group=group):
             self.copy_assignment(group, self.assignments, self.add_assignment)
 
@@ -907,24 +893,6 @@ requests an object selection.
             )
         )
 
-        group.append(
-            "should_save_outlines",
-            cps.Binary(
-                "Retain object outlines?",
-                False,
-                doc=RETAINING_OUTLINES_HELP
-            )
-        )
-
-        group.append(
-            "save_outlines",
-            cps.OutlineNameProvider(
-                "Name the outline image",
-                "LoadedOutlines",
-                doc=NAMING_OUTLINES_HELP
-            )
-        )
-
         def copy_assignment(group=group):
             self.copy_assignment(
                     group, self.single_images, self.add_single_image)
@@ -963,16 +931,24 @@ requests an object selection.
         ]
 
         for assignment in self.assignments:
-            result += [assignment.rule_filter, assignment.image_name,
-                       assignment.object_name, assignment.load_as_choice,
-                       assignment.rescale, assignment.should_save_outlines,
-                       assignment.save_outlines, assignment.manual_rescale]
+            result += [
+                assignment.rule_filter,
+                assignment.image_name,
+                assignment.object_name,
+                assignment.load_as_choice,
+                assignment.rescale,
+                assignment.manual_rescale
+            ]
+
         for single_image in self.single_images:
             result += [
-                single_image.image_plane, single_image.image_name,
-                single_image.object_name, single_image.load_as_choice,
-                single_image.rescale, single_image.should_save_outlines,
-                single_image.save_outlines, single_image.manual_rescale]
+                single_image.image_plane,
+                single_image.image_name,
+                single_image.object_name,
+                single_image.load_as_choice,
+                single_image.rescale,
+                single_image.manual_rescale
+            ]
 
         return result
     
@@ -1032,10 +1008,6 @@ requests an object selection.
                     result += [assignment.rescale]
                     if assignment.rescale == INTENSITY_MANUAL:
                         result += [self.manual_rescale]
-                elif assignment.load_as_choice == LOAD_AS_OBJECTS:
-                    result += [assignment.should_save_outlines]
-                    if assignment.should_save_outlines.value:
-                        result += [assignment.save_outlines]
                 result += [assignment.copy_button]
                 if assignment.can_remove:
                     result += [assignment.remover]
@@ -1051,10 +1023,6 @@ requests an object selection.
                     result += [single_image.rescale]
                     if single_image.rescale == INTENSITY_MANUAL:
                         result += [single_image.manual_rescale]
-                elif single_image.load_as_choice == LOAD_AS_OBJECTS:
-                    result += [single_image.should_save_outlines]
-                    if single_image.should_save_outlines.value:
-                        result += [single_image.save_outlines]
                 result += [single_image.copy_button, single_image.remover]
             result += [self.add_assignment_divider, self.add_assignment_button]
             if len(self.assignments) > 1:
@@ -1758,8 +1726,6 @@ requests an object selection.
                 if group.load_as_choice == LOAD_AS_OBJECTS:
                     self.add_objects(workspace,
                                      group.object_name.value,
-                                     group.should_save_outlines.value,
-                                     group.save_outlines.value,
                                      stack)
                 else:
                     rescale = group.rescale.value
@@ -1893,14 +1859,11 @@ requests an object selection.
         '''Get an md5 checksum from the (cached) file courtesy of the provider'''
         return provider.get_md5_hash(measurements)
 
-    def add_objects(self, workspace, name, should_save_outlines,
-                    outlines_name, stack):
+    def add_objects(self, workspace, name, stack):
         '''Add objects loaded from a file to the object set
 
         workspace - the workspace for the analysis
         name - the objects' name in the pipeline
-        should_save_outlines - True if the user wants to save outlines as an image
-        outlines_name - the name of the outlines image in the pipeline
         stack - the ImagePlaneDetailsStack representing the planes to be loaded
         '''
         from cellprofiler.modules.identify import add_object_count_measurements
@@ -1969,13 +1932,6 @@ requests an object selection.
                                                  name, o.ijv, o.count)
         add_object_count_measurements(workspace.measurements, name, o.count)
         workspace.object_set.add_objects(o, name)
-        if should_save_outlines:
-            outline_image = np.zeros(image.pixel_data.shape[:2], bool)
-            for labeled_image, indices in o.get_labels():
-                plane = centrosome.outline.outline(labeled_image)
-                outline_image |= plane.astype(outline_image.dtype)
-            out_img = cpi.Image(outline_image)
-            workspace.image_set.add(outlines_name, out_img)
 
     def on_activated(self, workspace):
         self.pipeline = workspace.pipeline
@@ -2242,6 +2198,51 @@ requests an object selection.
             new_setting_values = setting_values[:9] + [False, 1.0, 1.0, 1.0] + setting_values[9:]
             setting_values = new_setting_values
             variable_revision_number = 7
+
+        if variable_revision_number == 7:
+            offset = IDX_FIRST_ASSIGNMENT_V7
+            n_settings = NUM_ASSIGNMENT_SETTINGS_V7
+            n_assignments = int(setting_values[IDX_ASSIGNMENTS_COUNT_V7])
+
+            assignment_rule_filter = setting_values[offset::n_settings][:n_assignments]
+            assignment_image_name = setting_values[offset + 1::n_settings][:n_assignments]
+            assignment_object_name = setting_values[offset + 2::n_settings][:n_assignments]
+            assignment_load_as_choice = setting_values[offset + 3::n_settings][:n_assignments]
+            assignment_rescale = setting_values[offset + 4::n_settings][:n_assignments]
+            assignment_manual_rescale = setting_values[offset + 7::n_settings][:n_assignments]
+
+            assignment_settings = sum([list(settings) for settings in zip(
+                assignment_rule_filter,
+                assignment_image_name,
+                assignment_object_name,
+                assignment_load_as_choice,
+                assignment_rescale,
+                assignment_manual_rescale
+            )], [])
+
+            offset = IDX_FIRST_ASSIGNMENT_V7 + (n_assignments * NUM_ASSIGNMENT_SETTINGS_V7)
+            n_settings = NUM_SINGLE_IMAGE_SETTINGS_V7
+            n_single_images = int(setting_values[IDX_SINGLE_IMAGES_COUNT_V7])
+
+            single_image_image_plane = setting_values[offset::n_settings][:n_single_images]
+            single_image_image_name = setting_values[offset + 1::n_settings][:n_single_images]
+            single_image_object_name = setting_values[offset + 2::n_settings][:n_single_images]
+            single_image_load_as_choice = setting_values[offset + 3::n_settings][:n_single_images]
+            single_image_rescale = setting_values[offset + 4::n_settings][:n_single_images]
+            single_image_manual_rescale = setting_values[offset + 7::n_settings][:n_single_images]
+
+            single_image_settings = sum([list(settings) for settings in zip(
+                single_image_image_plane,
+                single_image_image_name,
+                single_image_object_name,
+                single_image_load_as_choice,
+                single_image_rescale,
+                single_image_manual_rescale
+            )], [])
+
+            setting_values = setting_values[:IDX_FIRST_ASSIGNMENT_V7] + assignment_settings + single_image_settings
+
+            variable_revision_number = 8
 
         return setting_values, variable_revision_number, from_matlab
 

--- a/cellprofiler/modules/overlayoutlines.py
+++ b/cellprofiler/modules/overlayoutlines.py
@@ -7,11 +7,8 @@ OverlayOutlines
 **OverlayOutlines** places outlines of objects over a desired image.
 Outlines can be placed around 2D and 3D objects.
 
-This module places outlines of objects (often produced by an
-**Identify** module) on any desired image (grayscale, color, or blank).
-The resulting image can be saved using the **SaveImages** module. See
-also **IdentifyPrimaryObjects, IdentifySecondaryObjects,
-IdentifyTertiaryObjects**.
+This module places outlines of objects on any desired image (grayscale, color, or blank).
+The resulting image can be saved using the **SaveImages** module.
 """
 
 import numpy

--- a/cellprofiler/modules/splitormergeobjects.py
+++ b/cellprofiler/modules/splitormergeobjects.py
@@ -59,7 +59,6 @@ import cellprofiler.measurement as cpmeas
 import cellprofiler.object as cpo
 import cellprofiler.preferences as cpprefs
 import cellprofiler.setting as cps
-from cellprofiler.modules._help import NAMING_OUTLINES_HELP, RETAINING_OUTLINES_HELP
 from cellprofiler.measurement import C_PARENT, C_CHILDREN, FF_CHILDREN_COUNT, FF_PARENT
 from cellprofiler.modules.identify import add_object_count_measurements
 from cellprofiler.modules.identify import add_object_location_measurements

--- a/cellprofiler/modules/untangleworms.py
+++ b/cellprofiler/modules/untangleworms.py
@@ -112,8 +112,18 @@ from centrosome.outline import outline
 from cellprofiler.preferences import standardize_default_folder_names, \
     DEFAULT_INPUT_FOLDER_NAME, DEFAULT_OUTPUT_FOLDER_NAME, NO_FOLDER_NAME, \
     ABSOLUTE_FOLDER_NAME
-from cellprofiler.modules._help import NAMING_OUTLINES_HELP, RETAINING_OUTLINES_HELP, USING_METADATA_GROUPING_HELP_REF, \
+from cellprofiler.modules._help import USING_METADATA_GROUPING_HELP_REF, \
     IO_FOLDER_CHOICE_HELP_TEXT
+
+RETAINING_OUTLINES_HELP = """\
+Select *{YES}* to retain the outlines of the new objects for later use
+in the pipeline. For example, a common use is for quality control
+purposes by overlaying them on your image of choice using the
+**OverlayOutlines** module and then saving the overlay image with the
+**SaveImages** module.
+""".format(**{
+    "YES": cps.YES
+})
 
 OO_WITH_OVERLAP = "With overlap"
 OO_WITHOUT_OVERLAP = "Without overlap"

--- a/tests/modules/test_identifyobjectsingrid.py
+++ b/tests/modules/test_identifyobjectsingrid.py
@@ -21,12 +21,10 @@ import cellprofiler.measurement as cpmeas
 import cellprofiler.pipeline as cpp
 import cellprofiler.modules.identifyobjectsingrid as I
 import cellprofiler.modules.definegrid as D
-from centrosome.outline import outline
 
 OUTPUT_OBJECTS_NAME = 'outputobjects'
 GRID_NAME = 'mygrid'
 GUIDING_OBJECTS_NAME = 'inputobjects'
-OUTLINES_NAME = 'myoutlines'
 
 
 class TestIdentifyObjectsInGrid(unittest.TestCase):
@@ -36,7 +34,6 @@ class TestIdentifyObjectsInGrid(unittest.TestCase):
         module.grid_name.value = GRID_NAME
         module.output_objects_name.value = OUTPUT_OBJECTS_NAME
         module.guiding_object_name.value = GUIDING_OBJECTS_NAME
-        module.outlines_name.value = OUTLINES_NAME
         image_set_list = cpi.ImageSetList()
         object_set = cpo.ObjectSet()
         if labels is not None:
@@ -99,7 +96,6 @@ class TestIdentifyObjectsInGrid(unittest.TestCase):
         module.diameter_choice.value = I.AM_MANUAL
         module.diameter.value = diameter
         module.shape_choice.value = I.SHAPE_CIRCLE_FORCED
-        module.wants_outlines.value = True
         module.run(workspace)
         labels = workspace.object_set.get_objects(OUTPUT_OBJECTS_NAME).segmented
         self.assertTrue(np.all(labels == expected[0:labels.shape[0], 0:labels.shape[1]]))
@@ -124,13 +120,6 @@ class TestIdentifyObjectsInGrid(unittest.TestCase):
         self.assertTrue(
                 all([column[1] in ('Location_Center_X', 'Location_Center_Y', count_feature, 'Number_Object_Number')
                      for column in columns]))
-        #
-        # Check the outlines
-        #
-        outlines = workspace.image_set.get_image(OUTLINES_NAME)
-        outlines = outlines.pixel_data
-        expected_outlines = outline(expected)
-        self.assertTrue(np.all(outlines == (expected_outlines[0:outlines.shape[0], 0:outlines.shape[1]] > 0)))
         #
         # Check the measurements
         #

--- a/tests/modules/test_namesandtypes.py
+++ b/tests/modules/test_namesandtypes.py
@@ -312,7 +312,6 @@ NamesAndTypes:[module_num:3|svn_version:\'Unknown\'|variable_revision_number:3|s
                 self.assertEqual(assignment.image_name, image_name)
                 self.assertEqual(assignment.object_name, objects_name)
                 self.assertEqual(assignment.load_as_choice, load_as)
-                self.assertFalse(assignment.should_save_outlines)
 
     def test_00_04_load_v4(self):
             data = r"""CellProfiler Pipeline: http://www.cellprofiler.org
@@ -397,21 +396,18 @@ NamesAndTypes:[module_num:3|svn_version:\'Unknown\'|variable_revision_number:4|s
             self.assertEqual(module.matching_choice, N.MATCH_BY_ORDER)
             self.assertEqual(module.assignments_count.value, 5)
             aa = module.assignments
-            for assignment, rule, image_name, objects_name, load_as, \
-                rescale, should_save_outlines, outlines_name in (
-                (aa[0], 'or (metadata does ChannelNumber "0")', "DNA", "Nuclei", N.LOAD_AS_GRAYSCALE_IMAGE, N.INTENSITY_RESCALING_BY_METADATA, False, "LoadedOutlines"),
-                (aa[1], 'or (image does ismonochrome) (metadata does ChannelNumber "1") (extension does istif)', "Actin", "Cells", N.LOAD_AS_COLOR_IMAGE, N.INTENSITY_RESCALING_BY_DATATYPE, False, "LoadedOutlines"),
-                (aa[2], 'or (metadata does ChannelNumber "2")', "GFP", "Cells", N.LOAD_AS_MASK, N.INTENSITY_RESCALING_BY_METADATA, False, "LoadedOutlines"),
-                (aa[3], 'or (metadata does ChannelNumber "2")', "Foo", "Cells", N.LOAD_AS_OBJECTS, N.INTENSITY_RESCALING_BY_DATATYPE, True, "MyCellOutlines"),
-                (aa[4], 'or (metadata does ChannelNumber "2")', "Illum", "Cells", N.LOAD_AS_ILLUMINATION_FUNCTION, N.INTENSITY_RESCALING_BY_METADATA, False, "LoadedOutlines")):
+            for assignment, rule, image_name, objects_name, load_as, rescale in (
+                (aa[0], 'or (metadata does ChannelNumber "0")', "DNA", "Nuclei", N.LOAD_AS_GRAYSCALE_IMAGE, N.INTENSITY_RESCALING_BY_METADATA),
+                (aa[1], 'or (image does ismonochrome) (metadata does ChannelNumber "1") (extension does istif)', "Actin", "Cells", N.LOAD_AS_COLOR_IMAGE, N.INTENSITY_RESCALING_BY_DATATYPE),
+                (aa[2], 'or (metadata does ChannelNumber "2")', "GFP", "Cells", N.LOAD_AS_MASK, N.INTENSITY_RESCALING_BY_METADATA),
+                (aa[3], 'or (metadata does ChannelNumber "2")', "Foo", "Cells", N.LOAD_AS_OBJECTS, N.INTENSITY_RESCALING_BY_DATATYPE),
+                (aa[4], 'or (metadata does ChannelNumber "2")', "Illum", "Cells", N.LOAD_AS_ILLUMINATION_FUNCTION, N.INTENSITY_RESCALING_BY_METADATA)):
                 self.assertEqual(assignment.rule_filter.value, rule)
-                self.assertEqual(assignment.image_name, image_name)
-                self.assertEqual(assignment.object_name, objects_name)
-                self.assertEqual(assignment.load_as_choice, load_as)
-                self.assertEqual(assignment.rescale, rescale)
-                self.assertEqual(assignment.should_save_outlines, should_save_outlines)
-                self.assertEqual(assignment.save_outlines, outlines_name)
-                self.assertEqual(assignment.manual_rescale, N.DEFAULT_MANUAL_RESCALE)
+                self.assertEqual(assignment.image_name.value, image_name)
+                self.assertEqual(assignment.object_name.value, objects_name)
+                self.assertEqual(assignment.load_as_choice.value, load_as)
+                self.assertEqual(assignment.rescale.value, rescale)
+                self.assertEqual(assignment.manual_rescale.value, N.DEFAULT_MANUAL_RESCALE)
             self.assertEqual(len(module.single_images), 0)
 
 #     def test_00_05_load_v5(self):
@@ -1302,8 +1298,6 @@ NamesAndTypes:[module_num:3|svn_version:\'Unknown\'|variable_revision_number:4|s
         n.assignments[0].load_as_choice.value = load_as_type
         n.assignments[0].rescale.value = rescaled
         n.assignments[0].manual_rescale.value = manual_rescale
-        n.assignments[0].should_save_outlines.value = True
-        n.assignments[0].save_outlines.value = OUTLINES_NAME
         n.module_num = 1
         pipeline = cpp.Pipeline()
         pipeline.add_module(n)
@@ -1360,8 +1354,6 @@ NamesAndTypes:[module_num:3|svn_version:\'Unknown\'|variable_revision_number:4|s
             name = d["name"]
             names.add(name)
             rescaled = d.get("rescaled", True)
-            should_save_outlines = d.get("should_save_outlines", False)
-            outlines_name = d.get("outlines_name", "_".join((name, "outlines")))
             n.add_single_image()
             si = n.single_images[-1]
             si.image_name.value = name
@@ -1369,8 +1361,6 @@ NamesAndTypes:[module_num:3|svn_version:\'Unknown\'|variable_revision_number:4|s
             si.load_as_choice.value = load_as_type
             si.rescale.value = rescaled
             si.manual_rescale.value = manual_rescale
-            si.should_save_outlines.value = should_save_outlines
-            si.save_outlines.value = outlines_name
 
             url = pathname2url(path)
             pathname, filename = os.path.split(path)
@@ -1540,8 +1530,6 @@ NamesAndTypes:[module_num:3|svn_version:\'Unknown\'|variable_revision_number:4|s
             m[cpmeas.IMAGE, C_MD5_DIGEST + "_" + OBJECTS_NAME], md5)
         self.assertEqual(m[cpmeas.IMAGE, C_WIDTH + "_" + OBJECTS_NAME],
                          target.shape[1])
-        outlines = workspace.image_set.get_image(OUTLINES_NAME)
-        self.assertEqual(o.shape, outlines.pixel_data.shape)
 
     def test_03_10_load_overlapped_objects(self):
         from .test_loadimages import overlapped_objects_data
@@ -1564,8 +1552,6 @@ NamesAndTypes:[module_num:3|svn_version:\'Unknown\'|variable_revision_number:4|s
                 self.assertTrue(np.all(expected[i, j]))
                 mask[i, j] = True
             self.assertFalse(np.any(mask[~ expected_mask]))
-            outlines = workspace.image_set.get_image(OUTLINES_NAME)
-            self.assertEqual(o.shape, outlines.pixel_data.shape)
         finally:
             try:
                 os.unlink(path)
@@ -1623,8 +1609,7 @@ NamesAndTypes:[module_num:3|svn_version:\'Unknown\'|variable_revision_number:4|s
             path, N.LOAD_AS_GRAYSCALE_IMAGE, lsi= [{
                 "path":lsi_path,
                 "load_as_type":N.LOAD_AS_OBJECTS,
-                "name":"lsi",
-                "should_save_outlines":True
+                "name":"lsi"
             }])
         o = workspace.object_set.get_objects("lsi")
         assert isinstance(o, N.cpo.Objects)
@@ -1637,8 +1622,6 @@ NamesAndTypes:[module_num:3|svn_version:\'Unknown\'|variable_revision_number:4|s
         self.assertEqual(
             m[cpmeas.IMAGE, C_MD5_DIGEST + "_lsi"], md5)
         self.assertEqual(m[cpmeas.IMAGE, C_WIDTH + "_lsi"], target.shape[1])
-        outlines = workspace.image_set.get_image("lsi_outlines")
-        self.assertEqual(o.shape, outlines.pixel_data.shape)
 
     def test_04_01_get_measurement_columns(self):
         p = cpp.Pipeline()


### PR DESCRIPTION
Resolves #3035 

Object identification modules no longer produce object outlines. Use **OverlayOutlines** to produce outline images.