### PR TITLE
Hide file format setting on saving movies

### DIFF
--- a/cellprofiler/modules/saveimages.py
+++ b/cellprofiler/modules/saveimages.py
@@ -245,7 +245,7 @@ automatically.
             doc="""\
 *(Used only when saving non-movie files)*
 
-Select the image or movie format to save the image(s).
+Select the format to save the image(s).
 
 Only *{FF_TIFF}* supports saving as 16-bit or 32-bit. *{FF_TIFF}* is a
 "lossless" file format.
@@ -435,8 +435,10 @@ store images in the subfolder, "*date*\/*plate-name*".""")
             result.append(self.single_file_name)
         else:
             raise NotImplementedError("Unhandled file name method: %s" % self.file_name_method)
-        result.append(self.file_format)
-        supports_16_bit = (self.file_format == FF_TIFF and self.save_image_or_figure == IF_IMAGE)
+        if self.save_image_or_figure != IF_MOVIE:
+            result.append(self.file_format)
+        supports_16_bit = (self.file_format == FF_TIFF and self.save_image_or_figure == IF_IMAGE) or \
+                          self.save_image_or_figure == IF_MOVIE
         if supports_16_bit:
             # TIFF supports 8 & 16-bit, all others are written 8-bit
             result.append(self.bit_depth)


### PR DESCRIPTION
Resolves #3150 

The only supported file format for movies is TIFF. Remove the option to chose a file format when a movie is being saved.

![screen shot 2017-09-15 at 1 33 48 pm](https://user-images.githubusercontent.com/4721755/30495628-c3440488-9a1a-11e7-9fef-f31be18d610b.png)
