### PR TITLE
Return correct measurement objects for IDPrimary and IDSecondary

### DIFF
--- a/cellprofiler/modules/identifyprimaryobjects.py
+++ b/cellprofiler/modules/identifyprimaryobjects.py
@@ -304,7 +304,7 @@ class IdentifyPrimaryObjects(cellprofiler.module.ImageSegmentation):
     module_name = "IdentifyPrimaryObjects"
 
     def __init__(self):
-        self.apply_threshold = threshold.Threshold()
+        self.threshold = threshold.Threshold()
 
         super(IdentifyPrimaryObjects, self).__init__()
 
@@ -755,16 +755,16 @@ If "*{NO}*" is selected, the following settings are used:
                 "LIMIT_CHOICE_VALUE": LIMIT_NONE,
                 "LOW_RES_MAXIMA_TEXT": self.low_res_maxima.get_text(),
                 "NO": cellprofiler.setting.NO,
-                "THRESHOLD_CORRECTION_FACTOR_TEXT": self.apply_threshold.threshold_correction_factor.get_text(),
+                "THRESHOLD_CORRECTION_FACTOR_TEXT": self.threshold.threshold_correction_factor.get_text(),
                 "THRESHOLD_CORRECTION_FACTOR_VALUE": 1.0,
-                "THRESHOLD_METHOD_TEXT": self.apply_threshold.global_operation.get_text(),
+                "THRESHOLD_METHOD_TEXT": self.threshold.global_operation.get_text(),
                 "THRESHOLD_METHOD_VALUE": threshold.TM_LI,
                 "THRESHOLD_RANGE_MAX": 1.0,
                 "THRESHOLD_RANGE_MIN": 0.0,
-                "THRESHOLD_RANGE_TEXT": self.apply_threshold.threshold_range.get_text(),
-                "THRESHOLD_SCOPE_TEXT": self.apply_threshold.threshold_scope.get_text(),
+                "THRESHOLD_RANGE_TEXT": self.threshold.threshold_range.get_text(),
+                "THRESHOLD_SCOPE_TEXT": self.threshold.threshold_scope.get_text(),
                 "THRESHOLD_SCOPE_VALUE": threshold.TS_GLOBAL,
-                "THRESHOLD_SMOOTHING_SCALE_TEXT": self.apply_threshold.threshold_smoothing_scale.get_text(),
+                "THRESHOLD_SMOOTHING_SCALE_TEXT": self.threshold.threshold_smoothing_scale.get_text(),
                 "THRESHOLD_SMOOTHING_SCALE_VALUE": 1.3488,
                 "UNCLUMP_METHOD_TEXT": self.unclump_method.get_text(),
                 "UNCLUMP_METHOD_VALUE": UN_INTENSITY,
@@ -776,12 +776,12 @@ If "*{NO}*" is selected, the following settings are used:
 
         self.threshold_setting_version = cellprofiler.setting.Integer(
             "Threshold setting version",
-            value=self.apply_threshold.variable_revision_number
+            value=self.threshold.variable_revision_number
         )
 
-        self.apply_threshold.create_settings()
+        self.threshold.create_settings()
 
-        self.apply_threshold.threshold_smoothing_scale.value = 1.3488  # sigma = 1
+        self.threshold.threshold_smoothing_scale.value = 1.3488  # sigma = 1
 
     def settings(self):
         settings = super(IdentifyPrimaryObjects, self).settings()
@@ -803,7 +803,7 @@ If "*{NO}*" is selected, the following settings are used:
             self.use_advanced
         ]
 
-        threshold_settings = self.apply_threshold.settings()[2:]
+        threshold_settings = self.threshold.settings()[2:]
 
         return settings + [self.threshold_setting_version] + threshold_settings
 
@@ -855,11 +855,11 @@ If "*{NO}*" is selected, the following settings are used:
         threshold_settings_version = int(threshold_setting_values[0])
 
         if threshold_settings_version < 4:
-            threshold_setting_values = self.apply_threshold.upgrade_threshold_settings(threshold_setting_values)
+            threshold_setting_values = self.threshold.upgrade_threshold_settings(threshold_setting_values)
 
             threshold_settings_version = 9
 
-        threshold_upgrade_settings, threshold_settings_version, _ = self.apply_threshold.upgrade_settings(
+        threshold_upgrade_settings, threshold_settings_version, _ = self.threshold.upgrade_settings(
             ["None", "None"] + threshold_setting_values[1:],
             threshold_settings_version,
             "Threshold",
@@ -873,7 +873,7 @@ If "*{NO}*" is selected, the following settings are used:
         return setting_values, variable_revision_number, False
 
     def help_settings(self):
-        threshold_help_settings = self.apply_threshold.help_settings()[2:]
+        threshold_help_settings = self.threshold.help_settings()[2:]
 
         return [
             self.use_advanced,
@@ -907,7 +907,7 @@ If "*{NO}*" is selected, the following settings are used:
         ]
 
         if self.use_advanced.value:
-            visible_settings += self.apply_threshold.visible_settings()[2:]
+            visible_settings += self.threshold.visible_settings()[2:]
 
             visible_settings += [self.unclump_method, self.watershed_method]
 
@@ -1056,18 +1056,18 @@ If "*{NO}*" is selected, the following settings are used:
     def _threshold_image(self, image_name, workspace, automatic=False):
         image = workspace.image_set.get_image(image_name, must_be_grayscale=True)
 
-        local_threshold, global_threshold = self.apply_threshold.get_threshold(image, workspace, automatic)
+        local_threshold, global_threshold = self.threshold.get_threshold(image, workspace, automatic)
 
-        self.apply_threshold.add_threshold_measurements(
+        self.threshold.add_threshold_measurements(
             self.y_name.value,
             workspace.measurements,
             local_threshold,
             global_threshold
         )
 
-        binary_image, sigma = self.apply_threshold.apply_threshold(image, local_threshold, automatic)
+        binary_image, sigma = self.threshold.apply_threshold(image, local_threshold, automatic)
 
-        self.apply_threshold.add_fg_bg_measurements(
+        self.threshold.add_fg_bg_measurements(
             self.y_name.value,
             workspace.measurements,
             image,
@@ -1390,26 +1390,26 @@ If "*{NO}*" is selected, the following settings are used:
     def get_measurement_columns(self, pipeline):
         columns = super(IdentifyPrimaryObjects, self).get_measurement_columns(pipeline)
 
-        columns += self.apply_threshold.get_measurement_columns(pipeline, object_name=self.y_name.value)
+        columns += self.threshold.get_measurement_columns(pipeline, object_name=self.y_name.value)
 
         return columns
 
     def get_categories(self, pipeline, object_name):
-        categories = self.apply_threshold.get_categories(pipeline, object_name)
+        categories = self.threshold.get_categories(pipeline, object_name)
 
         categories += super(IdentifyPrimaryObjects, self).get_categories(pipeline, object_name)
 
         return categories
 
     def get_measurements(self, pipeline, object_name, category):
-        measurements = self.apply_threshold.get_measurements(pipeline, object_name, category)
+        measurements = self.threshold.get_measurements(pipeline, object_name, category)
 
         measurements += super(IdentifyPrimaryObjects, self).get_measurements(pipeline, object_name, category)
 
         return measurements
 
     def get_measurement_objects(self, pipeline, object_name, category, measurement):
-        if measurement in self.get_measurements(pipeline, object_name, category):
+        if measurement in self.threshold.get_measurements(pipeline, object_name, category):
             return [self.y_name.value]
 
         return []

--- a/cellprofiler/modules/identifysecondaryobjects.py
+++ b/cellprofiler/modules/identifysecondaryobjects.py
@@ -68,7 +68,7 @@ This module identifies secondary objects based on two types of input:
    example, an image processing module might be used to transform a
    brightfield image into one that captures the characteristics of a
    cell body fluorescent stain. This input is optional because you can
-   instead define secondary objects as a fixed distance aruond each
+   instead define secondary objects as a fixed distance around each
    primary object.
 
 What do I get as output?
@@ -110,7 +110,7 @@ modules might be needed):
 -  *Lower right:* A table showing some of the settings you chose,
    as well as those calculated by the module in order to produce
    the objects shown.
-   
+
 See the section "Measurements made by this module" below for the measurements
 that are produced by this module.
 
@@ -163,7 +163,7 @@ class IdentifySecondaryObjects(cellprofiler.module.ObjectProcessing):
     category = "Object Processing"
 
     def __init__(self):
-        self.apply_threshold = threshold.Threshold()
+        self.threshold = threshold.Threshold()
 
         super(IdentifySecondaryObjects, self).__init__()
 
@@ -207,7 +207,7 @@ secondary objects that touch each other:
    Boundaries are preferentially placed where the image’s local
    appearance changes perpendicularly to the boundary (*Jones et al,
    2005*).
-   
+
    |image0| The {M_PROPAGATION:s} algorithm is the default approach for secondary object
    creation. Each primary object is a "seed" for its corresponding
    secondary object, guided by the input
@@ -391,12 +391,12 @@ segmentation.""")
 
         self.threshold_setting_version = cellprofiler.setting.Integer(
             "Threshold setting version",
-            value=self.apply_threshold.variable_revision_number
+            value=self.threshold.variable_revision_number
         )
 
-        self.apply_threshold.create_settings()
+        self.threshold.create_settings()
 
-        self.apply_threshold.threshold_smoothing_scale.value = 0
+        self.threshold.threshold_smoothing_scale.value = 0
 
     def settings(self):
         settings = super(IdentifySecondaryObjects, self).settings()
@@ -410,7 +410,7 @@ segmentation.""")
             self.wants_discard_primary,
             self.new_primary_objects_name,
             self.fill_holes
-        ] + [self.threshold_setting_version] + self.apply_threshold.settings()[2:]
+        ] + [self.threshold_setting_version] + self.threshold.settings()[2:]
 
     def visible_settings(self):
         visible_settings = [self.image_name]
@@ -420,7 +420,7 @@ segmentation.""")
         visible_settings += [self.method]
 
         if self.method != M_DISTANCE_N:
-            visible_settings += self.apply_threshold.visible_settings()[2:]
+            visible_settings += self.threshold.visible_settings()[2:]
 
         if self.method in (M_DISTANCE_B, M_DISTANCE_N):
             visible_settings += [self.distance_to_dilate]
@@ -448,7 +448,7 @@ segmentation.""")
             self.image_name
         ]
 
