### PR TITLE
Documentation - ColorToGray

### DIFF
--- a/cellprofiler/modules/colortogray.py
+++ b/cellprofiler/modules/colortogray.py
@@ -4,14 +4,14 @@
 ColorToGray
 ===========
 
-**ColortoGray** converts an image with multiple color channels to a set
-of individual grayscale images.
+**ColortoGray** converts an image with multiple color channels to one or more
+grayscale images.
 
-This module converts RGB (Red, Green, Blue) color  and channel-stacked 
+This module converts color and channel-stacked 
 images to grayscale. All channels can be merged into one grayscale image 
 (*Combine*), or each channel can be extracted into a separate grayscale image
-(*Split*). If you use *Combine*, the relative weights will adjust the
-contribution of the colors relative to each other.
+(*Split*). If you use *Combine*, the relative weights you provide allow
+adjusting the contribution of the colors relative to each other.
 Note that all **Identify** modules require grayscale images.
 
 See also **GrayToColor**.
@@ -55,28 +55,29 @@ class ColorToGray(cpm.Module):
                 [COMBINE, SPLIT], doc='''\
 How do you want to convert the color image?
 
--  *%(SPLIT)s:* Splits the three channels (red, green, blue) of a color
-   image into three separate grayscale images.
--  *%(COMBINE)s* Converts a color image to a grayscale image by
-   combining the three channels (red, green, blue) together.''' % globals())
+-  *%(SPLIT)s:* Splits the channels of a color
+   image (e.g., red, green, blue) into separate grayscale images.
+-  *%(COMBINE)s:* Converts a color image to a grayscale image by
+   combining channels together (e.g., red, green, blue).''' % globals())
 
         self.rgb_or_channels = cps.Choice(
                 "Image type", [CH_RGB, CH_HSV, CH_CHANNELS], doc="""\
-Many images contain color channels other than red, green and blue. For
-instance, GIF and PNG formats can have an alpha channel that encodes
-transparency. TIF formats can have an arbitrary number of channels which
-represent pixel measurements made by different detectors, filters or
-lighting conditions. This setting provides three options to choose from:
+This setting provides three options to choose from:
 
--  *%(CH_RGB)s:* The RGB (red,green,blue) color space is the typical
+-  *%(CH_RGB)s:* The RGB (red, green, blue) color space is the typical
    model in which color images are stored. Choosing this option will
-   split the image into any of the red, green and blue component images.
--  *%(CH_HSV)s:*\ The HSV (hue, saturation, value) color space is based
-   on more intuitive color characteristics as tint, shade and tone.
-   Choosing this option will split the image into any of the hue,
+   split the image into red, green, and blue component images.
+-  *%(CH_HSV)s:* The HSV (hue, saturation, value) color space is based
+   on color characteristics such as tint, shade, and tone.
+   Choosing this option will split the image into the hue,
    saturation, and value component images.
--  *%(CH_CHANNELS)s:*\ This is a more complex model for images which
-   involve more than three channels.""" % globals())
+-  *%(CH_CHANNELS)s:* Many images contain color channels other than RGB
+   or HSV. For instance, GIF and PNG formats can have an alpha
+   channel that encodes transparency. TIF formats can have an arbitrary
+   number of channels which represent pixel measurements made by
+   different detectors, filters or lighting conditions. This setting
+   allows you to handle a more complex model for images that
+   have more than three channels.""" % globals())
 
         # The following settings are used for the combine option
         self.grayscale_name = cps.ImageNameProvider(
@@ -188,14 +189,15 @@ Enter a name for the resulting grayscale image coming from the value.""")
                 self.channel_names[len(self.channels) % len(self.channel_names)], doc="""\
 *(Used only when splitting images)*
 
-This setting chooses a channel to be processed. *Red: 1* is the first
+This setting chooses a channel to be processed. For example, *Red: 1*
+is the first
 channel in a .TIF or the red channel in a traditional image file.
 *Green: 2* and *Blue: 3* are the second and third channels of a TIF or
 the green and blue channels in other formats. *Alpha: 4* is the
 transparency channel for image formats that support transparency and is
 channel # 4 for a .TIF file. **ColorToGray** will fail to process an
 image if you select a channel that is not supported by that image, for
-example, “5” for a .PNG file"""))
+example, “5” for a three-channel .PNG file."""))
 
         group.append("contribution", cps.Float(
                 "Relative weight of the channel", 1, 0, doc='''\
