### PR TITLE
Restore help manual GUI link.

### DIFF
--- a/cellprofiler/gui/help/menu.py
+++ b/cellprofiler/gui/help/menu.py
@@ -18,11 +18,10 @@ class Menu(cellprofiler.gui.menu.Menu):
             event_fn=lambda _: self.frame.show_welcome_screen(True)
         )
 
-        # TODO: Requires updated online help manual
-        # self.append(
-        #     "Online Manual",
-        #     event_fn=self.__on_help_online_manual
-        # )
+        self.append(
+            "Online Manual",
+            event_fn=self.__on_help_online_manual
+        )
 
         self.AppendSeparator()
 
@@ -185,10 +184,17 @@ class Menu(cellprofiler.gui.menu.Menu):
         import webbrowser
         webbrowser.open("https://github.com/CellProfiler/CellProfiler/wiki")
 
-    # @staticmethod
-    # def __on_help_online_manual(event):
-    #     import webbrowser
-    #     webbrowser.open("http://d1zymp9ayga15t.cloudfront.net/CPmanual/index.html")
+    @staticmethod
+    def __on_help_online_manual(event):
+        import requests
+        import webbrowser
+
+        url = "http://cellprofiler.readthedocs.io/en/v{}/".format(cellprofiler.__version__)
+
+        if requests.get(url).ok:
+            webbrowser.open(url)
+        else:
+            webbrowser.open("http://cellprofiler.readthedocs.io/en/latest")
 
     @staticmethod
     def __on_help_source_code():
@@ -218,7 +224,7 @@ class Menu(cellprofiler.gui.menu.Menu):
             "Accessing Images From OMERO",
             contents=cellprofiler.gui.help.content.read_content("other_omero.rst")
         )
-        
+
         other_menu.append(
             "Using Plugins",
             contents=cellprofiler.gui.help.content.read_content("other_plugins.rst")

--- a/cellprofiler/gui/help/menu.py
+++ b/cellprofiler/gui/help/menu.py
@@ -1,5 +1,9 @@
 # coding:utf-8
 
+import webbrowser
+
+import requests
+
 import cellprofiler.gui.help.content
 import cellprofiler.gui.help.search
 import cellprofiler.gui.htmldialog
@@ -181,14 +185,10 @@ class Menu(cellprofiler.gui.menu.Menu):
 
     @staticmethod
     def __on_help_developers_guide():
-        import webbrowser
         webbrowser.open("https://github.com/CellProfiler/CellProfiler/wiki")
 
     @staticmethod
     def __on_help_online_manual(event):
-        import requests
-        import webbrowser
-
         url = "http://cellprofiler.readthedocs.io/en/v{}/".format(cellprofiler.__version__)
 
         if requests.get(url).ok:
@@ -198,7 +198,6 @@ class Menu(cellprofiler.gui.menu.Menu):
 
     @staticmethod
     def __on_help_source_code():
-        import webbrowser
         webbrowser.open("https://github.com/CellProfiler/CellProfiler")
 
     def __on_search_help(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+--index-url https://pypi.python.org/simple/
+
+--editable .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
---index-url https://pypi.python.org/simple/
-
 --editable .


### PR DESCRIPTION
Resolves #3296 

I've published the [CellProfiler manual on RTD](http://cellprofiler.readthedocs.io/en/latest/) and enabled a webhook to automatically build the latest documentation whenever there's a change to CellProfiler (we can configure this, if this seems too aggressive). 

This PR re-enables the GUI's Help > Online Manual. It's configured such that is tries to access a version of the documentation matching the running CellProfiler version (e.g., "v3.0.0"). If that fails, it defaults to "latest". I handle the logic here since it doesn't seem configurable in RTD.

There's only one manual step (which I'd love to figure out whether or not it can be automated). When a new version is tagged/released, RTD will update "latest" but it won't automatically make the tagged version available (e.g., "v3.0.0"). You have to [manually activate the newly published version](https://readthedocs.org/dashboard/cellprofiler/versions/). Anyone with a RTD account who is a maintainer can activate and deactivate versions. (@0x00b1 let's get you added and update the release process instructions with this step.)

**Note:** The published documentation is partially broken right now, because it's missing the `requirements.txt` file added by this PR. The "latest" documentation should build fine once this is merged.