### PR TITLE
Use `READ COMMITTED` isolation in place of coarse grained lock

### DIFF
--- a/cellprofiler/modules/exporttodatabase.py
+++ b/cellprofiler/modules/exporttodatabase.py
@@ -301,6 +301,11 @@ def connect_mysql(host, user, pw, db):
     '''Creates and returns a db connection and cursor.'''
     connection = MySQLdb.connect(host=host, user=user, passwd=pw, db=db)
     cursor = SSCursor(connection)
+
+    rv = cursor.execute('SET TRANSACTION ISOLATION LEVEL READ COMMITTED')
+    logger.info('Set MySQL transaction isolation to "READ COMMITTED": %r' % rv)
+    cursor.execute('BEGIN')
+
     #
     # Use utf-8 encoding for strings
     #
@@ -3299,21 +3304,6 @@ OPTIONALLY ENCLOSED BY '"' ESCAPED BY '\\\\';
 
             ###########################################
             #
-            # The experiment table
-            #
-            # Update the modification timestamp. This
-            # has a side-effect of synchronizing (and blocking
-            # writes to the database for transactional DB engines)
-            # by taking a lock on the single row of
-            # the experiment table
-            ###########################################
-            stmt = "UPDATE %s SET %s='%s'" % \
-                   (self.get_table_name(cellprofiler.measurement.EXPERIMENT),
-                    cellprofiler.pipeline.M_MODIFICATION_TIMESTAMP,
-                    datetime.datetime.now().isoformat())
-            execute(self.cursor, stmt, return_result=False)
-            ###########################################
-            #
             # The image table
             #
             ###########################################
@@ -3568,6 +3558,17 @@ OPTIONALLY ENCLOSED BY '"' ESCAPED BY '\\\\';
             if self.show_window:
                 workspace.display_data.header = disp_header
                 workspace.display_data.columns = disp_columns
+
+            ###########################################
+            #
+            # The experiment table
+            #
+            ###########################################
+            stmt = "UPDATE %s SET %s='%s'" % \
+                   (self.get_table_name(cellprofiler.measurement.EXPERIMENT),
+                    cellprofiler.pipeline.M_MODIFICATION_TIMESTAMP,
+                    datetime.datetime.now().isoformat())
+            execute(self.cursor, stmt, return_result=False)
 
             self.connection.commit()
         except:


### PR DESCRIPTION
In a highly concurent batch processing environment there can easily be
100s of instances of CellProfiler.  With a decently complicated
pipeline and images collected with large frame (2K x 2K+) cameras there
can also easily be several 100 objects per image.  Under these
conditions MySQL lock timeouts will occur when using the InnoDB database
engine which is the default as of MySQL 5.7.

The coarse grained lock was instituted in 26c3841 as a fix for #1022.
While that issue does not detail the specifics it can be assumed that
the deadlocks mentioned were related to gap locking:

  https://dev.mysql.com/doc/refman/5.7/en/innodb-locking.html#innodb-gap-locks

The propensity for InnoDB to be affected by deadlocking problems is well
known.  So much so that there is a page dedicated to it in the MySQL
manual:

  https://dev.mysql.com/doc/refman/5.7/en/innodb-deadlocks.html

The ExportToDatabase module really executes no interdependent SELECT
statements in each corresponding transaction.  So, solving deadlocking
issues can be done much more elegently and concurrently by selecting an
appropriate level of transaction isolation for MySQL.  These levels are
detailed here:

  https://dev.mysql.com/doc/refman/5.7/en/innodb-transaction-isolation-levels.html

The level `READ COMMITTED` has been specifically chosen due to the
lack of interdependency in CellProfiler batch processing workflows and
the fact that gap locking is *disabled* for this isolation level.