### PR TITLE
Documentation - EnhanceEdges

### DIFF
--- a/cellprofiler/modules/enhanceedges.py
+++ b/cellprofiler/modules/enhanceedges.py
@@ -7,7 +7,8 @@ EnhanceEdges
 **EnhanceEdges** enhances or identifies edges in an image, which can
 improve object identification or other downstream image processing.
 
-This module enhances the edges (gradients) in a grayscale image. All
+This module enhances the edges (gradients - places where pixel
+intensities change dramatically) in a grayscale image. All
 methods other than Canny produce a grayscale image that can be used in
 an **Identify** module or thresholded using the **Threshold**
 module to produce a binary (black/white) mask of edges. The Canny
@@ -50,10 +51,42 @@ class EnhanceEdges(cpm.Module):
 
     def create_settings(self):
         self.image_name = cps.ImageNameSubscriber(
-                "Select the input image", cps.NONE, doc='''What did you call the image in which you want to enhance the edges?''')
+                "Select the input image", cps.NONE, doc='''Select the image whose edges you want to enhance.''')
 
         self.output_image_name = cps.ImageNameProvider(
-                "Name the output image", "EdgedImage", doc='''What do you want to call the image with edges enhanced?''')
+                "Name the output image", "EdgedImage", doc='''Enter a name for the resulting image with edges enhanced.''')
+
+        self.method = cps.Choice(
+                "Select an edge-finding method",
+                [M_SOBEL, M_PREWITT, M_ROBERTS, M_LOG, M_CANNY, M_KIRSCH], doc='''\
+There are several methods that can be used to enhance edges. Often, it
+is best to test them against each other empirically:
+
+-  *%(M_SOBEL)s:* Finds edges using the %(M_SOBEL)s approximation to
+   the derivative. The %(M_SOBEL)s method derives a horizontal and
+   vertical gradient measure and returns the square-root of the sum of
+   the two squared signals.
+-  *%(M_PREWITT)s:* Finds edges using the %(M_PREWITT)s approximation
+   to the derivative. It returns edges at those points where the
+   gradient of the image is maximum.
+-  *%(M_ROBERTS)s:* Finds edges using the Roberts approximation to the
+   derivative. The %(M_ROBERTS)s method looks for gradients in the
+   diagonal and anti-diagonal directions and returns the square-root of
+   the sum of the two squared signals. This method is fast, but it
+   creates diagonal artifacts that may need to be removed by smoothing.
+-  *%(M_LOG)s:* Applies a Laplacian of Gaussian filter to the image and
+   finds zero crossings.
+-  *%(M_CANNY)s:* Finds edges by looking for local maxima of the
+   gradient of the image. The gradient is calculated using the
+   derivative of a Gaussian filter. The method uses two thresholds to
+   detect strong and weak edges, and includes the weak edges in the
+   output only if they are connected to strong edges. This method is
+   therefore less likely than the others to be fooled by noise, and more
+   likely to detect true weak edges.
+-  *%(M_KIRSCH)s:* Finds edges by calculating the gradient among the 8
+   compass points (North, North-east, etc.) and selecting the maximum as
+   the pixel’s value.
+''' % globals())
 
         self.wants_automatic_threshold = cps.Binary(
                 "Automatically calculate the threshold?", True, doc='''\
@@ -82,39 +115,7 @@ between 0 and 1.
 This threshold adjustment factor is a multiplier that is applied to both
 the lower and upper Canny thresholds if they are calculated
 automatically. An adjustment factor of 1 indicates no adjustment. The
-adjustment factor has no effect on any threshhold entered manually
-entered.
-''' % globals())
-
-        self.method = cps.Choice(
-                "Select an edge-finding method",
-                [M_SOBEL, M_PREWITT, M_ROBERTS, M_LOG, M_CANNY, M_KIRSCH], doc='''\
-There are several methods that can be used to enhance edges:
-
--  *%(M_SOBEL)s:* Finds edges using the %(M_SOBEL)s approximation to
-   the derivative. The %(M_SOBEL)s method derives a horizontal and
-   vertical gradient measure and returns the square-root of the sum of
-   the two squared signals.
--  *%(M_PREWITT)s:* Finds edges using the %(M_PREWITT)s approximation
-   to the derivative. It returns edges at those points where the
-   gradient of the image is maximum.
--  *%(M_ROBERTS)s:* Finds edges using the Roberts approximation to the
-   derivative. The %(M_ROBERTS)s method looks for gradients in the
-   diagonal and anti-diagonal directions and returns the square-root of
-   the sum of the two squared signals. This method is fast, but it
-   creates diagonal artifacts that may need to be removed by smoothing.
--  *%(M_LOG)s:* Applies a Laplacian of Gaussian filter to the image and
-   finds zero crossings.
--  *%(M_CANNY)s:* Finds edges by looking for local maxima of the
-   gradient of the image. The gradient is calculated using the
-   derivative of a Gaussian filter. The method uses two thresholds to
-   detect strong and weak edges, and includes the weak edges in the
-   output only if they are connected to strong edges. This method is
-   therefore less likely than the others to be fooled by noise, and more
-   likely to detect true weak edges.
--  *%(M_KIRSCH)s:* Finds edges by calculating the gradient among the 8
-   compass points (North, North-east, etc.) and selecting the maximum as
-   the pixel’s value.
+adjustment factor has no effect on any threshhold entered manually.
 ''' % globals())
 
         self.direction = cps.Choice(
@@ -122,7 +123,7 @@ There are several methods that can be used to enhance edges:
                 [E_ALL, E_HORIZONTAL, E_VERTICAL], doc='''\
 *(Used only with "%(M_PREWITT)s" and "%(M_SOBEL)s" methods)*
 
-The direction of the edges are you are identifying in the image
+Select the direction of the edges you aim to identify in the image
 (predominantly horizontal, predominantly vertical, or both).
 ''' % globals())
 
@@ -132,7 +133,7 @@ Select *%(YES)s* to automatically calculate the Gaussian's sigma.
 Select *%(NO)s* to manually enter the value.
 """ % globals())
 
-        self.sigma = cps.Float("Gaussian's sigma value", 10, doc="""Set a value for Gaussian's sigma""")
+        self.sigma = cps.Float("Gaussian's sigma value", 10, doc="""Set a value for Gaussian's sigma.""")
 
         self.wants_automatic_low_threshold = cps.Binary(
                 "Calculate value for low threshold automatically?", True, doc="""\


### PR DESCRIPTION
Is it possible to move settings to be this order in the help? 
Select the input (already first)
Name the output (already second)
Select an edge-finding method (ought to be third, right now a few settings are shown that are specific to dift methods so it's a little confusing)

I did so but feel free to revert if it causes problems.