### PR TITLE
Ubuntu 16.04 compatibility fix follow up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ addons:
       - libgtk2.0-dev
       - python-imaging
       - python-mysqldb
-      - python-networkx
       - python-pip
       - python-tk
       - python-wxgtk2.8

--- a/setup.py
+++ b/setup.py
@@ -427,7 +427,6 @@ setuptools.setup(
     install_requires=[
         "cellh5",
         "centrosome>=1.0.4",
-        "decorator",
         "h5py<2.7.0",
         "inflect",
         "javabridge",

--- a/setup.py
+++ b/setup.py
@@ -435,7 +435,6 @@ setuptools.setup(
         "MySQL-python",
         "numpy<1.12.0",
         "prokaryote",
-        "pytest",
         "python-bioformats",
         "pyzmq",
         "scipy"
@@ -455,6 +454,9 @@ setuptools.setup(
         "tutorial"
     ])+["artwork"],
     setup_requires=[
+        "pytest"
+    ],
+    tests_requires=[
         "pytest"
     ],
     url="https://github.com/CellProfiler/CellProfiler",


### PR DESCRIPTION
This is a follow up to #3455 which fixes a runtime dependency resolution issue that manifests itself when having the `decorator` dependency explicitly set (2910fe126d75f00f0de14b2377807ae211093678) and following the [Ubuntu 16.04](https://github.com/CellProfiler/CellProfiler/wiki/Source-installation-%28Ubuntu-16.04-LTS%29) install documentation.

Everything will install fine, but you will get this exception when trying to run CellProfiler:

```
Traceback (most recent call last):
  File "/home/callan/v/cp22-new/bin/cellprofiler", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/home/callan/v/cp22-new/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2927, in <module>
    @_call_aside
  File "/home/callan/v/cp22-new/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2913, in _call_aside
    f(*args, **kwargs)
  File "/home/callan/v/cp22-new/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2940, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/home/callan/v/cp22-new/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 637, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/home/callan/v/cp22-new/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 650, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/home/callan/v/cp22-new/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 834, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (decorator 4.0.6 (/usr/lib/python2.7/dist-packages), Requirement.parse('decorator>=4.1.0'), set(['networkx']))
```

When following the aforementioned documentation, decorator 4.0.6 will have been installed globally by APT as a dependency of scipy. For some reason that I'm not 100% on it will not be upgraded even though networkx 2.0 depends on decorator >= 4.1.0. networkx 2.0 will be installed by `pip` when `pip install --editable .` is executed following this dependency tree:

 * `networkx>=1.8 (from scikit-image->centrosome>=1.0.4->CellProfiler==2.2.0)`

The original change (2910fe126d75f00f0de14b2377807ae211093678) was made to fix Travis running Ubuntu 14.04 with networkx installed globally via APT. This version is 1.8.1 which includes no dependency on the decorator package. As no explicit dependency was then included in CellProfiler's `setup.py` imports of the `cellprofiler.objects` package would fail.

It suffices to simply remove the global APT installation of networkx. networkx will then be installed via `pip` following the aforementioned dependency tree along with the decorator dependency.