### PR TITLE
Documentation - Tile

### DIFF
--- a/cellprofiler/modules/tile.py
+++ b/cellprofiler/modules/tile.py
@@ -21,12 +21,9 @@ avoided by the following suggestions:
 -  Resize the images to a fraction of their original size, using the
    **Resize** module prior to this module in the pipeline.
 -  Rescale the images to 8-bit using the **RescaleIntensity** module,
-   which diminished image quality by decreasing the number of graylevels
+   which diminishes image quality by decreasing the number of graylevels
    in the image (that is, bit depth) but also decreases the size of the
    image.
--  Place this module prior to the **Tile** module (and maybe also
-   afterwards) and set it to retain only those images that are needed
-   for downstream modules.
 
 Please also note that this module does not perform *image stitching*
 (i.e., intelligent adjustment of the alignment between adjacent images).
@@ -104,7 +101,7 @@ class Tile(cpm.Module):
         self.input_image = cps.ImageNameSubscriber(
                 "Select an input image",
                 cps.NONE, doc="""Select the image to be tiled. Additional images within the cycle can be
-added later by choosing the "*%(T_ACROSS_CYCLES)s*"option below.
+added later by choosing the "*%(T_ACROSS_CYCLES)s*" option below.
 """ % globals())
 
         self.output_image = cps.ImageNameProvider(
@@ -119,7 +116,7 @@ added later by choosing the "*%(T_ACROSS_CYCLES)s*"option below.
                 "Tile assembly method",
                 T_ALL, doc='''\
 This setting controls the method by which the final tiled image is
-asembled:
+assembled:
 
 -  *%(T_WITHIN_CYCLES)s:* If you have loaded more than one image for
    each cycle using modules upstream in the pipeline, the images can be
@@ -171,8 +168,8 @@ left-hand corner for a typical multi-well plate format where the first image is 
 ''')
 
         self.tile_style = cps.Choice(
-                "Direction to begin tiling", S_ALL, doc='''This setting specifies the order that the images are to be arranged. If
-your images are named A01, A02, etc, enter *%(S_ROW)s*".
+                "Direction to begin tiling", S_ALL, doc='''This setting specifies the order that the images are to be arranged. For example, if
+your images are named A01, A02, etc, enter "*%(S_ROW)s*".
 ''' % globals())
 
         self.meander = cps.Binary(


### PR DESCRIPTION
FYI, I removed these lines (in the section on how to handle memory problems) which were pretty bizarre. I *think* it made sense if you replace "this module" with "SpeedUpCellProfiler", a module that cleared images from CP's memory. But I've no idea why someone would have replaced that module's name with "this module", and anyhow SpeedUpCellProfiler is no more. 
"-  Place this module prior to the **Tile** module (and maybe also
   afterwards) and set it to retain only those images that are needed
   for downstream modules."

I dunno why there is a vertical bar at line 46 so I left it.