### PR TITLE
Fix help search 

### DIFF
--- a/cellprofiler/data/help/why_use_cellprofiler.rst
+++ b/cellprofiler/data/help/why_use_cellprofiler.rst
@@ -1,4 +1,6 @@
 :orphan:
+Why Use CellProfiler?
+=====================
 
 Most laboratories studying biological processes and human disease use
 light/fluorescence microscopes to image cells and other biological

--- a/cellprofiler/gui/help/search.py
+++ b/cellprofiler/gui/help/search.py
@@ -273,6 +273,11 @@ def search_module_help(text):
 
         start_match = re.search(r"<\s*body[^>]*?>", help_text, re.IGNORECASE)
 
+        # Some pages don't have in-line titles
+        # Not matching "<h1>" here for cases that have "<h1 class='title'>", etc.
+        if not help_text.startswith(u"<h1"):
+            body += u"<h1>{}</h1>".format(title)
+
         if start_match is None:
             start = 0
         else:

--- a/cellprofiler/gui/help/search.py
+++ b/cellprofiler/gui/help/search.py
@@ -262,10 +262,7 @@ def search_module_help(text):
 
     match_num = 1
 
-    prev_link = u"""\
-<a href="#match%d" title="Previous match">
-    <img alt="previous match" src=memory:previous.png">
-</a>"""
+    prev_link = u"""<a href="#match%d" title="Previous match"><img alt="previous match" src="memory:previous.png"></a>"""
 
     anchor = u"""<a name="match%d"><u>%s</u></a>"""
 

--- a/cellprofiler/gui/help/search.py
+++ b/cellprofiler/gui/help/search.py
@@ -249,7 +249,7 @@ def search_module_help(text):
     <title>{count} match{es} found</title>
 </head>
 <body>
-    <h1>Match{es} found</h1><br>
+    <h1>Match{es} found ({count} total)</h1><br>
     <ul></ul>
 </body>
 </html>

--- a/cellprofiler/gui/help/search.py
+++ b/cellprofiler/gui/help/search.py
@@ -271,9 +271,6 @@ def search_module_help(text):
     for title, help_text, pairs in matching_help:
         top += u"""<li><a href="#match{:d}">{}</a></li>\n""".format(match_num, title)
 
-        if help_text.find("<h1>") == -1:
-            body += u"<h1>{}</h1>".format(title)
-
         start_match = re.search(r"<\s*body[^>]*?>", help_text, re.IGNORECASE)
 
         if start_match is None:

--- a/cellprofiler/modules/measureobjectintensitydistribution.py
+++ b/cellprofiler/modules/measureobjectintensitydistribution.py
@@ -1,6 +1,10 @@
 # coding=utf-8
 
-"""
+import _help
+MeasureObjectIntensityDistribution_Magnitude_Phase = _help.__image_resource('MeasureObjectIntensityDistribution_Magnitude_Phase.png')
+MeasureObjectIntensityDistribution_Edges_Centers = _help.__image_resource('MeasureObjectIntensityDistribution_Edges_Centers.png')
+
+__doc__ = """
 MeasureObjectIntensityDistribution
 ==================================
 
@@ -58,31 +62,10 @@ Measurements made by this module
 .. |MeasureObjectIntensityDistribution_image0| image:: {MeasureObjectIntensityDistribution_Magnitude_Phase}
 .. |MeasureObjectIntensityDistribution_image1| image:: {MeasureObjectIntensityDistribution_Edges_Centers}
 
-"""
-
-import os
-import pkg_resources
-
-
-def __image_resource(filename):
-    #If you're rendering in the GUI, relative paths are fine
-    if os.path.relpath(pkg_resources.resource_filename(
-        "cellprofiler",
-        os.path.join("data", "images", filename)
-    )) == os.path.join("cellprofiler","data", "images", filename):
-        return os.path.relpath(pkg_resources.resource_filename(
-            "cellprofiler",
-            os.path.join("data", "images", filename)
-        ))
-    else:
-    #If you're rendering in sphinx, the relative path of the rst file is one below the make file so compensate accordingly
-        return os.path.join('..',os.path.relpath(pkg_resources.resource_filename(
-            "cellprofiler",
-            os.path.join("data", "images", filename)
-        )))
-
-MeasureObjectIntensityDistribution_Magnitude_Phase = __image_resource('MeasureObjectIntensityDistribution_Magnitude_Phase.png')
-MeasureObjectIntensityDistribution_Edges_Centers = __image_resource('MeasureObjectIntensityDistribution_Edges_Centers.png')
+""".format(**{
+    "MeasureObjectIntensityDistribution_Magnitude_Phase": MeasureObjectIntensityDistribution_Magnitude_Phase,
+    "MeasureObjectIntensityDistribution_Edges_Centers": MeasureObjectIntensityDistribution_Edges_Centers
+})
 
 import centrosome.cpmorphology
 import centrosome.propagate
