### PR TITLE
Issues/3375

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setuptools.setup(
     license="BSD",
     name="CellProfiler",
     package_data={
-        "cellprofiler": ['data/**/*']
+        "cellprofiler": os.path.join("data", "**", "*")
     },
     include_package_data=True,
     packages=setuptools.find_packages(exclude=[

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setuptools.setup(
     license="BSD",
     name="CellProfiler",
     package_data={
-        "cellprofiler": ['data/*']
+        "cellprofiler": ['data/**/*']
     },
     include_package_data=True,
     packages=setuptools.find_packages(exclude=[

--- a/setup.py
+++ b/setup.py
@@ -73,8 +73,9 @@ setuptools.setup(
     license="BSD",
     name="CellProfiler",
     package_data={
-        "images": glob.glob(os.path.join("data", "**", "*"))
+        "cellprofiler": ['data/*']
     },
+    include_package_data=True,
     packages=setuptools.find_packages(exclude=[
         "tests*"
     ]),

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setuptools.setup(
     license="BSD",
     name="CellProfiler",
     package_data={
-        "cellprofiler": os.path.join("data", "**", "*")
+        "cellprofiler": [os.path.join("data", "**", "*")]
     },
     include_package_data=True,
     packages=setuptools.find_packages(exclude=[


### PR DESCRIPTION
As it turns out, `python setup.py install` requires a list rather than a single expression. 

> The value must be a mapping from package name to a list of relative path names that should be copied into the package. 

From: https://docs.python.org/2/distutils/setupscript.html
This ensures that the files are picked up by both `pip install .` and `python setup.py install`, which enables the module to be installed from git via `pip install git+https://github.com/CellProfiler/CellProfiler.git@master` and grab the `/data` files properly. 

I don't think I can request reviewers, but @0x00b1 please take a look if you can!