-        help_settings += self.apply_threshold.help_settings()[2:]
+        help_settings += self.threshold.help_settings()[2:]
 
         help_settings += [
             self.distance_to_dilate,
@@ -478,11 +478,11 @@ segmentation.""")
         threshold_settings_version = int(threshold_setting_values[0])
 
         if threshold_settings_version < 4:
-            threshold_setting_values = self.apply_threshold.upgrade_threshold_settings(threshold_setting_values)
+            threshold_setting_values = self.threshold.upgrade_threshold_settings(threshold_setting_values)
 
             threshold_settings_version = 9
 
-        threshold_upgrade_settings, threshold_settings_version, _ = self.apply_threshold.upgrade_settings(
+        threshold_upgrade_settings, threshold_settings_version, _ = self.threshold.upgrade_settings(
             ["None", "None"] + threshold_setting_values[1:],
             threshold_settings_version,
             "Threshold",
@@ -726,18 +726,18 @@ segmentation.""")
     def _threshold_image(self, image_name, workspace, automatic=False):
         image = workspace.image_set.get_image(image_name, must_be_grayscale=True)
 
-        local_threshold, global_threshold = self.apply_threshold.get_threshold(image, workspace, automatic)
+        local_threshold, global_threshold = self.threshold.get_threshold(image, workspace, automatic)
 