@@ -164,10 +147,6 @@ MEASUREMENT_ALIASES = {
 
 
 class MeasureObjectIntensityDistribution(cellprofiler.module.Module):
-    __doc__ = __doc__.format(**{
-        "MeasureObjectIntensityDistribution_Magnitude_Phase": MeasureObjectIntensityDistribution_Magnitude_Phase,
-        "MeasureObjectIntensityDistribution_Edges_Centers": MeasureObjectIntensityDistribution_Edges_Centers
-    })
     module_name = "MeasureObjectIntensityDistribution"
     category = "Measurement"
     variable_revision_number = 5

--- a/cellprofiler/modules/measureobjectintensitydistribution.py
+++ b/cellprofiler/modules/measureobjectintensitydistribution.py
@@ -1,29 +1,5 @@
 # coding=utf-8
 
-import os
-
-import pkg_resources
-
-def __image_resource(filename):
-    #If you're rendering in the GUI, relative paths are fine
-    if os.path.relpath(pkg_resources.resource_filename(
-        "cellprofiler",
-        os.path.join("data", "images", filename)
-    )) == os.path.join("cellprofiler","data", "images", filename):
-        return os.path.relpath(pkg_resources.resource_filename(
-            "cellprofiler",
-            os.path.join("data", "images", filename)
-        ))
-    else:
-    #If you're rendering in sphinx, the relative path of the rst file is one below the make file so compensate accordingly
-        return os.path.join('..',os.path.relpath(pkg_resources.resource_filename(
-            "cellprofiler",
-            os.path.join("data", "images", filename)
-        )))
-
-MeasureObjectIntensityDistribution_Magnitude_Phase = __image_resource('MeasureObjectIntensityDistribution_Magnitude_Phase.png')
-MeasureObjectIntensityDistribution_Edges_Centers = __image_resource('MeasureObjectIntensityDistribution_Edges_Centers.png')
-
 """
 MeasureObjectIntensityDistribution
 ==================================
@@ -82,10 +58,31 @@ Measurements made by this module
 .. |MeasureObjectIntensityDistribution_image0| image:: {MeasureObjectIntensityDistribution_Magnitude_Phase}
 .. |MeasureObjectIntensityDistribution_image1| image:: {MeasureObjectIntensityDistribution_Edges_Centers}
 
-""".format(**{
-                "MeasureObjectIntensityDistribution_Magnitude_Phase":MeasureObjectIntensityDistribution_Magnitude_Phase,
-                "MeasureObjectIntensityDistribution_Edges_Centers":MeasureObjectIntensityDistribution_Edges_Centers
-})
+"""
+
+import os
+import pkg_resources
+
+
+def __image_resource(filename):
+    #If you're rendering in the GUI, relative paths are fine
+    if os.path.relpath(pkg_resources.resource_filename(
+        "cellprofiler",
+        os.path.join("data", "images", filename)
+    )) == os.path.join("cellprofiler","data", "images", filename):
+        return os.path.relpath(pkg_resources.resource_filename(
+            "cellprofiler",
+            os.path.join("data", "images", filename)
+        ))
+    else:
+    #If you're rendering in sphinx, the relative path of the rst file is one below the make file so compensate accordingly
+        return os.path.join('..',os.path.relpath(pkg_resources.resource_filename(
+            "cellprofiler",
+            os.path.join("data", "images", filename)
+        )))
+
+MeasureObjectIntensityDistribution_Magnitude_Phase = __image_resource('MeasureObjectIntensityDistribution_Magnitude_Phase.png')
+MeasureObjectIntensityDistribution_Edges_Centers = __image_resource('MeasureObjectIntensityDistribution_Edges_Centers.png')
 
 import centrosome.cpmorphology
 import centrosome.propagate
@@ -167,6 +164,10 @@ MEASUREMENT_ALIASES = {
 
 
 class MeasureObjectIntensityDistribution(cellprofiler.module.Module):
+    __doc__ = __doc__.format(**{
+        "MeasureObjectIntensityDistribution_Magnitude_Phase": MeasureObjectIntensityDistribution_Magnitude_Phase,
+        "MeasureObjectIntensityDistribution_Edges_Centers": MeasureObjectIntensityDistribution_Edges_Centers
+    })
     module_name = "MeasureObjectIntensityDistribution"
     category = "Measurement"
     variable_revision_number = 5


### PR DESCRIPTION
Addresses #3407. Fixing this issue actually exposed a number of other issues, namely:

- `previous.png` (previous match arrow) wasn't displaying properly
- There was extra whitespace between the previous text arrow and the match term
- The first match title was duplicated
- No indication of count was actually displayed (it was only present in the title)