### PR TITLE
Indicate IDPrimary, IDSecondary do not support volumes.

### DIFF
--- a/cellprofiler/modules/identifyprimaryobjects.py
+++ b/cellprofiler/modules/identifyprimaryobjects.py
@@ -320,6 +320,9 @@ class IdentifyPrimaryObjects(cellprofiler.module.ImageSegmentation):
 
         super(IdentifyPrimaryObjects, self).__init__()
 
+    def volumetric(self):
+        return False
+
     def create_settings(self):
         super(IdentifyPrimaryObjects, self).create_settings()
 

--- a/cellprofiler/modules/identifysecondaryobjects.py
+++ b/cellprofiler/modules/identifysecondaryobjects.py
@@ -179,6 +179,9 @@ class IdentifySecondaryObjects(cellprofiler.module.ObjectProcessing):
 
         super(IdentifySecondaryObjects, self).__init__()
 
+    def volumetric(self):
+        return False
+
     def create_settings(self):
         super(IdentifySecondaryObjects, self).create_settings()
 


### PR DESCRIPTION
Resolves #3338 

IDPrimary and IDSecondary were falsely reporting volumetric support. Overriding the volumetric method from the parent class to return `False` (rather than `True`) resolves the issue:

- Users cannot add non-3D modules to a 3D pipeline (dialog appears, prevents addition to pipeline)
- Users cannot run non-3D modules in a 3D pipeline (error is raised on run)