-        self.apply_threshold.add_threshold_measurements(
+        self.threshold.add_threshold_measurements(
             self.y_name.value,
             workspace.measurements,
             local_threshold,
             global_threshold
         )
 
-        binary_image, sigma = self.apply_threshold.apply_threshold(image, local_threshold, automatic)
+        binary_image, sigma = self.threshold.apply_threshold(image, local_threshold, automatic)
 
-        self.apply_threshold.add_fg_bg_measurements(
+        self.threshold.add_fg_bg_measurements(
             self.y_name.value,
             workspace.measurements,
             image,
@@ -871,7 +871,7 @@ segmentation.""")
             columns = super(IdentifySecondaryObjects, self).get_measurement_columns(pipeline)
 
         if self.method != M_DISTANCE_N:
-            columns += self.apply_threshold.get_measurement_columns(pipeline, object_name=self.y_name.value)
+            columns += self.threshold.get_measurement_columns(pipeline, object_name=self.y_name.value)
 
         return columns
 
@@ -879,7 +879,7 @@ segmentation.""")
         categories = super(IdentifySecondaryObjects, self).get_categories(pipeline, object_name)
 
         if self.method != M_DISTANCE_N:
-            categories += self.apply_threshold.get_categories(pipeline, object_name)
+            categories += self.threshold.get_categories(pipeline, object_name)
 
         if self.wants_discard_edge and self.wants_discard_primary:
             if object_name == self.new_primary_objects_name.value:
@@ -894,7 +894,7 @@ segmentation.""")
         measurements = super(IdentifySecondaryObjects, self).get_measurements(pipeline, object_name, category)
 
         if self.method.value != M_DISTANCE_N:
-            measurements += self.apply_threshold.get_measurements(pipeline, object_name, category)
+            measurements += self.threshold.get_measurements(pipeline, object_name, category)
 
         if self.wants_discard_edge and self.wants_discard_primary:
             if object_name == cellprofiler.measurement.IMAGE and category == cellprofiler.measurement.C_COUNT:
@@ -931,7 +931,9 @@ segmentation.""")
         return measurements
 
     def get_measurement_objects(self, pipeline, object_name, category, measurement):
-        if self.method != M_DISTANCE_N:
+        threshold_measurements = self.threshold.get_measurements(pipeline, object_name, category)
+
+        if self.method != M_DISTANCE_N and measurement in threshold_measurements:
             return [self.y_name.value]
 
         return []

--- a/tests/modules/test_identifyprimaryobjects.py
+++ b/tests/modules/test_identifyprimaryobjects.py
@@ -67,8 +67,8 @@ class TestIdentifyPrimaryObjects(unittest.TestCase):
         x = cellprofiler.modules.identifyprimaryobjects.IdentifyPrimaryObjects()
         x.y_name.value = "my_object"
         x.x_name.value = "my_image"
-        x.apply_threshold.threshold_range.min = .1
-        x.apply_threshold.threshold_range.max = 1
+        x.threshold.threshold_range.min = .1
+        x.threshold.threshold_range.max = 1
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_NONE
         img = numpy.zeros((25, 25))
         image = cellprofiler.image.Image(img)
@@ -103,8 +103,8 @@ class TestIdentifyPrimaryObjects(unittest.TestCase):
         x = cellprofiler.modules.identifyprimaryobjects.IdentifyPrimaryObjects()
         x.y_name.value = "my_object"
         x.x_name.value = "my_image"
-        x.apply_threshold.threshold_range.min = .1
-        x.apply_threshold.threshold_range.max = 1
+        x.threshold.threshold_range.min = .1
+        x.threshold.threshold_range.max = 1
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_INTENSITY
         x.unclump_method.value = cellprofiler.modules.identifyprimaryobjects.UN_INTENSITY
         img = numpy.zeros((25, 25))
@@ -126,8 +126,8 @@ class TestIdentifyPrimaryObjects(unittest.TestCase):
         x = cellprofiler.modules.identifyprimaryobjects.IdentifyPrimaryObjects()
         x.y_name.value = "my_object"
         x.x_name.value = "my_image"
-        x.apply_threshold.threshold_range.min = .1
-        x.apply_threshold.threshold_range.max = 1
+        x.threshold.threshold_range.min = .1
+        x.threshold.threshold_range.max = 1
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_SHAPE
         x.unclump_method.value = cellprofiler.modules.identifyprimaryobjects.UN_INTENSITY
         img = numpy.zeros((25, 25))
@@ -149,8 +149,8 @@ class TestIdentifyPrimaryObjects(unittest.TestCase):
         x = cellprofiler.modules.identifyprimaryobjects.IdentifyPrimaryObjects()
         x.y_name.value = "my_object"
         x.x_name.value = "my_image"
-        x.apply_threshold.threshold_range.min = .1
-        x.apply_threshold.threshold_range.max = 1
+        x.threshold.threshold_range.min = .1
+        x.threshold.threshold_range.max = 1
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_INTENSITY
         x.unclump_method.value = cellprofiler.modules.identifyprimaryobjects.UN_SHAPE
         img = numpy.zeros((25, 25))
@@ -172,8 +172,8 @@ class TestIdentifyPrimaryObjects(unittest.TestCase):
         x = cellprofiler.modules.identifyprimaryobjects.IdentifyPrimaryObjects()
         x.y_name.value = "my_object"
         x.x_name.value = "my_image"
-        x.apply_threshold.threshold_range.min = .1
-        x.apply_threshold.threshold_range.max = 1
+        x.threshold.threshold_range.min = .1
+        x.threshold.threshold_range.max = 1
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_SHAPE
         x.unclump_method.value = cellprofiler.modules.identifyprimaryobjects.UN_SHAPE
         img = numpy.zeros((25, 25))
@@ -198,9 +198,9 @@ class TestIdentifyPrimaryObjects(unittest.TestCase):
         x.x_name.value = "my_image"
         x.exclude_size.value = False
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_NONE
-        x.apply_threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
-        x.apply_threshold.global_operation.value = centrosome.threshold.TM_OTSU
-        x.apply_threshold.threshold_smoothing_scale.value = 0
+        x.threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
+        x.threshold.global_operation.value = centrosome.threshold.TM_OTSU
+        x.threshold.threshold_smoothing_scale.value = 0
         img = one_cell_image()
         image = cellprofiler.image.Image(img)
         image_set_list = cellprofiler.image.ImageSetList()
@@ -250,9 +250,9 @@ class TestIdentifyPrimaryObjects(unittest.TestCase):
         x.x_name.value = "my_image"
         x.exclude_size.value = False
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_NONE
-        x.apply_threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
-        x.apply_threshold.global_operation.value = centrosome.threshold.TM_OTSU
-        x.apply_threshold.threshold_smoothing_scale.value = 0
+        x.threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
+        x.threshold.global_operation.value = centrosome.threshold.TM_OTSU
+        x.threshold.threshold_smoothing_scale.value = 0
         img = two_cell_image()
         image = cellprofiler.image.Image(img)
         image_set_list = cellprofiler.image.ImageSetList()
@@ -295,11 +295,11 @@ class TestIdentifyPrimaryObjects(unittest.TestCase):
         x.use_advanced.value = True
         x.y_name.value = "my_object"
         x.x_name.value = "my_image"
-        x.apply_threshold.threshold_range.min = .7
-        x.apply_threshold.threshold_range.max = 1
-        x.apply_threshold.threshold_correction_factor.value = .95
-        x.apply_threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
-        x.apply_threshold.global_operation.value = cellprofiler.modules.threshold.TM_LI
+        x.threshold.threshold_range.min = .7
+        x.threshold.threshold_range.max = 1
+        x.threshold.threshold_correction_factor.value = .95
+        x.threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
+        x.threshold.global_operation.value = cellprofiler.modules.threshold.TM_LI
         x.exclude_size.value = False
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_NONE
         img = two_cell_image()
@@ -344,9 +344,9 @@ class TestIdentifyPrimaryObjects(unittest.TestCase):
         x.exclude_size.value = False
         x.fill_holes.value = True
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_NONE
-        x.apply_threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
-        x.apply_threshold.global_operation.value = centrosome.threshold.TM_OTSU
-        x.apply_threshold.threshold_smoothing_scale.value = 0
+        x.threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
+        x.threshold.global_operation.value = centrosome.threshold.TM_OTSU
+        x.threshold.threshold_smoothing_scale.value = 0
         img = numpy.zeros((40, 40))
         draw_circle(img, (10, 10), 7, .5)
         draw_circle(img, (30, 30), 7, .5)
@@ -369,8 +369,8 @@ class TestIdentifyPrimaryObjects(unittest.TestCase):
         x.use_advanced.value = True
         x.y_name.value = "my_object"
         x.x_name.value = "my_image"
-        x.apply_threshold.threshold_range.min = .7
-        x.apply_threshold.threshold_range.max = 1
+        x.threshold.threshold_range.min = .7
+        x.threshold.threshold_range.max = 1
         x.exclude_size.value = False
         x.fill_holes.value = False
         x.smoothing_filter_size.value = 0
@@ -404,9 +404,9 @@ class TestIdentifyPrimaryObjects(unittest.TestCase):
         x.exclude_size.value = False
         x.fill_holes.value = cellprofiler.modules.identifyprimaryobjects.FH_DECLUMP
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_NONE
-        x.apply_threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
-        x.apply_threshold.global_operation.value = centrosome.threshold.TM_OTSU
-        x.apply_threshold.threshold_smoothing_scale.value = 0
+        x.threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
+        x.threshold.global_operation.value = centrosome.threshold.TM_OTSU
+        x.threshold.threshold_smoothing_scale.value = 0
         img = numpy.zeros((40, 40))
         draw_circle(img, (20, 20), 10, .5)
         draw_circle(img, (20, 20), 4, 0)
@@ -441,9 +441,9 @@ class TestIdentifyPrimaryObjects(unittest.TestCase):
         x.automatic_suppression.value = False
         x.unclump_method.value = cellprofiler.modules.identifyprimaryobjects.UN_SHAPE
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_SHAPE
-        x.apply_threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
-        x.apply_threshold.global_operation.value = centrosome.threshold.TM_OTSU
-        x.apply_threshold.threshold_smoothing_scale.value = 0
+        x.threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
+        x.threshold.global_operation.value = centrosome.threshold.TM_OTSU
+        x.threshold.threshold_smoothing_scale.value = 0
         img = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                            [0, 0, 0, 0, 0, .5, .5, .5, .5, .5, .5, 0, 0, 0, 0, 0],
@@ -494,9 +494,9 @@ class TestIdentifyPrimaryObjects(unittest.TestCase):
         x.automatic_suppression.value = False
         x.unclump_method.value = cellprofiler.modules.identifyprimaryobjects.UN_SHAPE
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_INTENSITY
-        x.apply_threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
-        x.apply_threshold.global_operation.value = centrosome.threshold.TM_OTSU
-        x.apply_threshold.threshold_smoothing_scale.value = 0
+        x.threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
+        x.threshold.global_operation.value = centrosome.threshold.TM_OTSU
+        x.threshold.threshold_smoothing_scale.value = 0
         img = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                            [0, 0, 0, 0, 0, .5, .5, .5, .5, .5, .5, 0, 0, 0, 0, 0],
@@ -548,9 +548,9 @@ class TestIdentifyPrimaryObjects(unittest.TestCase):
         x.automatic_suppression.value = False
         x.unclump_method.value = cellprofiler.modules.identifyprimaryobjects.UN_INTENSITY
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_SHAPE
-        x.apply_threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
-        x.apply_threshold.global_operation.value = centrosome.threshold.TM_OTSU
-        x.apply_threshold.threshold_smoothing_scale.value = 0
+        x.threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
+        x.threshold.global_operation.value = centrosome.threshold.TM_OTSU
+        x.threshold.threshold_smoothing_scale.value = 0
         img = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                            [0, 0, 0, 0, 0, .5, .5, .5, .5, .5, .5, 0, 0, 0, 0, 0],
@@ -606,9 +606,9 @@ class TestIdentifyPrimaryObjects(unittest.TestCase):
         x.automatic_suppression.value = False
         x.unclump_method.value = cellprofiler.modules.identifyprimaryobjects.UN_INTENSITY
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_SHAPE
-        x.apply_threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
-        x.apply_threshold.global_operation.value = centrosome.threshold.TM_OTSU
-        x.apply_threshold.threshold_smoothing_scale.value = 0
+        x.threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
+        x.threshold.global_operation.value = centrosome.threshold.TM_OTSU
+        x.threshold.threshold_smoothing_scale.value = 0
         img = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                            [0, 0, 0, 0, 0, .5, .5, .5, .5, .5, .5, 0, 0, 0, 0, 0],
@@ -661,9 +661,9 @@ class TestIdentifyPrimaryObjects(unittest.TestCase):
         x.automatic_suppression.value = False
         x.unclump_method.value = cellprofiler.modules.identifyprimaryobjects.UN_INTENSITY
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_SHAPE
-        x.apply_threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
-        x.apply_threshold.global_operation.value = centrosome.threshold.TM_OTSU
-        x.apply_threshold.threshold_smoothing_scale.value = 0
+        x.threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
+        x.threshold.global_operation.value = centrosome.threshold.TM_OTSU
+        x.threshold.threshold_smoothing_scale.value = 0
         img = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                            [0, 0, 0, 0, 0, .5, .5, .5, .5, .5, .5, 0, 0, 0, 0, 0],
@@ -769,12 +769,12 @@ class TestIdentifyPrimaryObjects(unittest.TestCase):
         x.automatic_smoothing.value = 0
         x.maxima_suppression_size.value = 7
         x.automatic_suppression.value = False
-        x.apply_threshold.manual_threshold.value = .3
+        x.threshold.manual_threshold.value = .3
         x.unclump_method.value = cellprofiler.modules.identifyprimaryobjects.UN_INTENSITY
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_PROPAGATE
-        x.apply_threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
-        x.apply_threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
-        x.apply_threshold.threshold_smoothing_scale.value = 0
+        x.threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
+        x.threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
+        x.threshold.threshold_smoothing_scale.value = 0
         img = numpy.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                            [0, 0, 0, 0, 0, .5, .5, .5, .5, .5, .5, 0, 0, 0, 0, 0],
@@ -925,12 +925,12 @@ IdentifyPrimaryObjects:[module_num:1|svn_version:\'Unknown\'|variable_revision_n
             x.automatic_smoothing.value = 0
             x.maxima_suppression_size.value = distance
             x.automatic_suppression.value = False
-            x.apply_threshold.manual_threshold.value = .05
+            x.threshold.manual_threshold.value = .05
             x.unclump_method.value = cellprofiler.modules.identifyprimaryobjects.UN_INTENSITY
             x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_INTENSITY
-            x.apply_threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
-            x.apply_threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
-            x.apply_threshold.threshold_smoothing_scale.value = 0
+            x.threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
+            x.threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
+            x.threshold.threshold_smoothing_scale.value = 0
             pipeline = cellprofiler.pipeline.Pipeline()
             x.module_num = 1
             pipeline.add_module(x)
@@ -1311,17 +1311,17 @@ IdentifyPrimaryObjects:[module_num:11|svn_version:\'Unknown\'|variable_revision_
         self.assertEqual(module.limit_choice, cellprofiler.modules.identifyprimaryobjects.LIMIT_NONE)
         self.assertEqual(module.maximum_object_count, 499)
         #
-        self.assertEqual(module.apply_threshold.threshold_scope, cellprofiler.modules.identify.TS_ADAPTIVE)
-        self.assertEqual(module.apply_threshold.local_operation.value, centrosome.threshold.TM_OTSU)
-        self.assertEqual(module.apply_threshold.threshold_smoothing_scale, 1.3488)
-        self.assertAlmostEqual(module.apply_threshold.threshold_correction_factor, .80)
-        self.assertAlmostEqual(module.apply_threshold.threshold_range.min, 0.01)
-        self.assertAlmostEqual(module.apply_threshold.threshold_range.max, 0.90)
-        self.assertAlmostEqual(module.apply_threshold.manual_threshold, 0.03)
-        self.assertEqual(module.apply_threshold.thresholding_measurement, "Metadata_Threshold")
-        self.assertEqual(module.apply_threshold.two_class_otsu, cellprofiler.modules.identify.O_TWO_CLASS)
-        self.assertEqual(module.apply_threshold.assign_middle_to_foreground, cellprofiler.modules.identify.O_FOREGROUND)
-        self.assertEqual(module.apply_threshold.adaptive_window_size, 12)
+        self.assertEqual(module.threshold.threshold_scope, cellprofiler.modules.identify.TS_ADAPTIVE)
+        self.assertEqual(module.threshold.local_operation.value, centrosome.threshold.TM_OTSU)
+        self.assertEqual(module.threshold.threshold_smoothing_scale, 1.3488)
+        self.assertAlmostEqual(module.threshold.threshold_correction_factor, .80)
+        self.assertAlmostEqual(module.threshold.threshold_range.min, 0.01)
+        self.assertAlmostEqual(module.threshold.threshold_range.max, 0.90)
+        self.assertAlmostEqual(module.threshold.manual_threshold, 0.03)
+        self.assertEqual(module.threshold.thresholding_measurement, "Metadata_Threshold")
+        self.assertEqual(module.threshold.two_class_otsu, cellprofiler.modules.identify.O_TWO_CLASS)
+        self.assertEqual(module.threshold.assign_middle_to_foreground, cellprofiler.modules.identify.O_FOREGROUND)
+        self.assertEqual(module.threshold.adaptive_window_size, 12)
         #
         # Test alternate settings using subsequent instances of IDPrimary
         #
@@ -1336,10 +1336,10 @@ IdentifyPrimaryObjects:[module_num:11|svn_version:\'Unknown\'|variable_revision_
         self.assertFalse(module.low_res_maxima)
         self.assertEqual(module.fill_holes, cellprofiler.modules.identifyprimaryobjects.FH_NEVER)
         self.assertEqual(module.limit_choice, cellprofiler.modules.identifyprimaryobjects.LIMIT_ERASE)
-        self.assertEqual(module.apply_threshold.threshold_scope, cellprofiler.modules.identify.TS_GLOBAL)
-        self.assertEqual(module.apply_threshold.global_operation.value, cellprofiler.modules.threshold.TM_LI)
-        self.assertEqual(module.apply_threshold.two_class_otsu, cellprofiler.modules.identify.O_THREE_CLASS)
-        self.assertEqual(module.apply_threshold.assign_middle_to_foreground, cellprofiler.modules.identify.O_BACKGROUND)
+        self.assertEqual(module.threshold.threshold_scope, cellprofiler.modules.identify.TS_GLOBAL)
+        self.assertEqual(module.threshold.global_operation.value, cellprofiler.modules.threshold.TM_LI)
+        self.assertEqual(module.threshold.two_class_otsu, cellprofiler.modules.identify.O_THREE_CLASS)
+        self.assertEqual(module.threshold.assign_middle_to_foreground, cellprofiler.modules.identify.O_BACKGROUND)
         self.assertTrue(module.use_advanced.value)
 
         module = pipeline.modules()[6]
@@ -1347,45 +1347,45 @@ IdentifyPrimaryObjects:[module_num:11|svn_version:\'Unknown\'|variable_revision_
         self.assertEqual(module.unclump_method, cellprofiler.modules.identifyprimaryobjects.UN_NONE)
         self.assertEqual(module.watershed_method, cellprofiler.modules.identifyprimaryobjects.WA_PROPAGATE)
         self.assertEqual(module.limit_choice, "None")
-        self.assertEqual(module.apply_threshold.global_operation.value, "None")
-        self.assertEqual(module.apply_threshold.threshold_smoothing_scale, 0)
+        self.assertEqual(module.threshold.global_operation.value, "None")
+        self.assertEqual(module.threshold.threshold_smoothing_scale, 0)
         self.assertTrue(module.use_advanced.value)
 
         module = pipeline.modules()[7]
         self.assertTrue(isinstance(module, cellprofiler.modules.identifyprimaryobjects.IdentifyPrimaryObjects))
         self.assertEqual(module.unclump_method, cellprofiler.modules.identifyprimaryobjects.UN_SHAPE)
         self.assertEqual(module.watershed_method, cellprofiler.modules.identifyprimaryobjects.WA_SHAPE)
-        self.assertEqual(module.apply_threshold.threshold_scope, cellprofiler.modules.identify.TS_GLOBAL)
-        self.assertEqual(module.apply_threshold.global_operation.value, centrosome.threshold.TM_ROBUST_BACKGROUND)
-        self.assertEqual(module.apply_threshold.lower_outlier_fraction.value, 0.02)
-        self.assertEqual(module.apply_threshold.upper_outlier_fraction.value, 0.02)
-        self.assertEqual(module.apply_threshold.averaging_method.value, cellprofiler.modules.identify.RB_MODE)
-        self.assertEqual(module.apply_threshold.variance_method.value, cellprofiler.modules.identify.RB_SD)
-        self.assertEqual(module.apply_threshold.number_of_deviations.value, 0)
-        self.assertEqual(module.apply_threshold.threshold_correction_factor.value, 1.6)
+        self.assertEqual(module.threshold.threshold_scope, cellprofiler.modules.identify.TS_GLOBAL)
+        self.assertEqual(module.threshold.global_operation.value, centrosome.threshold.TM_ROBUST_BACKGROUND)
+        self.assertEqual(module.threshold.lower_outlier_fraction.value, 0.02)
+        self.assertEqual(module.threshold.upper_outlier_fraction.value, 0.02)
+        self.assertEqual(module.threshold.averaging_method.value, cellprofiler.modules.identify.RB_MODE)
+        self.assertEqual(module.threshold.variance_method.value, cellprofiler.modules.identify.RB_SD)
+        self.assertEqual(module.threshold.number_of_deviations.value, 0)
+        self.assertEqual(module.threshold.threshold_correction_factor.value, 1.6)
         self.assertTrue(module.use_advanced.value)
 
         module = pipeline.modules()[8]
         self.assertTrue(isinstance(module, cellprofiler.modules.identifyprimaryobjects.IdentifyPrimaryObjects))
-        self.assertEqual(module.apply_threshold.threshold_scope, cellprofiler.modules.threshold.TS_GLOBAL)
-        self.assertEqual(module.apply_threshold.global_operation.value, cellprofiler.modules.threshold.TM_MANUAL)
+        self.assertEqual(module.threshold.threshold_scope, cellprofiler.modules.threshold.TS_GLOBAL)
+        self.assertEqual(module.threshold.global_operation.value, cellprofiler.modules.threshold.TM_MANUAL)
         self.assertTrue(module.use_advanced.value)
 
         module = pipeline.modules()[9]
         self.assertTrue(isinstance(module, cellprofiler.modules.identifyprimaryobjects.IdentifyPrimaryObjects))
-        self.assertEqual(module.apply_threshold.threshold_scope, cellprofiler.modules.threshold.TS_GLOBAL)
-        self.assertEqual(module.apply_threshold.global_operation.value, cellprofiler.modules.threshold.TM_MEASUREMENT)
+        self.assertEqual(module.threshold.threshold_scope, cellprofiler.modules.threshold.TS_GLOBAL)
+        self.assertEqual(module.threshold.global_operation.value, cellprofiler.modules.threshold.TM_MEASUREMENT)
         self.assertTrue(module.use_advanced.value)
 
         module = pipeline.modules()[10]
         self.assertTrue(isinstance(module, cellprofiler.modules.identifyprimaryobjects.IdentifyPrimaryObjects))
-        self.assertEqual(module.apply_threshold.threshold_scope, "None")
-        self.assertEqual(module.apply_threshold.global_operation.value, centrosome.threshold.TM_ROBUST_BACKGROUND)
-        self.assertEqual(module.apply_threshold.lower_outlier_fraction, .05)
-        self.assertEqual(module.apply_threshold.upper_outlier_fraction, .05)
-        self.assertEqual(module.apply_threshold.averaging_method, cellprofiler.modules.identify.RB_MEAN)
-        self.assertEqual(module.apply_threshold.variance_method, cellprofiler.modules.identify.RB_SD)
-        self.assertEqual(module.apply_threshold.number_of_deviations, 2)
+        self.assertEqual(module.threshold.threshold_scope, "None")
+        self.assertEqual(module.threshold.global_operation.value, centrosome.threshold.TM_ROBUST_BACKGROUND)
+        self.assertEqual(module.threshold.lower_outlier_fraction, .05)
+        self.assertEqual(module.threshold.upper_outlier_fraction, .05)
+        self.assertEqual(module.threshold.averaging_method, cellprofiler.modules.identify.RB_MEAN)
+        self.assertEqual(module.threshold.variance_method, cellprofiler.modules.identify.RB_SD)
+        self.assertEqual(module.threshold.number_of_deviations, 2)
         self.assertTrue(module.use_advanced.value)
 
     def test_04_10_01_load_new_robust_background(self):
@@ -1558,11 +1558,11 @@ IdentifyPrimaryObjects:[module_num:3|svn_version:\'Unknown\'|variable_revision_n
                  cellprofiler.modules.identify.RB_MAD)
         ):
             assert isinstance(module, cellprofiler.modules.identifyprimaryobjects.IdentifyPrimaryObjects)
-            self.assertEqual(module.apply_threshold.lower_outlier_fraction, .1)
-            self.assertEqual(module.apply_threshold.upper_outlier_fraction, .2)
-            self.assertEqual(module.apply_threshold.number_of_deviations, 2.5)
-            self.assertEqual(module.apply_threshold.averaging_method, averaging_method)
-            self.assertEqual(module.apply_threshold.variance_method, variance_method)
+            self.assertEqual(module.threshold.lower_outlier_fraction, .1)
+            self.assertEqual(module.threshold.upper_outlier_fraction, .2)
+            self.assertEqual(module.threshold.number_of_deviations, 2.5)
+            self.assertEqual(module.threshold.averaging_method, averaging_method)
+            self.assertEqual(module.threshold.variance_method, variance_method)
             self.assertTrue(module.use_advanced.value)
 
     def test_05_01_discard_large(self):
@@ -1574,9 +1574,9 @@ IdentifyPrimaryObjects:[module_num:3|svn_version:\'Unknown\'|variable_revision_n
         x.size_range.min = 10
         x.size_range.max = 40
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_NONE
-        x.apply_threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
-        x.apply_threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
-        x.apply_threshold.manual_threshold.value = .3
+        x.threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
+        x.threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
+        x.threshold.manual_threshold.value = .3
         img = numpy.zeros((200, 200))
         draw_circle(img, (100, 100), 25, .5)
         draw_circle(img, (25, 25), 10, .5)
@@ -1610,9 +1610,9 @@ IdentifyPrimaryObjects:[module_num:3|svn_version:\'Unknown\'|variable_revision_n
         x.size_range.min = 10
         x.size_range.max = 40
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_NONE
-        x.apply_threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
-        x.apply_threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
-        x.apply_threshold.manual_threshold.value = .3
+        x.threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
+        x.threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
+        x.threshold.manual_threshold.value = .3
         img = numpy.zeros((200, 200))
         draw_circle(img, (100, 100), 25, .5)
         draw_circle(img, (25, 25), 10, .5)
@@ -1642,9 +1642,9 @@ IdentifyPrimaryObjects:[module_num:3|svn_version:\'Unknown\'|variable_revision_n
         x.size_range.min = 40
         x.size_range.max = 60
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_NONE
-        x.apply_threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
-        x.apply_threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
-        x.apply_threshold.manual_threshold.value = .3
+        x.threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
+        x.threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
+        x.threshold.manual_threshold.value = .3
         img = numpy.zeros((200, 200))
         draw_circle(img, (100, 100), 25, .5)
         draw_circle(img, (25, 25), 10, .5)
@@ -1677,8 +1677,8 @@ IdentifyPrimaryObjects:[module_num:3|svn_version:\'Unknown\'|variable_revision_n
         x.size_range.min = 10
         x.size_range.max = 40
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_NONE
-        x.apply_threshold.threshold_scope.value = cellprofiler.modules.identify.TS_MANUAL
-        x.apply_threshold.manual_threshold.value = .3
+        x.threshold.threshold_scope.value = cellprofiler.modules.identify.TS_MANUAL
+        x.threshold.manual_threshold.value = .3
         img = numpy.zeros((100, 100))
         centers = [(50, 50), (10, 50), (50, 10), (90, 50), (50, 90)]
         present = [True, False, False, False, False]
@@ -1711,8 +1711,8 @@ IdentifyPrimaryObjects:[module_num:3|svn_version:\'Unknown\'|variable_revision_n
         x.size_range.min = 10
         x.size_range.max = 40
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_NONE
-        x.apply_threshold.threshold_scope.value = cellprofiler.modules.identify.TS_MANUAL
-        x.apply_threshold.manual_threshold.value = .3
+        x.threshold.threshold_scope.value = cellprofiler.modules.identify.TS_MANUAL
+        x.threshold.manual_threshold.value = .3
         img = numpy.zeros((200, 200))
         centers = [(100, 100), (30, 100), (100, 30), (170, 100), (100, 170)]
         present = [True, False, False, False, False]
@@ -1748,10 +1748,10 @@ IdentifyPrimaryObjects:[module_num:3|svn_version:\'Unknown\'|variable_revision_n
         x.smoothing_filter_size.value = 0
         x.automatic_smoothing.value = False
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_NONE
-        x.apply_threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
-        x.apply_threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
-        x.apply_threshold.threshold_smoothing_scale.value = 0
-        x.apply_threshold.manual_threshold.value = .5
+        x.threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
+        x.threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
+        x.threshold.threshold_smoothing_scale.value = 0
+        x.threshold.manual_threshold.value = .5
         img = numpy.zeros((10, 10))
         img[4, 4] = 1
         img[5, 5] = 1
@@ -1776,8 +1776,8 @@ IdentifyPrimaryObjects:[module_num:3|svn_version:\'Unknown\'|variable_revision_n
         x.y_name.value = "my_object"
         x.x_name.value = "my_image"
         x.exclude_size.value = False
-        x.apply_threshold.threshold_scope.value = centrosome.threshold.TM_ADAPTIVE
-        x.apply_threshold.global_operation.value = centrosome.threshold.TM_OTSU
+        x.threshold.threshold_scope.value = centrosome.threshold.TM_ADAPTIVE
+        x.threshold.global_operation.value = centrosome.threshold.TM_OTSU
         numpy.random.seed(62)
         img = numpy.random.uniform(size=(100, 100))
         mask = numpy.zeros(img.shape, bool)
@@ -1799,7 +1799,7 @@ IdentifyPrimaryObjects:[module_num:3|svn_version:\'Unknown\'|variable_revision_n
     # def test_11_01_test_robust_background_fly(self):
     #     image = fly_image()
     #     workspace, x = self.make_workspace(image)
-    #     x.apply_threshold.threshold_scope.value = I.TS_GLOBAL
+    #     x.threshold.threshold_scope.value = I.TS_GLOBAL
     #     x.threshold_method.value = T.TM_ROBUST_BACKGROUND
     #     local_threshold,threshold = x.get_threshold(
     #         cpi.Image(image), np.ones(image.shape,bool), workspace)
@@ -1910,11 +1910,11 @@ IdentifyPrimaryObjects:[module_num:3|svn_version:\'Unknown\'|variable_revision_n
         x.maxima_suppression_size.value = 3
         x.automatic_suppression.value = False
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_INTENSITY
-        x.apply_threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
-        x.apply_threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
-        x.apply_threshold.threshold_smoothing_scale.value = 0
-        x.apply_threshold.manual_threshold.value = .05
-        x.apply_threshold.threshold_correction_factor.value = 1
+        x.threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
+        x.threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
+        x.threshold.threshold_smoothing_scale.value = 0
+        x.threshold.manual_threshold.value = .05
+        x.threshold.threshold_correction_factor.value = 1
         measurements = workspace.measurements
         x.run(workspace)
         my_objects = workspace.object_set.get_objects(OBJECTS_NAME)
@@ -2004,9 +2004,9 @@ IdentifyPrimaryObjects:[module_num:3|svn_version:\'Unknown\'|variable_revision_n
         x.maxima_suppression_size.value = 3
         x.automatic_suppression.value = False
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_NONE
-        x.apply_threshold.local_operation.value = centrosome.threshold.TM_MANUAL
-        x.apply_threshold.manual_threshold.value = .1
-        x.apply_threshold.threshold_correction_factor.value = 1
+        x.threshold.local_operation.value = centrosome.threshold.TM_MANUAL
+        x.threshold.manual_threshold.value = .1
+        x.threshold.threshold_correction_factor.value = 1
         x.module_num = 1
         pipeline = cellprofiler.pipeline.Pipeline()
         pipeline.add_module(x)
@@ -2039,10 +2039,10 @@ IdentifyPrimaryObjects:[module_num:3|svn_version:\'Unknown\'|variable_revision_n
         x.exclude_size.value = False
         x.unclump_method.value = cellprofiler.modules.identifyprimaryobjects.UN_NONE
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_NONE
-        x.apply_threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
-        x.apply_threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
-        x.apply_threshold.manual_threshold.value = .25
-        x.apply_threshold.threshold_correction_factor.value = 1
+        x.threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
+        x.threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
+        x.threshold.manual_threshold.value = .25
+        x.threshold.threshold_correction_factor.value = 1
         x.limit_choice.value = cellprofiler.modules.identifyprimaryobjects.LIMIT_ERASE
         x.maximum_object_count.value = maximum_object_count
         x.module_num = 1
@@ -2079,10 +2079,10 @@ IdentifyPrimaryObjects:[module_num:3|svn_version:\'Unknown\'|variable_revision_n
         x.exclude_size.value = False
         x.unclump_method.value = cellprofiler.modules.identifyprimaryobjects.UN_NONE
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_NONE
-        x.apply_threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
-        x.apply_threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
-        x.apply_threshold.manual_threshold.value = .25
-        x.apply_threshold.threshold_correction_factor.value = 1
+        x.threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
+        x.threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
+        x.threshold.manual_threshold.value = .25
+        x.threshold.threshold_correction_factor.value = 1
         x.limit_choice.value = cellprofiler.modules.identifyprimaryobjects.LIMIT_ERASE
         x.maximum_object_count.value = maximum_object_count
         x.module_num = 1
@@ -2119,11 +2119,11 @@ IdentifyPrimaryObjects:[module_num:3|svn_version:\'Unknown\'|variable_revision_n
         x.exclude_size.value = False
         x.unclump_method.value = cellprofiler.modules.identifyprimaryobjects.UN_NONE
         x.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_NONE
-        x.apply_threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
-        x.apply_threshold.global_operation.value = cellprofiler.modules.threshold.TM_MEASUREMENT
-        x.apply_threshold.threshold_smoothing_scale.value = 0
-        x.apply_threshold.thresholding_measurement.value = "MeanIntensity_MyImage"
-        x.apply_threshold.threshold_correction_factor.value = 1
+        x.threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
+        x.threshold.global_operation.value = cellprofiler.modules.threshold.TM_MEASUREMENT
+        x.threshold.threshold_smoothing_scale.value = 0
+        x.threshold.thresholding_measurement.value = "MeanIntensity_MyImage"
+        x.threshold.threshold_correction_factor.value = 1
         x.module_num = 1
         pipeline.add_module(x)
 
@@ -2157,9 +2157,9 @@ IdentifyPrimaryObjects:[module_num:3|svn_version:\'Unknown\'|variable_revision_n
         module.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_NONE
         # MCT on this image is zero, so set the threshold at .225
         # with the threshold minimum (manual = no smoothing)
-        module.apply_threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
-        module.apply_threshold.global_operation.value = cellprofiler.modules.threshold.TM_LI
-        module.apply_threshold.threshold_range.min = .225
+        module.threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
+        module.threshold.global_operation.value = cellprofiler.modules.threshold.TM_LI
+        module.threshold.threshold_range.min = .225
         module.run(workspace)
         labels = workspace.object_set.get_objects(OBJECTS_NAME).segmented
         numpy.testing.assert_array_equal(expected, labels)
@@ -2185,10 +2185,10 @@ IdentifyPrimaryObjects:[module_num:3|svn_version:\'Unknown\'|variable_revision_n
         module.exclude_size.value = False
         module.unclump_method.value = cellprofiler.modules.identifyprimaryobjects.UN_NONE
         module.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_NONE
-        module.apply_threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
-        module.apply_threshold.global_operation.value = cellprofiler.modules.threshold.TM_LI
-        module.apply_threshold.threshold_range.min = .125
-        module.apply_threshold.threshold_smoothing_scale.value = 3
+        module.threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
+        module.threshold.global_operation.value = cellprofiler.modules.threshold.TM_LI
+        module.threshold.threshold_range.min = .125
+        module.threshold.threshold_smoothing_scale.value = 3
         module.run(workspace)
         labels = workspace.object_set.get_objects(OBJECTS_NAME).segmented
         numpy.testing.assert_array_equal(expected, labels)
@@ -2215,12 +2215,12 @@ IdentifyPrimaryObjects:[module_num:3|svn_version:\'Unknown\'|variable_revision_n
             module.exclude_size.value = False
             module.unclump_method.value = cellprofiler.modules.identifyprimaryobjects.UN_NONE
             module.watershed_method.value = cellprofiler.modules.identifyprimaryobjects.WA_NONE
-            module.apply_threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
-            module.apply_threshold.global_operation.value = tm
-            module.apply_threshold.manual_threshold.value = .125
-            module.apply_threshold.thresholding_measurement.value = MEASUREMENT_NAME
+            module.threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
+            module.threshold.global_operation.value = tm
+            module.threshold.manual_threshold.value = .125
+            module.threshold.thresholding_measurement.value = MEASUREMENT_NAME
             workspace.measurements[cellprofiler.measurement.IMAGE, MEASUREMENT_NAME] = .125
-            module.apply_threshold.threshold_smoothing_scale.value = 3
+            module.threshold.threshold_smoothing_scale.value = 3
             module.run(workspace)
             labels = workspace.object_set.get_objects(OBJECTS_NAME).segmented
             numpy.testing.assert_array_equal(expected, labels)

--- a/tests/modules/test_identifysecondaryobjects.py
+++ b/tests/modules/test_identifysecondaryobjects.py
@@ -121,17 +121,17 @@ IdentifySecondaryObjects:[module_num:5|svn_version:\'Unknown\'|variable_revision
         self.assertFalse(module.wants_discard_primary)
         self.assertEqual(module.new_primary_objects_name, "FilteredChocolateChips")
         self.assertTrue(module.fill_holes)
-        self.assertEqual(module.apply_threshold.threshold_scope, cellprofiler.modules.identify.TS_GLOBAL)
-        self.assertEqual(module.apply_threshold.global_operation.value, cellprofiler.modules.threshold.TM_LI)
-        self.assertEqual(module.apply_threshold.threshold_smoothing_scale.value, 1.3488)
-        self.assertEqual(module.apply_threshold.threshold_correction_factor, 1)
-        self.assertEqual(module.apply_threshold.threshold_range.min, 0.0)
-        self.assertEqual(module.apply_threshold.threshold_range.max, 1.0)
-        self.assertEqual(module.apply_threshold.manual_threshold, .3)
-        self.assertEqual(module.apply_threshold.thresholding_measurement, "Count_Cookies")
-        self.assertEqual(module.apply_threshold.two_class_otsu, cellprofiler.modules.identify.O_TWO_CLASS)
-        self.assertEqual(module.apply_threshold.assign_middle_to_foreground, cellprofiler.modules.identify.O_FOREGROUND)
-        self.assertEqual(module.apply_threshold.adaptive_window_size, 9)
+        self.assertEqual(module.threshold.threshold_scope, cellprofiler.modules.identify.TS_GLOBAL)
+        self.assertEqual(module.threshold.global_operation.value, cellprofiler.modules.threshold.TM_LI)
+        self.assertEqual(module.threshold.threshold_smoothing_scale.value, 1.3488)
+        self.assertEqual(module.threshold.threshold_correction_factor, 1)
+        self.assertEqual(module.threshold.threshold_range.min, 0.0)
+        self.assertEqual(module.threshold.threshold_range.max, 1.0)
+        self.assertEqual(module.threshold.manual_threshold, .3)
+        self.assertEqual(module.threshold.thresholding_measurement, "Count_Cookies")
+        self.assertEqual(module.threshold.two_class_otsu, cellprofiler.modules.identify.O_TWO_CLASS)
+        self.assertEqual(module.threshold.assign_middle_to_foreground, cellprofiler.modules.identify.O_FOREGROUND)
+        self.assertEqual(module.threshold.adaptive_window_size, 9)
 
     def test_01_10_load_v10(self):
         data = r"""CellProfiler Pipeline: http://www.cellprofiler.org
@@ -247,9 +247,9 @@ IdentifySecondaryObjects:[module_num:1|svn_version:\'Unknown\'|variable_revision
         labels[3:6, 3:6] = 1
         workspace, module = self.make_workspace(img, labels)
         module.method.value = cellprofiler.modules.identifysecondaryobjects.M_PROPAGATION
-        module.apply_threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
-        module.apply_threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
-        module.apply_threshold.manual_threshold.value = .25
+        module.threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
+        module.threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
+        module.threshold.manual_threshold.value = .25
         module.run(workspace)
         m = workspace.measurements
         self.assertTrue(OUTPUT_OBJECTS_NAME in m.get_object_names())
@@ -280,9 +280,9 @@ IdentifySecondaryObjects:[module_num:1|svn_version:\'Unknown\'|variable_revision
         workspace, module = self.make_workspace(img, labels)
         module.method.value = cellprofiler.modules.identifysecondaryobjects.M_PROPAGATION
         module.regularization_factor.value = 0  # propagate by image
-        module.apply_threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
-        module.apply_threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
-        module.apply_threshold.manual_threshold.value = .2
+        module.threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
+        module.threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
+        module.threshold.manual_threshold.value = .2
         module.run(workspace)
         m = workspace.measurements
         self.assertTrue(OUTPUT_OBJECTS_NAME in m.get_object_names())
@@ -324,9 +324,9 @@ IdentifySecondaryObjects:[module_num:1|svn_version:\'Unknown\'|variable_revision
         module.image_name.value = IMAGE_NAME
         module.method.value = cellprofiler.modules.identifysecondaryobjects.M_PROPAGATION
         module.regularization_factor.value = 1000  # propagate by distance
-        module.apply_threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
-        module.apply_threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
-        module.apply_threshold.manual_threshold.value = .2
+        module.threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
+        module.threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
+        module.threshold.manual_threshold.value = .2
         module.module_num = 1
         p.add_module(module)
         workspace = cellprofiler.workspace.Workspace(p, module, i_s, o_s, m, i_l)
@@ -353,8 +353,8 @@ IdentifySecondaryObjects:[module_num:1|svn_version:\'Unknown\'|variable_revision
         labels[3:6, 3:6] = 1
         workspace, module = self.make_workspace(img, labels)
         module.method.value = cellprofiler.modules.identifysecondaryobjects.M_PROPAGATION
-        module.apply_threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
-        module.apply_threshold.global_operation.value = centrosome.threshold.TM_OTSU
+        module.threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
+        module.threshold.global_operation.value = centrosome.threshold.TM_OTSU
         module.run(workspace)
         m = workspace.measurements
         self.assertTrue(OUTPUT_OBJECTS_NAME in m.get_object_names())
@@ -425,8 +425,8 @@ IdentifySecondaryObjects:[module_num:1|svn_version:\'Unknown\'|variable_revision
         module.y_name.value = OUTPUT_OBJECTS_NAME
         module.image_name.value = IMAGE_NAME
         module.method.value = cellprofiler.modules.identifysecondaryobjects.M_WATERSHED_G
-        module.apply_threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
-        module.apply_threshold.global_operation.value = centrosome.threshold.TM_OTSU
+        module.threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
+        module.threshold.global_operation.value = centrosome.threshold.TM_OTSU
         module.module_num = 1
         p.add_module(module)
         workspace = cellprofiler.workspace.Workspace(p, module, i_s, o_s, m, i_l)
@@ -476,9 +476,9 @@ IdentifySecondaryObjects:[module_num:1|svn_version:\'Unknown\'|variable_revision
         module.y_name.value = OUTPUT_OBJECTS_NAME
         module.image_name.value = IMAGE_NAME
         module.method.value = cellprofiler.modules.identifysecondaryobjects.M_WATERSHED_G
-        module.apply_threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
-        module.apply_threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
-        module.apply_threshold.manual_threshold.value = .2
+        module.threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
+        module.threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
+        module.threshold.manual_threshold.value = .2
         module.module_num = 1
         p.add_module(module)
         workspace = cellprofiler.workspace.Workspace(p, module, i_s, o_s, m, i_l)
@@ -504,8 +504,8 @@ IdentifySecondaryObjects:[module_num:1|svn_version:\'Unknown\'|variable_revision
         labels[3:6, 3:6] = 1
         workspace, module = self.make_workspace(img, labels)
         module.method.value = cellprofiler.modules.identifysecondaryobjects.M_WATERSHED_G
-        module.apply_threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
-        module.apply_threshold.global_operation.value = centrosome.threshold.TM_OTSU
+        module.threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
+        module.threshold.global_operation.value = centrosome.threshold.TM_OTSU
         module.run(workspace)
         m = workspace.measurements
         self.assertTrue(OUTPUT_OBJECTS_NAME in m.get_object_names())
@@ -579,8 +579,8 @@ IdentifySecondaryObjects:[module_num:1|svn_version:\'Unknown\'|variable_revision
         module.image_name.value = IMAGE_NAME
         module.method.value = cellprofiler.modules.identifysecondaryobjects.M_WATERSHED_I
         workspace = cellprofiler.workspace.Workspace(p, module, i_s, o_s, m, i_l)
-        module.apply_threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
-        module.apply_threshold.global_operation.value = centrosome.threshold.TM_OTSU
+        module.threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
+        module.threshold.global_operation.value = centrosome.threshold.TM_OTSU
         module.module_num = 1
         p.add_module(module)
         module.run(workspace)
@@ -622,9 +622,9 @@ IdentifySecondaryObjects:[module_num:1|svn_version:\'Unknown\'|variable_revision
         module.y_name.value = OUTPUT_OBJECTS_NAME
         module.image_name.value = IMAGE_NAME
         module.method.value = cellprofiler.modules.identifysecondaryobjects.M_WATERSHED_I
-        module.apply_threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
-        module.apply_threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
-        module.apply_threshold.manual_threshold.value = .01
+        module.threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
+        module.threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
+        module.threshold.manual_threshold.value = .01
         module.module_num = 1
         p.add_module(module)
         workspace = cellprofiler.workspace.Workspace(p, module, i_s, o_s, m, i_l)
@@ -650,8 +650,8 @@ IdentifySecondaryObjects:[module_num:1|svn_version:\'Unknown\'|variable_revision
         labels[3:6, 3:6] = 1
         workspace, module = self.make_workspace(img, labels)
         module.method.value = cellprofiler.modules.identifysecondaryobjects.M_WATERSHED_I
-        module.apply_threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
-        module.apply_threshold.global_operation.value = centrosome.threshold.TM_OTSU
+        module.threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
+        module.threshold.global_operation.value = centrosome.threshold.TM_OTSU
         module.run(workspace)
         m = workspace.measurements
         self.assertTrue(OUTPUT_OBJECTS_NAME in m.get_object_names())
@@ -1003,8 +1003,8 @@ IdentifySecondaryObjects:[module_num:1|svn_version:\'Unknown\'|variable_revision
         module.module_num = 1
         p.add_module(module)
         workspace = cellprofiler.workspace.Workspace(p, module, i_s, o_s, m, i_l)
-        module.apply_threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
-        module.apply_threshold.global_operation.value = centrosome.threshold.TM_OTSU
+        module.threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
+        module.threshold.global_operation.value = centrosome.threshold.TM_OTSU
         module.run(workspace)
         object_out = workspace.object_set.get_objects(OUTPUT_OBJECTS_NAME)
         self.assertTrue(numpy.all(object_out.segmented == 0))
@@ -1062,8 +1062,8 @@ IdentifySecondaryObjects:[module_num:1|svn_version:\'Unknown\'|variable_revision
         module.wants_discard_edge.value = True
         module.wants_discard_primary.value = True
         module.new_primary_objects_name.value = NEW_OBJECTS_NAME
-        module.apply_threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
-        module.apply_threshold.global_operation.value = centrosome.threshold.TM_OTSU
+        module.threshold.threshold_scope.value = cellprofiler.modules.identify.TS_GLOBAL
+        module.threshold.global_operation.value = centrosome.threshold.TM_OTSU
         module.module_num = 1
         p.add_module(module)
         workspace = cellprofiler.workspace.Workspace(p, module, i_s, o_s, m, i_l)
@@ -1122,9 +1122,9 @@ IdentifySecondaryObjects:[module_num:1|svn_version:\'Unknown\'|variable_revision
         module.y_name.value = OUTPUT_OBJECTS_NAME
         module.image_name.value = IMAGE_NAME
         module.method.value = cellprofiler.modules.identifysecondaryobjects.M_PROPAGATION
-        module.apply_threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
-        module.apply_threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
-        module.apply_threshold.manual_threshold.value = .5
+        module.threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
+        module.threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
+        module.threshold.manual_threshold.value = .5
         module.module_num = 1
         p.add_module(module)
         workspace = cellprofiler.workspace.Workspace(p, module, i_s, o_s, m, i_l)
@@ -1177,9 +1177,9 @@ IdentifySecondaryObjects:[module_num:1|svn_version:\'Unknown\'|variable_revision
         module.y_name.value = OUTPUT_OBJECTS_NAME
         module.image_name.value = IMAGE_NAME
         module.method.value = cellprofiler.modules.identifysecondaryobjects.M_PROPAGATION
-        module.apply_threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
-        module.apply_threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
-        module.apply_threshold.manual_threshold.value = .5
+        module.threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
+        module.threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
+        module.threshold.manual_threshold.value = .5
         module.module_num = 1
         p.add_module(module)
         workspace = cellprofiler.workspace.Workspace(p, module, i_s, o_s, m, i_l)
@@ -1210,9 +1210,9 @@ IdentifySecondaryObjects:[module_num:1|svn_version:\'Unknown\'|variable_revision
                     expected[2, 5] = 0
                 workspace, module = self.make_workspace(threshold * 0.5, labels)
                 self.assertTrue(isinstance(module, cellprofiler.modules.identifysecondaryobjects.IdentifySecondaryObjects))
-                module.apply_threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
-                module.apply_threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
-                module.apply_threshold.manual_threshold.value = 0.5
+                module.threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
+                module.threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
+                module.threshold.manual_threshold.value = 0.5
                 module.method.value = method
                 module.fill_holes.value = wants_fill_holes
                 module.distance_to_dilate.value = 10000
@@ -1247,9 +1247,9 @@ IdentifySecondaryObjects:[module_num:1|svn_version:\'Unknown\'|variable_revision
         labels[3:6, 3:6] = 1
         workspace, module = self.make_workspace(img, labels)
         module.method.value = cellprofiler.modules.identifysecondaryobjects.M_PROPAGATION
-        module.apply_threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
-        module.apply_threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
-        module.apply_threshold.manual_threshold.value = .25
+        module.threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
+        module.threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
+        module.threshold.manual_threshold.value = .25
         module.run(workspace)
         m = workspace.measurements
         self.assertTrue(isinstance(m, cellprofiler.measurement.Measurements))
@@ -1277,11 +1277,11 @@ IdentifySecondaryObjects:[module_num:1|svn_version:\'Unknown\'|variable_revision
             workspace, module = self.make_workspace(img, labels)
             self.assertTrue(isinstance(module, cellprofiler.modules.identifysecondaryobjects.IdentifySecondaryObjects))
             module.method.value = cellprofiler.modules.identifysecondaryobjects.M_PROPAGATION
-            module.apply_threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
-            module.apply_threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
+            module.threshold.threshold_scope.value = cellprofiler.modules.threshold.TS_GLOBAL
+            module.threshold.global_operation.value = cellprofiler.modules.threshold.TM_MANUAL
             module.wants_discard_edge.value = True
             module.wants_discard_primary.value = False
-            module.apply_threshold.manual_threshold.value = .25
+            module.threshold.manual_threshold.value = .25
             module.run(workspace)
             m = workspace.measurements
             self.assertTrue(isinstance(m, cellprofiler.measurement.Measurements))

--- a/tests/test_knime_bridge.py
+++ b/tests/test_knime_bridge.py
@@ -166,9 +166,9 @@ class TestKnimeBridge(unittest.TestCase):
         identify.module_num = 2
         identify.x_name.value = "Foo"
         identify.y_name.value = "dizzy"
-        identify.apply_threshold.threshold_scope.value = TS_GLOBAL
-        identify.apply_threshold.global_operation.value = TM_MANUAL
-        identify.apply_threshold.manual_threshold.value = .5
+        identify.threshold.threshold_scope.value = TS_GLOBAL
+        identify.threshold.global_operation.value = TM_MANUAL
+        identify.threshold.manual_threshold.value = .5
         identify.exclude_size.value = False
         pipeline.add_module(identify)
 
@@ -210,9 +210,9 @@ class TestKnimeBridge(unittest.TestCase):
         identify.module_num = 2
         identify.x_name.value = "Foo"
         identify.y_name.value = "dizzy"
-        identify.apply_threshold.threshold_scope.value = TS_GLOBAL
-        identify.apply_threshold.global_operation.value = TM_MANUAL
-        identify.apply_threshold.manual_threshold.value = .5
+        identify.threshold.threshold_scope.value = TS_GLOBAL
+        identify.threshold.global_operation.value = TM_MANUAL
+        identify.threshold.manual_threshold.value = .5
         identify.exclude_size.value = False
         pipeline.add_module(identify)
 
@@ -255,9 +255,9 @@ class TestKnimeBridge(unittest.TestCase):
         identify.use_advanced.value = True
         identify.x_name.value = "Foo"
         identify.y_name.value = "dizzy"
-        identify.apply_threshold.threshold_scope.value = TS_GLOBAL
-        identify.apply_threshold.global_operation.value = TM_MANUAL
-        identify.apply_threshold.manual_threshold.value = .5
+        identify.threshold.threshold_scope.value = TS_GLOBAL
+        identify.threshold.global_operation.value = TM_MANUAL
+        identify.threshold.manual_threshold.value = .5
         identify.exclude_size.value = False
         pipeline.add_module(identify)
 
@@ -317,9 +317,9 @@ class TestKnimeBridge(unittest.TestCase):
         identify.module_num = 2
         identify.x_name.value = "Foo"
         identify.y_name.value = "dizzy"
-        identify.apply_threshold.threshold_scope.value = TS_GLOBAL
-        identify.apply_threshold.global_operation.value = TM_MANUAL
-        identify.apply_threshold.manual_threshold.value = .5
+        identify.threshold.threshold_scope.value = TS_GLOBAL
+        identify.threshold.global_operation.value = TM_MANUAL
+        identify.threshold.manual_threshold.value = .5
         identify.exclude_size.value = False
         pipeline.add_module(identify)
 
@@ -366,9 +366,9 @@ class TestKnimeBridge(unittest.TestCase):
         identify.module_num = 2
         identify.x_name.value = "Foo"
         identify.y_name.value = "dizzy"
-        identify.apply_threshold.threshold_scope.value = TS_GLOBAL
-        identify.apply_threshold.global_operation.value = TM_MANUAL
-        identify.apply_threshold.manual_threshold.value = .5
+        identify.threshold.threshold_scope.value = TS_GLOBAL
+        identify.threshold.global_operation.value = TM_MANUAL
+        identify.threshold.manual_threshold.value = .5
         identify.exclude_size.value = False
         pipeline.add_module(identify)
 


### PR DESCRIPTION
Resolves #2814 

Verified on pipeline submitted with issue. Also verified functionality with other modules such as FilterObjects.

Correct measurement objects:
* https://github.com/CellProfiler/CellProfiler/blob/1cf1a96e5613294149fff94dc7adb897bddfb594/cellprofiler/modules/identifyprimaryobjects.py#L1426-L1432
* https://github.com/CellProfiler/CellProfiler/blob/1cf1a96e5613294149fff94dc7adb897bddfb594/cellprofiler/modules/identifysecondaryobjects.py#L908-L912