### PR TITLE
Add /data as additional package data for pip installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setuptools.setup(
     license="BSD",
     name="CellProfiler",
     package_data={
-        "cellprofiler": ['data/**/*']
+        "cellprofiler": os.path.join("data", "**", "*")
     },
     include_package_data=True,
     packages=setuptools.find_packages(exclude=[

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setuptools.setup(
     license="BSD",
     name="CellProfiler",
     package_data={
-        "cellprofiler": ['data/*']
+        "cellprofiler": ['data/**/*']
     },
     include_package_data=True,
     packages=setuptools.find_packages(exclude=[

--- a/setup.py
+++ b/setup.py
@@ -73,8 +73,9 @@ setuptools.setup(
     license="BSD",
     name="CellProfiler",
     package_data={
-        "images": glob.glob(os.path.join("data", "**", "*"))
+        "cellprofiler": ['data/*']
     },
+    include_package_data=True,
     packages=setuptools.find_packages(exclude=[
         "tests*"
     ]),


### PR DESCRIPTION
I've explicitly added the `data` directory to `setup.py` to allow it to be installed as a binary package, rather than just in editable mode. I also removed an unused package_data group that referenced the package `images` which did not exist. 

#3375 