@@ -207,7 +209,7 @@ other, increase or decrease the relative weights.'''))
 
         group.append("image_name", cps.ImageNameProvider(
                 "Image name", value="Channel%d" % (len(self.channels) + 1), doc="""\
-*(Used only when splitting images)*                
+*(Used only when combining images)*                
                 
 Select the name of the output grayscale image."""))
 

--- a/cellprofiler/modules/colortogray.py
+++ b/cellprofiler/modules/colortogray.py
@@ -117,7 +117,10 @@ other, increase or decrease the relative weights.''')
         self.use_red = cps.Binary('Convert red to gray?', True, doc="""\
 *(Used only when splitting RGB images)*
 
-Select *"%(YES)s"* to extract the red channel to grayscale.""" % globals())
+Select *"%(YES)s"* to extract the red channel to grayscale. Otherwise, the
+red channel will be ignored.
+""" % globals())
+
         self.red_name = cps.ImageNameProvider('Name the output image', "OrigRed", doc="""\
 *(Used only when splitting RGB images)*
 
@@ -126,7 +129,10 @@ Enter a name for the resulting grayscale image coming from the red channel.""")
         self.use_green = cps.Binary('Convert green to gray?', True, doc="""\
 *(Used only when splitting RGB images)*
 
-Select *"%(YES)s"* to extract the green channel to grayscale.""" % globals())
+Select *"%(YES)s"* to extract the green channel to grayscale. Otherwise, the
+green channel will be ignored.
+""" % globals())
+
         self.green_name = cps.ImageNameProvider('Name the output image', "OrigGreen", doc="""\
 *(Used only when splitting RGB images)*
 
@@ -135,7 +141,10 @@ Enter a name for the resulting grayscale image coming from the green channel."""
         self.use_blue = cps.Binary('Convert blue to gray?', True, doc="""\
 *(Used only when splitting RGB images)*
 
-Select *"%(YES)s"* to extract the blue channel to grayscale.""" % globals())
+Select *"%(YES)s"* to extract the blue channel to grayscale. Otherwise, the
+blue channel will be ignored.
+""" % globals())
+
         self.blue_name = cps.ImageNameProvider('Name the output image', "OrigBlue", doc="""\
 *(Used only when splitting RGB images)*
 
@@ -145,7 +154,10 @@ Enter a name for the resulting grayscale image coming from the blue channel.""")
         self.use_hue = cps.Binary('Convert hue to gray?', True, doc="""\
 *(Used only when splitting HSV images)*
 
-Select *"%(YES)s"* to extract the hue to grayscale.""" % globals())
+Select *"%(YES)s"* to extract the hue to grayscale. Otherwise, the hue
+will be ignored.
+""" % globals())
+
         self.hue_name = cps.ImageNameProvider('Name the output image', "OrigHue", doc="""\
 *(Used only when splitting HSV images)*
 
@@ -154,7 +166,10 @@ Enter a name for the resulting grayscale image coming from the hue.""")
         self.use_saturation = cps.Binary('Convert saturation to gray?', True, doc="""\
 *(Used only when splitting HSV images)*
 
-Select *"%(YES)s"* to extract the saturation to grayscale.""" % globals())
+Select *"%(YES)s"* to extract the saturation to grayscale. Otherwise, the
+saturation will be ignored.
+""" % globals())
+
         self.saturation_name = cps.ImageNameProvider('Name the output image', "OrigSaturation", doc="""\
 *(Used only when splitting HSV images)*
 
@@ -163,7 +178,10 @@ Enter a name for the resulting grayscale image coming from the saturation.""")
         self.use_value = cps.Binary('Convert value to gray?', True, doc="""\
 *(Used only when splitting HSV images)*
 
-Select *"%(YES)s"* to extract the value to grayscale.""" % globals())
+Select *"%(YES)s"* to extract the value to grayscale. Otherwise, the
+value will be ignored.
+""" % globals())
+
         self.value_name = cps.ImageNameProvider('Name the output image', "OrigValue", doc="""\
 *(Used only when splitting HSV images)*
 

--- a/cellprofiler/modules/colortogray.py
+++ b/cellprofiler/modules/colortogray.py
@@ -209,7 +209,7 @@ other, increase or decrease the relative weights.'''))
 
         group.append("image_name", cps.ImageNameProvider(
                 "Image name", value="Channel%d" % (len(self.channels) + 1), doc="""\
-*(Used only when combining images)*                
+*(Used only when splitting images)*                
                 
 Select the name of the output grayscale image."""))
 


### PR DESCRIPTION
Many changes are because it was likely originally written only for RGB and now handles other types.

I need two bits of help: 
1) pls check it's correct what I've changed from splitting -> combining
2) there are three similar settings like this: 
Select *"%(YES)s"* to extract the red channel to grayscale."""

My Q is: else what? Is it correct to add "Otherwise, the red channel will be (ignored?) (separated but stored as a color image?)" (if you know the answer please do make the change for red, green, and blue.