### PR TITLE
Improve visualization for low-contrast images.

### DIFF
--- a/cellprofiler/gui/figure.py
+++ b/cellprofiler/gui/figure.py
@@ -909,6 +909,7 @@ class Figure(wx.Frame):
         MENU_CONTRAST_RAW = wx.NewId()
         MENU_CONTRAST_NORMALIZED = wx.NewId()
         MENU_CONTRAST_LOG = wx.NewId()
+        MENU_CONTRAST_GAMMA = wx.NewId()
         MENU_INTERPOLATION_NEAREST = wx.NewId()
         MENU_INTERPOLATION_BILINEAR = wx.NewId()
         MENU_INTERPOLATION_BICUBIC = wx.NewId()
@@ -933,13 +934,25 @@ class Figure(wx.Frame):
                                          'Stretch pixel intensities to fit '
                                          'the interval [0,1]',
                                          wx.ITEM_RADIO)
-        item_log = submenu.Append(MENU_CONTRAST_LOG, 'Log normalized',
-                                  'Log transform pixel intensities, then '
-                                  'stretch them to fit the interval [0,1]',
-                                  wx.ITEM_RADIO)
+        item_log = submenu.Append(
+            MENU_CONTRAST_LOG,
+            'Log normalized',
+            'Log transform pixel intensities, after stretching them to fit the interval [0,1]',
+            wx.ITEM_RADIO
+        )
+
+        item_gamma = submenu.Append(
+            MENU_CONTRAST_GAMMA,
+            'Adjust gamma',
+            'Apply gamma correction (a.k.a., power law transform) pixel intensities, after stretching them'
+            ' to fit the interval [0,1].',
+            wx.ITEM_RADIO
+        )
 
         if params['normalize'] == 'log':
             item_log.Check()
+        elif params['normalize'] == 'gamma':
+            item_gamma.Check()
         elif params['normalize']:
             item_normalized.Check()
         else:
@@ -1020,6 +1033,8 @@ class Figure(wx.Frame):
                 params['normalize'] = True
             elif evt.Id == MENU_CONTRAST_LOG:
                 params['normalize'] = 'log'
+            elif evt.Id == MENU_CONTRAST_GAMMA:
+                params['normalize'] = 'gamma'
             for artist in axes.artists:
                 if isinstance(artist, cellprofiler.gui.artist.CPImageArtist):
                     artist.kwargs["normalize"] = params['normalize']
@@ -1031,6 +1046,24 @@ class Figure(wx.Frame):
                 self.subplot(x, y).set_xlim(xlims[0], xlims[1])
                 self.subplot(x, y).set_ylim(ylims[0], ylims[1])
                 self.figure.canvas.draw()
+
+        def adjust_gamma(evt):
+            dlg = wx.TextEntryDialog(self, 'Normalization factor', 'Adjust gamma')
+            dlg.SetValue(cellprofiler.preferences.get_normalization_factor())
+            if dlg.ShowModal() == wx.ID_OK:
+                params["normalize_args"] = {"gamma": float(dlg.GetValue())}
+            dlg.Destroy()
+
+            change_contrast(evt)
+
+        def adjust_log(evt):
+            dlg = wx.TextEntryDialog(self, 'Normalization factor', 'Log normalization')
+            dlg.SetValue(cellprofiler.preferences.get_normalization_factor())
+            if dlg.ShowModal() == wx.ID_OK:
+                params["normalize_args"] = {"gain": float(dlg.GetValue())}
+            dlg.Destroy()
+
+            change_contrast(evt)
 
         def change_interpolation(evt):
             if evt.Id == MENU_INTERPOLATION_NEAREST:
@@ -1128,7 +1161,8 @@ class Figure(wx.Frame):
         self.Bind(wx.EVT_MENU, show_hist, show_hist_item)
         self.Bind(wx.EVT_MENU, change_contrast, id=MENU_CONTRAST_RAW)
         self.Bind(wx.EVT_MENU, change_contrast, id=MENU_CONTRAST_NORMALIZED)
-        self.Bind(wx.EVT_MENU, change_contrast, id=MENU_CONTRAST_LOG)
+        self.Bind(wx.EVT_MENU, adjust_log, id=MENU_CONTRAST_LOG)
+        self.Bind(wx.EVT_MENU, adjust_gamma, id=MENU_CONTRAST_GAMMA)
         self.Bind(wx.EVT_MENU, change_interpolation, id=MENU_INTERPOLATION_NEAREST)
         self.Bind(wx.EVT_MENU, change_interpolation, id=MENU_INTERPOLATION_BICUBIC)
         self.Bind(wx.EVT_MENU, change_interpolation, id=MENU_INTERPOLATION_BILINEAR)
