### PR TITLE
Documentation - CorrectIlluminationCalculate

### DIFF
--- a/cellprofiler/modules/correctilluminationcalculate.py
+++ b/cellprofiler/modules/correctilluminationcalculate.py
@@ -264,11 +264,11 @@ time-consuming process, but some methods are faster than others.
    median is less sensitive to outliers, although the results are also
    slightly less smooth and the fact that images are in the range of 0
    to 1 means that outliers typically will not dominate too strongly
-   anyway. The *%(GAUSSIAN_FILTER)s* convolves the image with a
+   anyway. The *%(SM_GAUSSIAN_FILTER)s* convolves the image with a
    Gaussian whose full width at half maximum is the artifact diameter
    entered. Its effect is to blur and obscure features smaller than the
    specified diameter and spread bright or dim features larger than the
-   specified diameter. The *%(MEDIAN_FILTER)s* finds the median pixel value within
+   specified diameter. The *%(SM_MEDIAN_FILTER)s* finds the median pixel value within
    the diameter you specify. It removes bright or dim features
    that are significantly smaller than the specified diameter.
 -  *%(SM_TO_AVERAGE)s:* A less commonly used option is to completely


### PR DESCRIPTION
1) The smoothing method setting said "See the **EnhanceOrSuppressFeatures** module help for more details. " That doesn't make sense to me, I assume it must've meant **Smooth**? Separately, I've made an issue to merge the settings documentation for smooth-related options within CorrecIllumCalc (#3194).
2) Can someone update the docs on Splines and Convex Hull... are they recommended, are they slow? Right now they are just described by pros/cons are not explained.
3) Note line ~321 I changed to FI_OBJECT_SIZE because I think it was wrong before, someone please confirm. Here is the context in case line numbers change: 

        self.object_width = cps.Integer(
            "Approximate object size", 10, doc="""\
*(Used only if %(FI_OBJECT_SIZE)s is selected for smoothing filter size calculation)*

Enter the approximate width of the artifacts to be smoothed, in pixels.