### PR TITLE
Install matplotlib 2+, excluding 2.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setuptools.setup(
         "javabridge",
         "joblib",
         "mahotas",
-        "matplotlib",
+        "matplotlib>=2.0.0, !=2.1.0",
         "MySQL-python",
         "numpy",
         "prokaryote==2.3.1",


### PR DESCRIPTION
Resolves #3355
Resolves #3356

Matplotlib 2.1.0 contains at least two bugs which cause CellProfiler tests to fail. These bugs have been fixed in Matplotlib (see comments in resolved issues) and should be released in a later version. In the meantime, require versions 2.0.0+ but exclude 2.1.0.