@@ -1232,7 +1266,7 @@ class Figure(wx.Frame):
     def subplot_imshow(self, x, y, image, title=None, clear=True, colormap=None,
                        colorbar=False, normalize=None, vmin=0, vmax=1,
                        rgb_mask=(1, 1, 1), sharex=None, sharey=None,
-                       use_imshow=False, interpolation=None, cplabels=None):
+                       use_imshow=False, interpolation=None, cplabels=None, normalize_args={}):
         """Show an image in a subplot
 
         x, y  - show image in this subplot
@@ -1271,6 +1305,10 @@ class Figure(wx.Frame):
                     normalize = False
                 elif normalize == cellprofiler.preferences.INTENSITY_MODE_LOG:
                     normalize = "log"
+                    normalize_args["gain"] = float(cellprofiler.preferences.get_normalization_factor())
+                elif normalize == cellprofiler.preferences.INTENSITY_MODE_GAMMA:
+                    normalize = "gamma"
+                    normalize_args["gamma"] = float(cellprofiler.preferences.get_normalization_factor())
                 else:
                     normalize = True
 
@@ -1324,7 +1362,8 @@ class Figure(wx.Frame):
                 'rgb_mask': rgb_mask,
                 'use_imshow': use_imshow,
                 'interpolation': interpolation,
-                'cplabels': cplabels
+                'cplabels': cplabels,
+                'normalize_args': normalize_args
             }
 
             if (x, y) not in self.subplot_user_params:
@@ -1698,11 +1737,18 @@ class Figure(wx.Frame):
         # Perform normalization
         if normalize == 'log':
             if is_color_image(image):
-                image = [skimage.exposure.adjust_log(image[:, :, ch]) for ch in range(image.shape[2])]
+                image = [skimage.exposure.adjust_log(image[:, :, ch], **kwargs["normalize_args"]) for ch in range(image.shape[2])]
 
                 image = numpy.dstack(image)
             else:
-                image = skimage.exposure.adjust_log(image)
+                image = skimage.exposure.adjust_log(image, **kwargs["normalize_args"])
+        elif normalize == "gamma":
+            if is_color_image(image):
+                image = [skimage.exposure.adjust_gamma(image[:, :, ch], **kwargs["normalize_args"]) for ch in range(image.shape[2])]
+
+                image = numpy.dstack(image)
+            else:
+                image = skimage.exposure.adjust_gamma(image, **kwargs["normalize_args"])
         elif normalize:
             if is_color_image(image):
                 image = [skimage.exposure.rescale_intensity(image[:, :, ch]) for ch in range(image.shape[2])]

--- a/cellprofiler/gui/preferencesdlg.py
+++ b/cellprofiler/gui/preferencesdlg.py
@@ -16,6 +16,7 @@ FILEBROWSE = "FileBrowse"
 FONT = "Font"
 COLOR = "Color"
 CHOICE = "Choice"
+TEXT = "Text"
 
 
 class IntegerPreference(object):
@@ -289,7 +290,7 @@ class PreferencesDlg(wx.Dialog):
                 ["Intensity normalization factor",
                  cellprofiler.preferences.get_normalization_factor,
                  cellprofiler.preferences.set_normalization_factor,
-                 "Text",
+                 TEXT,
                  cellprofiler.preferences.NORMALIZATION_FACTOR_HELP],
                 ["CellProfiler plugins directory",
                  cellprofiler.preferences.get_plugin_directory,

--- a/cellprofiler/gui/preferencesdlg.py
+++ b/cellprofiler/gui/preferencesdlg.py
@@ -119,8 +119,7 @@ class PreferencesDlg(wx.Dialog):
                 current = getter()
                 if current is None:
                     current = ""
-                ctl = wx.TextCtrl(scrollpanel, -1, current,
-                                  validator=validator)
+                ctl = wx.TextCtrl(parent=scrollpanel, id=-1, value=current, validator=validator)
                 min_height = ctl.GetMinHeight()
                 min_width = ctl.GetTextExtent("Make sure the window can display this")[0]
                 ctl.SetMinSize((min_width, min_height))
@@ -282,9 +281,16 @@ class PreferencesDlg(wx.Dialog):
                 ["Intensity normalization",
                  cellprofiler.preferences.get_intensity_mode,
                  cellprofiler.preferences.set_intensity_mode,
-                 [cellprofiler.preferences.INTENSITY_MODE_RAW, cellprofiler.preferences.INTENSITY_MODE_NORMAL,
-                  cellprofiler.preferences.INTENSITY_MODE_LOG],
+                 [cellprofiler.preferences.INTENSITY_MODE_RAW,
+                  cellprofiler.preferences.INTENSITY_MODE_NORMAL,
+                  cellprofiler.preferences.INTENSITY_MODE_LOG,
+                  cellprofiler.preferences.INTENSITY_MODE_GAMMA],
                  cellprofiler.preferences.INTENSITY_MODE_HELP],
+                ["Intensity normalization factor",
+                 cellprofiler.preferences.get_normalization_factor,
+                 cellprofiler.preferences.set_normalization_factor,
+                 "Text",
+                 cellprofiler.preferences.NORMALIZATION_FACTOR_HELP],
                 ["CellProfiler plugins directory",
                  cellprofiler.preferences.get_plugin_directory,
                  cellprofiler.preferences.set_plugin_directory,

--- a/cellprofiler/preferences.py
+++ b/cellprofiler/preferences.py
@@ -630,10 +630,11 @@ NORMALIZATION_FACTOR_HELP = """\
 Sets the normalization factor for intensity normalization methods:
 
 -  *{INTENSITY_MODE_LOG}*: Set the gain applied to the each pixel in the image during log normalization. Pixels are
