### PR TITLE
Display segmentations with missing/skipped labels.

### DIFF
--- a/cellprofiler/gui/figure.py
+++ b/cellprofiler/gui/figure.py
@@ -1494,7 +1494,9 @@ class Figure(wx.Frame):
             sharex=None,
             sharey=None,
             use_imshow=False,
-            background_image=None
+            background_image=None,
+            max_label=None,
+            seed=None
     ):
         """
         Show a labels matrix using the default color map
@@ -1509,6 +1511,10 @@ class Figure(wx.Frame):
         :param use_imshow: use matplotlib's imshow to display, instead of creating our own artist
         :param dimensions: dimensions of the data to display (2 or 3)
         :param background_image: a base image to overlay label data on, or None for blank
+        :param max_label: set the maximum label in the segmentation, or None to use the segmentation's maximum label
+                          (useful for generating consistent label colors in displays with varying # of objects)
+        :param seed: shuffle label colors with this seed, or None for completely random (useful for generating
+                     consistent label colors in multiple displays)
         :return:
         """
         if background_image is None:
@@ -1520,7 +1526,9 @@ class Figure(wx.Frame):
         label_image = cellprofiler.object.overlay_labels(
             labels=image,
             opacity=opacity,
-            pixel_data=background_image
+            pixel_data=background_image,
+            max_label=max_label,
+            seed=seed
         )
 
         return self.subplot_imshow(

--- a/cellprofiler/modules/relateobjects.py
+++ b/cellprofiler/modules/relateobjects.py
@@ -402,12 +402,21 @@ parents or children of the parent object."""
 
         parent_labeled_children[mask] = mapping[parents_of[child_labels[mask] - 1]]
 
+        max_label = max(
+            parent_labels.max(),
+            child_labels.max(),
+            parent_labeled_children.max()
+        )
+
+        seed = numpy.random.randint(256)
+
         figure.subplot_imshow_labels(
             0,
             0,
             parent_labels,
-            title=self.x_name.value
-
+            title=self.x_name.value,
+            max_label=max_label,
+            seed=seed
         )
 
         figure.subplot_imshow_labels(
@@ -415,15 +424,19 @@ parents or children of the parent object."""
             0,
             child_labels,
             title=self.y_name.value,
-            sharexy=figure.subplot(0, 0)
+            sharexy=figure.subplot(0, 0),
+            max_label=max_label,
+            seed=seed
         )
 
         figure.subplot_imshow_labels(
             0,
             1,
             parent_labeled_children,
-            "{} labeled by {}".format(self.y_name.value, self.x_name.value),
-            sharexy=figure.subplot(0, 0)
+            title="{} labeled by {}".format(self.y_name.value, self.x_name.value),
+            sharexy=figure.subplot(0, 0),
+            max_label=max_label,
+            seed=seed
         )
 
     def get_parent_names(self):

--- a/cellprofiler/object.py
+++ b/cellprofiler/object.py
@@ -953,8 +953,8 @@ def size_similarly(labels, secondary):
     return result, mask
 
 
-def overlay_labels(pixel_data, labels, opacity=0.7):
-    colors = _colors(labels)
+def overlay_labels(pixel_data, labels, opacity=0.7, max_label=None, seed=None):
+    colors = _colors(labels, max_label=max_label, seed=seed)
 
     if labels.ndim == 3:
         overlay = numpy.zeros(labels.shape + (3,), dtype=numpy.float32)
@@ -986,17 +986,19 @@ def overlay_labels(pixel_data, labels, opacity=0.7):
     )
 
 
-def _colors(labels):
-    unique_labels = numpy.unique(labels)
-
-    if unique_labels[0] == 0:
-        unique_labels = unique_labels[1:]
-
+def _colors(labels, max_label=None, seed=None):
     mappable = matplotlib.cm.ScalarMappable(
         cmap=matplotlib.cm.get_cmap(cellprofiler.preferences.get_default_colormap())
     )
 
-    colors = mappable.to_rgba(unique_labels)[:, :3]
+    colors = mappable.to_rgba(
+        numpy.arange(labels.max() if max_label is None else max_label)
+    )[:, :3]
+
+    if seed is not None:
+        # Resetting the random seed helps keep object label colors consistent in displays
+        # where consistency is important, like RelateObjects.
+        numpy.random.seed(seed)
 
     numpy.random.shuffle(colors)
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -905,6 +905,24 @@ class TestCropLabelsAndImage(unittest.TestCase):
         assert not numpy.all(overlay_region_1[0, 0, 0] == overlay_region_3[0, 0, 0])
         assert not numpy.all(overlay_region_2[0, 0, 0] == overlay_region_3[0, 0, 0])
 
+    # https://github.com/CellProfiler/CellProfiler/issues/3268
+    def test_overlay_objects_empty_label(self):
+        data = numpy.zeros((9, 9, 9))
+
+        labels = numpy.zeros_like(data, dtype=numpy.uint8)
+        labels[:3, :3, :3] = 1
+        labels[-3:, -3:, -3:] = 3
+
+        overlay_pixel_data = cpo.overlay_labels(pixel_data=data, labels=labels)
+
+        overlay_region_1 = overlay_pixel_data[:3, :3, :3]
+        assert numpy.all(overlay_region_1 == overlay_region_1[0, 0, 0])
+
+        overlay_region_3 = overlay_pixel_data[-3:, -3:, -3:]
+        assert numpy.all(overlay_region_3 == overlay_region_3[0, 0, 0])
+
+        assert not numpy.all(overlay_region_1[0, 0, 0] == overlay_region_3[0, 0, 0])
+
 
 class TestSizeSimilarly(unittest.TestCase):
     def test_01_01_size_same(self):


### PR DESCRIPTION
Resolves #3268 

Add options to `subplot_imshow_labels` to generate up to a `max_label` number of colors, and shuffle them according to `seed`.

![screen shot 2017-09-20 at 2 22 03 pm](https://user-images.githubusercontent.com/4721755/30661275-79cb39c0-9e11-11e7-8f45-65d5922dd2d1.png)
