### PR TITLE
Update run multiple pipelines documentation

### DIFF
--- a/cellprofiler/gui/help/content.py
+++ b/cellprofiler/gui/help/content.py
@@ -821,7 +821,7 @@ RUN_MULTIPLE_PIPELINES_HELP = u"""\
 The **Run multiple pipelines** dialog lets you select several
 pipelines which will be run consecutively. Please note the following:
 
--  Pipelines from CellProfiler 2.0 and lower are supported.
+-  Pipeline files (.cppipe) are supported.
 -  Project files (.cpproj) from CellProfiler 2.1 or newer are not supported.
    To convert your project to a pipeline (.cppipe), select *File > Export > Pipeline…*
    and, under the “Save as type” dropdown, select “CellProfiler pipeline and file list”

--- a/cellprofiler/gui/help/content.py
+++ b/cellprofiler/gui/help/content.py
@@ -348,7 +348,7 @@ This version of CellProfiler no longer supports exporting MATLAB format
 images. Instead, the recommended image format for illumination correction
 functions is NumPy (.npy). Loading MATLAB format images is deprecated and
 will be removed in a future version of CellProfiler. To ensure compatibility
-with future versions of CellProfiler you can convert your .mat files to .npy 
+with future versions of CellProfiler you can convert your .mat files to .npy
 files via **SaveImages** using this version of CellProfiler.
 
 See **SaveImages** for more details on saving NumPy format images.
@@ -821,12 +821,11 @@ RUN_MULTIPLE_PIPELINES_HELP = u"""\
 The **Run multiple pipelines** dialog lets you select several
 pipelines which will be run consecutively. Please note the following:
 
--  CellProfiler 2.1 project files are not currently supported.
 -  Pipelines from CellProfiler 2.0 and lower are supported.
--  If you want to use a pipeline made using CellProfiler 2.1, then you
-   need to include the project file list with the pipeline, by selecting
-   *Export > Pipeline…*, and under the “Save as type” dropdown, select
-   “CellProfiler pipeline and file list”.
+-  Project files (.cpproj) from CellProfiler 2.1 or newer are not supported.
+   To convert your project to a pipeline (.cppipe), select *File > Export > Pipeline…*
+   and, under the “Save as type” dropdown, select “CellProfiler pipeline and file list”
+   to export the project file list with the pipeline.
 
 You can invoke **Run multiple pipelines** by selecting it from the file menu. The dialog has three parts to it:
 


### PR DESCRIPTION
Running multiple pipelines only works with pipeline (.cppipe) files with image plane details. Use File > Export > Pipeline... to export "CellProfiler pipeline and file list".