-   transformed according to the formula O = gain * log(1 + I), where I is the pixel intensity.
--  *{INTENSITY_MODE_GAMMA}*: Set the value of gamma. Pixels are transformed according to the formula O = I ** gamma,
-   where I is the pixel intensity. For gamma > 1.0, the output image will appear darker than the original image. For
-   gamma < 1.0, the output image will appear brighter than the original image.
+   transformed according to the formula `O = gain * log(1 + I)`, where `I` is the pixel intensity. Increasing the value
+   of `gain` makes the displayed image appear brighter.
+-  *{INTENSITY_MODE_GAMMA}*: Set the value of gamma. Pixels are transformed according to the formula `O = I ** gamma`,
+   where I is the pixel intensity. For `gamma` > 1.0, the output image will appear darker than the original image. For
+   `gamma` < 1.0, the output image will appear brighter than the original image.
    
 The normalization factor is ignored when the normalization method is *{INTENSITY_MODE_NORMAL}* or 
 *{INTENSITY_MODE_RAW}*.

--- a/cellprofiler/preferences.py
+++ b/cellprofiler/preferences.py
@@ -342,6 +342,7 @@ IM_BICUBIC = "Bicubic"
 INTENSITY_MODE_RAW = "raw"
 INTENSITY_MODE_NORMAL = "normalized"
 INTENSITY_MODE_LOG = "log"
+INTENSITY_MODE_GAMMA = "gamma"
 
 WC_SHOW_WORKSPACE_CHOICE_DIALOG = "ShowWorkspaceChoiceDlg"
 WC_OPEN_LAST_WORKSPACE = "OpenLastWorkspace"
@@ -624,6 +625,24 @@ saved. CellProfiler will also save images accessed by http URL
 temporarily to disk (but will efficiently access OMERO image planes
 directly from the server).\
 """
+
+NORMALIZATION_FACTOR_HELP = """\
+Sets the normalization factor for intensity normalization methods:
+
+-  *{INTENSITY_MODE_LOG}*: Set the gain applied to the each pixel in the image during log normalization. Pixels are
+   transformed according to the formula O = gain * log(1 + I), where I is the pixel intensity.
+-  *{INTENSITY_MODE_GAMMA}*: Set the value of gamma. Pixels are transformed according to the formula O = I ** gamma,
+   where I is the pixel intensity. For gamma > 1.0, the output image will appear darker than the original image. For
+   gamma < 1.0, the output image will appear brighter than the original image.
+   
+The normalization factor is ignored when the normalization method is *{INTENSITY_MODE_NORMAL}* or 
+*{INTENSITY_MODE_RAW}*.
+""".format(**{
+    "INTENSITY_MODE_GAMMA": INTENSITY_MODE_GAMMA,
+    "INTENSITY_MODE_LOG": INTENSITY_MODE_LOG,
+    "INTENSITY_MODE_NORMAL": INTENSITY_MODE_NORMAL,
+    "INTENSITY_MODE_RAW": INTENSITY_MODE_RAW
+})
 
 
 def recent_file(index, category=""):
@@ -1838,6 +1857,21 @@ def set_choose_image_set_frame_size(w, h):
     global __choose_image_set_frame_size
     __choose_image_set_frame_size = (w, h)
     config_write(CHOOSE_IMAGE_SET_FRAME_SIZE, "%d,%d" % (w, h))
+
+
+__normalization_factor = "1.0"
+
+
+def get_normalization_factor():
+    global __normalization_factor
+
+    return __normalization_factor
+
+
+def set_normalization_factor(normalization_factor):
+    global __normalization_factor
+
+    __normalization_factor = normalization_factor
 
 
 def add_progress_callback(callback):


### PR DESCRIPTION
Resolves #3396.

Adds gamma adjustment/power law transformation. This feature can
be enabled via the figure menu or in the preferences dialog.

Additionally, allows configuring the value of gamma and the scale
of the log transformation in the preferences dialog, or when
the normalization option is selected from the figure menu.

Examples:
![screen shot 2018-01-08 at 1 43 50 pm](https://user-images.githubusercontent.com/4721755/34686564-003c8310-f47a-11e7-9c4f-60b641bf2090.png)

![screen shot 2018-01-08 at 1 44 54 pm](https://user-images.githubusercontent.com/4721755/34686608-261f8c12-f47a-11e7-8737-58396d58dc7e.png)
