### PR TITLE
Read TIF stacks with skimage.external.tifffile

### DIFF
--- a/cellprofiler/modules/loadimages.py
+++ b/cellprofiler/modules/loadimages.py
@@ -110,7 +110,7 @@ from cellprofiler.measurement import \
     C_FILE_NAME, C_PATH_NAME, C_URL, C_OBJECTS_FILE_NAME, C_OBJECTS_PATH_NAME, \
     C_OBJECTS_URL
 import numpy
-import skimage.io
+import skimage.external.tifffile
 
 '''STK TIFF Tag UIC1 - for MetaMorph internal use'''
 UIC1_TAG = 33628
@@ -3371,7 +3371,7 @@ class LoadImagesImageProvider(LoadImagesImageProviderBase):
         if self.is_numpy_file():
             data = np.load(pathname)
         else:
-            data = skimage.io.imread(pathname)
+            data = skimage.external.tifffile.imread(pathname)
 
         # https://github.com/CellProfiler/python-bioformats/blob/855f2fb7807f00ef41e6d169178b7f3d22530b79/bioformats/formatreader.py#L768-L791
         if data.dtype in [numpy.int8, numpy.uint8]:

--- a/tests/modules/test_loadimages.py
+++ b/tests/modules/test_loadimages.py
@@ -3910,6 +3910,29 @@ class TestLoadImagesImageProviderURL(unittest.TestCase):
 
         self.assertTrue(np.all(expected == image.pixel_data))
 
+    def test_provide_volume_3_planes(self):
+        data = np.random.rand(3, 256, 256)
+
+        path = tempfile.NamedTemporaryFile(suffix=".tif", delete=False).name
+
+        name = os.path.splitext(os.path.basename(path))[0]
+
+        provider = LI.LoadImagesImageProviderURL(
+            name=name,
+            url="file:/" + path,
+            volume=True,
+            spacing=(0.3, 0.7, 0.7)
+        )
+
+        try:
+            skimage.io.imsave(path, data)
+
+            image = provider.provide_image(None)
+        finally:
+            os.unlink(path)
+
+        assert image.pixel_data.shape == (3, 256, 256)
+
 '''A two-channel tif containing two overlapped objects'''
 overlapped_objects_data = zlib.decompress(base64.b64decode(
         "eJztlU9oI1Ucx1/abau7KO7irq6u8BwQqnYymfTfNiRZ2NRAILsJNMVuQfBl"


### PR DESCRIPTION
Resolves #3394

`skimage.io.imread` swaps axes on data it assumes to be multichannel.
CellProfiler only supports single-channel TIF stacks to represent
three-dimensional data. Avoid confusing stacks with only 3 or 4
planes with multichannel data by using `skimage.external.tifffile` to
load three-dimensional data.