### PR TITLE
link DOIs to new, secure resolver

### DIFF
--- a/cellprofiler/data/help/why_use_cellprofiler.rst
+++ b/cellprofiler/data/help/why_use_cellprofiler.rst
@@ -70,21 +70,21 @@ For a full list of references, visit our `citation`_ page.
    structure, function, and compatibility for CellProfiler: modular
    high-throughput image analysis software” *Bioinformatics*
    27(8):1179-1180
-   (`link <http://dx.doi.org/10.1093/bioinformatics/btr095>`__)
+   (`link <https://doi.org/10.1093/bioinformatics/btr095>`__)
 -  Lamprecht MR, Sabatini DM, Carpenter AE (2007) “CellProfiler: free,
    versatile software for automated biological image analysis”
    *Biotechniques* 42(1):71-75.
-   (`link <http://dx.doi.org/10.2144/000112257>`__)
+   (`link <https://doi.org/10.2144/000112257>`__)
 -  Jones TR, Carpenter AE, Lamprecht MR, Moffat J, Silver S, Grenier J,
    Root D, Golland P, Sabatini DM (2009) “Scoring diverse cellular
    morphologies in image-based screens with iterative feedback and
    machine learning” *PNAS* 106(6):1826-1831
-   (`link <http://dx.doi.org/10.1073/pnas.0808843106>`__)
+   (`link <https://doi.org/10.1073/pnas.0808843106>`__)
 -  Jones TR, Kang IH, Wheeler DB, Lindquist RA, Papallo A, Sabatini DM,
    Golland P, Carpenter AE (2008) “CellProfiler Analyst: data
    exploration and analysis software for complex image-based screens”
    *BMC Bioinformatics* 9(1):482
-   (`link <http://dx.doi.org/10.1186/1471-2105-9-482>`__)
+   (`link <https://doi.org/10.1186/1471-2105-9-482>`__)
 
 .. _citation: http://cellprofiler.org/citations/
-.. _link: http://dx.doi.org/10.1186/gb-2006-7-10-r100
+.. _link: https://doi.org/10.1186/gb-2006-7-10-r100

--- a/cellprofiler/data/help/why_use_cellprofiler.rst
+++ b/cellprofiler/data/help/why_use_cellprofiler.rst
@@ -87,4 +87,4 @@ For a full list of references, visit our `citation`_ page.
    (`link <https://doi.org/10.1186/1471-2105-9-482>`__)
 
 .. _citation: http://cellprofiler.org/citations/
-.. _link: https://doi.org/10.1186/gb-2006-7-10-r100
+.. _link: http://doi.org/10.1186/gb-2006-7-10-r100

--- a/cellprofiler/modules/calculatestatistics.py
+++ b/cellprofiler/modules/calculatestatistics.py
@@ -44,7 +44,7 @@ is a good way to guarantee that images are matched with the correct
 data. The control and dose information can be designated in one of two
 ways:
 
