### PR TITLE
Documentation - ImageMath

### DIFF
--- a/cellprofiler/modules/imagemath.py
+++ b/cellprofiler/modules/imagemath.py
@@ -95,7 +95,7 @@ last, e.g., for “Divide”, (Image1 / Image2) / Image3
    first and second images.
 -  *%(O_MULTIPLY)s:* Multiplies the first image by the second.
 -  *%(O_DIVIDE)s:* Divides the first image by the second.
--  *%(O_AVERAGE)s* Calculates the mean intensity of the images loaded
+-  *%(O_AVERAGE)s:* Calculates the mean intensity of the images loaded
    in the module. This is equivalent to the Add option divided by the
    number of images loaded by this module. If you would like to average
    all of the images in an entire pipeline, i.e., across cycles, you
@@ -107,18 +107,18 @@ last, e.g., for “Divide”, (Image1 / Image2) / Image3
    pixel location.
 -  *%(O_INVERT)s:* Subtracts the image intensities from 1. This makes
    the darkest color the brightest and vice-versa.
--  *%(O_LOG_TRANSFORM)s* Log transforms each pixel’s intensity. The
+-  *%(O_LOG_TRANSFORM)s:* Log transforms each pixel’s intensity. The
    actual function is log\ :sub:`2`\ (image + 1), transforming values
    from 0 to 1 into values from 0 to 1.
--  *%(O_LOG_TRANSFORM_LEGACY)s* Log\ :sub:`2` transform for backwards
+-  *%(O_LOG_TRANSFORM_LEGACY)s:* Log\ :sub:`2` transform for backwards
    compatibility.
--  *%(O_NONE)s* This option is useful if you simply want to select some
+-  *%(O_NONE)s:* This option is useful if you simply want to select some
    of the later options in the module, such as adding, multiplying, or
    exponentiating your image by a constant.
 
 The following are operations that produce binary images. In a binary
-image, the foreground has a truth value of “true” and the background has
-a truth value of “false”. The operations, *%(O_OR)s, %(O_AND)s and
+image, the foreground has a truth value of “true” (ones) and the background has
+a truth value of “false” (zeros). The operations, *%(O_OR)s, %(O_AND)s and
 %(O_NOT)s* will convert the input images to binary by changing all zero
 values to background (false) and all other values to foreground (true).
 
@@ -141,15 +141,15 @@ single image.
 
         self.exponent = cellprofiler.setting.Float(
                 "Raise the power of the result by", 1, doc="""\
-Enter an exponent to raise the result to *after* the chosen operation""")
+Enter an exponent to raise the result to *after* the chosen operation.""")
 
         self.after_factor = cellprofiler.setting.Float(
                 "Multiply the result by", 1, doc="""\
-Enter a factor to multiply the result by *after* the chosen operation""")
+Enter a factor to multiply the result by *after* the chosen operation.""")
 
         self.addend = cellprofiler.setting.Float(
                 "Add to result", 0, doc="""\
-Enter a number to add to the result *after* the chosen operation""")
+Enter a number to add to the result *after* the chosen operation.""")
 
         self.truncate_low = cellprofiler.setting.Binary(
                 "Set values less than 0 equal to 0?", True, doc="""\
@@ -192,7 +192,7 @@ intensity of one image by another, choose *%(IM_IMAGE)s* for both and
 pick the respective images. To divide the intensity of an image by its
 median intensity, use **MeasureImageIntensity** prior to this module to
 calculate the median intensity, then select *%(IM_MEASUREMENT)s* and
-use the median intensity measurement as the denominator
+use the median intensity measurement as the denominator.
 """ % globals()))
 
         group.append("image_name", cellprofiler.setting.ImageNameSubscriber("Select the image", "", doc="""\
@@ -200,7 +200,7 @@ Select the image that you want to use for this operation."""))
 
         group.append("measurement", cellprofiler.setting.Measurement(
                 "Measurement", lambda: cellprofiler.measurement.IMAGE, "", doc="""\
-This is a measurement made on the image. The value of the
+Select a measurement made on the image. The value of the
 measurement is used for the operand for all of the pixels of the
 other operand's image."""))
 

--- a/cellprofiler/modules/imagemath.py
+++ b/cellprofiler/modules/imagemath.py
@@ -166,10 +166,9 @@ value of 1.
 
         self.ignore_mask = cellprofiler.setting.Binary(
                 "Ignore the image masks?", False, doc="""\
-Usually, the smallest mask of all image operands is applied after image
-math has been completed. Select *%(YES)s* to set equal to zero all
-previously masked pixels and operate on the masked images as if no mask
-had been applied.
+Select *%(YES)s* to set equal to zero all previously masked pixels and 
+operate on the masked images as if no mask had been applied. Otherwise, 
+the smallest image mask is applied after image math has been completed.
 """ % globals())
 
         self.output_image_name = cellprofiler.setting.ImageNameProvider(


### PR DESCRIPTION
I found the sentence "Usually, the smallest mask of all image operands is applied after image
math has been completed. " to be confusing in its context. If someone who understands it can adjust the text, that'd be great.