-.. _(link): http://dx.doi.org/10.1177/108705719900400206
+.. _(link): https://doi.org/10.1177/108705719900400206
 .. _Ilya Ravkin: http://www.ravkin.net
 
 -  As metadata (so that the column header is prefixed with the

--- a/cellprofiler/modules/identifydeadworms.py
+++ b/cellprofiler/modules/identifydeadworms.py
@@ -39,12 +39,12 @@ References
 
 -  Peng H, Long F, Liu X, Kim SK, Myers EW (2008) "Straightening
    *Caenorhabditis elegans* images." *Bioinformatics*,
-   24(2):234-42. `(link) <http://dx.doi.org/10.1093/bioinformatics/btm569>`__
+   24(2):234-42. `(link) <https://doi.org/10.1093/bioinformatics/btm569>`__
 -  Wählby C, Kamentsky L, Liu ZH, Riklin-Raviv T, Conery AL, O’Rourke
    EJ, Sokolnicki KL, Visvikis O, Ljosa V, Irazoqui JE, Golland P,
    Ruvkun G, Ausubel FM, Carpenter AE (2012). "An image analysis toolbox
    for high-throughput *C. elegans* assays." *Nature Methods* 9(7):
-   714-716. `(link) <http://dx.doi.org/10.1038/nmeth.1984>`__
+   714-716. `(link) <https://doi.org/10.1038/nmeth.1984>`__
 
 See also
 ^^^^^^^^

--- a/cellprofiler/modules/identifyprimaryobjects.py
+++ b/cellprofiler/modules/identifyprimaryobjects.py
@@ -199,21 +199,21 @@ References
    (`link`_)
 -  Meyer F, Beucher S (1990) “Morphological segmentation.” *J Visual
    Communication and Image Representation* 1, 21-46.
-   (`link <http://dx.doi.org/10.1016/1047-3203(90)90014-M>`__)
+   (`link <https://doi.org/10.1016/1047-3203(90)90014-M>`__)
 -  Ortiz de Solorzano C, Rodriguez EG, Jones A, Pinkel D, Gray JW, Sudar
    D, Lockett SJ. (1999) “Segmentation of confocal microscope images of
    cell nuclei in thick tissue sections.” *Journal of Microscopy-Oxford*
    193, 212-226.
-   (`link <http://dx.doi.org/10.1046/j.1365-2818.1999.00463.x>`__)
+   (`link <https://doi.org/10.1046/j.1365-2818.1999.00463.x>`__)
 -  Wählby C (2003) *Algorithms for applied digital image cytometry*,
    Ph.D., Uppsala University, Uppsala.
 -  Wählby C, Sintorn IM, Erlandsson F, Borgefors G, Bengtsson E. (2004)
    “Combining intensity, edge and shape information for 2D and 3D
    segmentation of cell nuclei in tissue sections.” *J Microsc* 215,
    67-76.
-   (`link <http://dx.doi.org/10.1111/j.0022-2720.2004.01338.x>`__)
+   (`link <https://doi.org/10.1111/j.0022-2720.2004.01338.x>`__)
 
-.. _link: http://dx.doi.org/10.1002/(SICI)1097-0320(19970801)28:4%3C289::AID-CYTO3%3E3.0.CO;2-7
+.. _link: https://doi.org/10.1002/(SICI)1097-0320(19970801)28:4%3C289::AID-CYTO3%3E3.0.CO;2-7
 .. _tutorial: http://blog.cellprofiler.org/2017/01/19/cellprofiler-ilastik-superpowered-segmentation/
 
 """.format(**{

--- a/cellprofiler/modules/makeprojection.py
+++ b/cellprofiler/modules/makeprojection.py
@@ -138,7 +138,7 @@ References
    fluorescence in automated analysis of macrophage images”, *PLoS ONE*
    4(10): e7497 `(link)`_.
 
-.. _(link): http://dx.doi.org/10.1371/journal.pone.0007497
+.. _(link): https://doi.org/10.1371/journal.pone.0007497
 """% globals())
 
         self.projection_image_name = cps.ImageNameProvider(

--- a/cellprofiler/modules/measureimageoverlap.py
+++ b/cellprofiler/modules/measureimageoverlap.py
@@ -83,7 +83,7 @@ References
 
 -  Collins LM, Dent CW (1998) “Omega: A general formulation of the Rand
    Index of cluster recovery suitable for non-disjoint solutions”,
-   *Multivariate Behavioral Research*, 23, 231-242. `(link) <http://dx.doi.org/10.1207/s15327906mbr2302_6>`__
+   *Multivariate Behavioral Research*, 23, 231-242. `(link) <https://doi.org/10.1207/s15327906mbr2302_6>`__
 -  Pele O, Werman M (2009) “Fast and Robust Earth Mover’s Distances”,
    *2009 IEEE 12th International Conference on Computer Vision*.
 """

--- a/cellprofiler/modules/measureimagequality.py
+++ b/cellprofiler/modules/measureimagequality.py
@@ -114,7 +114,7 @@ References
 -  Bray MA, Fraser AN, Hasaka TP, Carpenter AE (2012) “Workflow and
    metrics for image quality control in large-scale high-content
    screens.” *J Biomol Screen* 17(2):266-74.
-   `(link) <http://dx.doi.org/10.1177/1087057111420292>`__
+   `(link) <https://doi.org/10.1177/1087057111420292>`__
 -  Field DJ (1997) "Relations between the statistics of natural images
    and the response properties of cortical cells" *Journal of the
    Optical Society of America. A, Optics, image science, and vision*,
@@ -122,14 +122,14 @@ References
    `(pdf) <http://redwood.psych.cornell.edu/papers/field_87.pdf>`__
 -  Haralick RM (1979) "Statistical and structural approaches to texture"
    Proc. IEEE, 67(5):786-804.
-   `(link) <http://dx.doi.org/10.1109/PROC.1979.11328>`__
+   `(link) <https://doi.org/10.1109/PROC.1979.11328>`__
 -  Vollath D (1987) "Automatic focusing by correlative methods" *Journal
    of Microscopy* 147(3):279-288.
-   `(link) <http://dx.doi.org/10.1111/j.1365-2818.1987.tb02839.x>`__
+   `(link) <https://doi.org/10.1111/j.1365-2818.1987.tb02839.x>`__
 -  Sun Y, Duthaler S, Nelson B (2004) "Autofocusing in computer
    microscopy: Selecting the optimal focus algorithm" *Microscopy
    Research and Technique*, 65:139-149
-   `(link) <http://dx.doi.org/10.1002/jemt.20118>`__
+   `(link) <https://doi.org/10.1002/jemt.20118>`__
 """
 
 import logging

--- a/cellprofiler/modules/measureobjectoverlap.py
+++ b/cellprofiler/modules/measureobjectoverlap.py
@@ -54,7 +54,7 @@ References
 -  Pele O, Werman M (2009) “Fast and Robust Earth Mover’s Distances”,
    *2009 IEEE 12th International Conference on Computer Vision*
 
-.. _(link): http://dx.doi.org/10.1207/s15327906mbr2302_6
+.. _(link): https://doi.org/10.1207/s15327906mbr2302_6
 """
 
 import centrosome.cpmorphology

--- a/cellprofiler/modules/measuretexture.py
+++ b/cellprofiler/modules/measuretexture.py
@@ -98,7 +98,7 @@ References
 
 -  Haralick RM, Shanmugam K, Dinstein I. (1973), “Textural Features for
    Image Classification” *IEEE Transaction on Systems Man, Cybernetics*,
-   SMC-3(6):610-621. `(link) <http://dx.doi.org/10.1109/TSMC.1973.4309314>`__
+   SMC-3(6):610-621. `(link) <https://doi.org/10.1109/TSMC.1973.4309314>`__
 
 .. _here: http://murphylab.web.cmu.edu/publications/boland/boland_node26.html
 """

--- a/cellprofiler/modules/straightenworms.py
+++ b/cellprofiler/modules/straightenworms.py
@@ -75,12 +75,12 @@ References
 
 -  Peng H, Long F, Liu X, Kim SK, Myers EW (2008) "Straightening
    *Caenorhabditis elegans* images." *Bioinformatics*,
-   24(2):234-42. `(link) <http://dx.doi.org/10.1093/bioinformatics/btm569>`__
+   24(2):234-42. `(link) <https://doi.org/10.1093/bioinformatics/btm569>`__
 -  Wählby C, Kamentsky L, Liu ZH, Riklin-Raviv T, Conery AL, O’Rourke
    EJ, Sokolnicki KL, Visvikis O, Ljosa V, Irazoqui JE, Golland P,
    Ruvkun G, Ausubel FM, Carpenter AE (2012). "An image analysis toolbox
    for high-throughput *C. elegans* assays." *Nature Methods* 9(7):
-   714-716. `(link) <http://dx.doi.org/10.1038/nmeth.1984>`__
+   714-716. `(link) <https://doi.org/10.1038/nmeth.1984>`__
 
 .. _Worm Toolbox: http://www.cellprofiler.org/wormtoolbox/
 """

--- a/cellprofiler/modules/threshold.py
+++ b/cellprofiler/modules/threshold.py
@@ -210,7 +210,7 @@ There are a number of methods for finding thresholds automatically:
    and quantitative performance evaluation.” *Journal of Electronic
    Imaging*, 13(1), 146-165. (`link`_)
 
-.. _link: http://dx.doi.org/10.1117/1.1631315
+.. _link: https://doi.org/10.1117/1.1631315
 .. |image0| image:: {PROTIP_RECOMMEND_ICON}
 .. |image1| image:: {PROTIP_AVOID_ICON}
 .. |image2| image:: {PROTIP_RECOMMEND_ICON}
@@ -288,7 +288,7 @@ threshold value.
    and quantitative performance evaluation.” *Journal of Electronic
    Imaging*, 13(1), 146-165. (`link`_)
 
-.. _link: http://dx.doi.org/10.1117/1.1631315
+.. _link: https://doi.org/10.1117/1.1631315
 """.format(**{
                 "HELP_ON_PIXEL_INTENSITIES": _help.HELP_ON_PIXEL_INTENSITIES,
                 "PROTIP_AVOID_ICON":_help.PROTIP_AVOID_ICON,

--- a/cellprofiler/modules/trackobjects.py
+++ b/cellprofiler/modules/trackobjects.py
@@ -470,11 +470,11 @@ References
 -  Jaqaman K, Loerke D, Mettlen M, Kuwata H, Grinstein S, Schmid SL,
   Danuser G. (2008) "Robust single-particle tracking in live-cell
   time-lapse sequences." *Nature Methods* 5(8),695-702.
-  `(link) <http://dx.doi.org/10.1038/nmeth.1237>`__
+  `(link) <https://doi.org/10.1038/nmeth.1237>`__
 -  Jaqaman K, Danuser G. (2009) "Computational image analysis of
   cellular dynamics: a case study based on particle tracking." Cold
   Spring Harb Protoc. 2009(12):pdb.top65.
-  `(link) <http://dx.doi.org/10.1101/pdb.top65>`__
+  `(link) <https://doi.org/10.1101/pdb.top65>`__
 
 .. |image0| image:: {PROTIP_RECOMMEND_ICON}
 .. |image1| image:: {PROTIP_RECOMMEND_ICON}

--- a/cellprofiler/modules/untangleworms.py
+++ b/cellprofiler/modules/untangleworms.py
@@ -86,7 +86,7 @@ References
    EJ, Sokolnicki KL, Visvikis O, Ljosa V, Irazoqui JE, Golland P,
    Ruvkun G, Ausubel FM, Carpenter AE (2012). "An image analysis toolbox
    for high-throughput *C. elegans* assays." *Nature Methods* 9(7):
-   714-716. `(link) <http://dx.doi.org/10.1038/nmeth.1984>`__
+   714-716. `(link) <https://doi.org/10.1038/nmeth.1984>`__
 
 .. _Worm Toolbox: http://www.cellprofiler.org/wormtoolbox/
 """

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -74,24 +74,24 @@ For a full list of references, visit our `citation`_ page.
    structure, function, and compatibility for CellProfiler: modular
    high-throughput image analysis software” *Bioinformatics*
    27(8):1179-1180
-   (`link <http://dx.doi.org/10.1093/bioinformatics/btr095>`__)
+   (`link <https://doi.org/10.1093/bioinformatics/btr095>`__)
 -  Lamprecht MR, Sabatini DM, Carpenter AE (2007) “CellProfiler: free,
    versatile software for automated biological image analysis”
    *Biotechniques* 42(1):71-75.
-   (`link <http://dx.doi.org/10.2144/000112257>`__)
+   (`link <https://doi.org/10.2144/000112257>`__)
 -  Jones TR, Carpenter AE, Lamprecht MR, Moffat J, Silver S, Grenier J,
    Root D, Golland P, Sabatini DM (2009) “Scoring diverse cellular
    morphologies in image-based screens with iterative feedback and
    machine learning” *PNAS* 106(6):1826-1831
-   (`link <http://dx.doi.org/10.1073/pnas.0808843106>`__)
+   (`link <https://doi.org/10.1073/pnas.0808843106>`__)
 -  Jones TR, Kang IH, Wheeler DB, Lindquist RA, Papallo A, Sabatini DM,
    Golland P, Carpenter AE (2008) “CellProfiler Analyst: data
    exploration and analysis software for complex image-based screens”
    *BMC Bioinformatics* 9(1):482
-   (`link <http://dx.doi.org/10.1186/1471-2105-9-482>`__)
+   (`link <https://doi.org/10.1186/1471-2105-9-482>`__)
 
 .. _citation: http://cellprofiler.org/citations/
-.. _link: http://dx.doi.org/10.1186/gb-2006-7-10-r100
+.. _link: https://doi.org/10.1186/gb-2006-7-10-r100
 
 
 Menu Options


### PR DESCRIPTION
See #3478 :-)   I used Atom's project-wide search-and-replace, so I guess I caught all them DOIs.