### PR TITLE
enable citation import from source code

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -108,19 +108,4 @@ CellProfiler Analyst software in general:
 }
 
 
-CellProfiler Analyst for scoring phenotypes by machine learning:
-
-@article{Jones1826,
-  title = {Scoring Diverse Cellular Morphologies in Image-Based Screens with Iterative Feedback and Machine Learning},
-  volume = {106},
-  issn = {0027-8424},
-  doi = {10.1073/pnas.0808843106},
-  abstract = {Many biological pathways were first uncovered by identifying mutants with visible phenotypes and by scoring every sample in a screen via tedious and subjective visual inspection. Now, automated image analysis can effectively score many phenotypes. In practical application, customizing an image-analysis algorithm or finding a sufficient number of example cells to train a machine learning algorithm can be infeasible, particularly when positive control samples are not available and the phenotype of interest is rare. Here we present a supervised machine learning approach that uses iterative feedback to readily score multiple subtle and complex morphological phenotypes in high-throughput, image-based screens. First, automated cytological profiling extracts hundreds of numerical descriptors for every cell in every image. Next, the researcher generates a rule (i.e., classifier) to recognize cells with a phenotype of interest during a short, interactive training session using iterative feedback. Finally, all of the cells in the experiment are automatically classified and each sample is scored based on the presence of cells displaying the phenotype. By using this approach, we successfully scored images in RNA interference screens in 2 organisms for the prevalence of 15 diverse cellular morphologies, some of which were previously intractable.},
-  number = {6},
-  url = {http://www.pnas.org/content/106/6/1826},
-  journal = {Proceedings of the National Academy of Sciences},
-  author = {Jones, Thouis R. and Carpenter, Anne E. and Lamprecht, Michael R. and Moffat, Jason and Silver, Serena J. and Grenier, Jennifer K. and Castoreno, Adam B. and Eggert, Ulrike S. and Root, David E. and Golland, Polina and Sabatini, David M.},
-  year = {2009},
-  pages = {1826--1831},
-  eprint = {http://www.pnas.org/content/106/6/1826.full.pdf}
-}
+Please find the CellProfiler Analyst's BibTeX snippets in  https://github.com/CellProfiler/CellProfiler-Analyst/blob/master/CITATION

--- a/CITATION
+++ b/CITATION
@@ -1,0 +1,126 @@
+When using CellProfiler, please cite one of the following papers.
+See also: http://cellprofiler.org/citations/
+
+
+CellProfiler for cells:
+
+@Article{Carpenter2006,
+author="Carpenter, Anne E.
+and Jones, Thouis R.
+and Lamprecht, Michael R.
+and Clarke, Colin
+and Kang, In Han
+and Friman, Ola
+and Guertin, David A.
+and Chang, Joo Han
+and Lindquist, Robert A.
+and Moffat, Jason
+and Golland, Polina
+and Sabatini, David M.",
+title="CellProfiler: image analysis software for identifying and quantifying cell phenotypes",
+journal="Genome Biology",
+year="2006",
+month="Oct",
+day="31",
+volume="7",
+number="10",
+pages="R100",
+abstract="Biologists can now prepare and image thousands of samples per day using automation, enabling chemical screens and functional genomics (for example, using RNA interference). Here we describe the first free, open-source system designed for flexible, high-throughput cell image analysis, CellProfiler. CellProfiler can address a variety of biological questions quantitatively, including standard assays (for example, cell count, size, per-cell protein levels) and complex morphological assays (for example, cell/organelle shape or subcellular patterns of DNA or protein staining).",
+issn="1474-760X",
+doi="10.1186/gb-2006-7-10-r100",
+url="https://doi.org/10.1186/gb-2006-7-10-r100"
+}
+
+or
+
+@article{doi:10.1093/bioinformatics/btr095,
+author = {Kamentsky, Lee and Jones, Thouis R. and Fraser, Adam and Bray, Mark-Anthony and Logan, David J. and Madden, Katherine L. and Ljosa, Vebjorn and Rueden, Curtis and Eliceiri, Kevin W. and Carpenter, Anne E.},
+title = {Improved structure, function and compatibility for CellProfiler: modular high-throughput image analysis software},
+journal = {Bioinformatics},
+volume = {27},
+number = {8},
+pages = {1179-1180},
+year = {2011},
+doi = {10.1093/bioinformatics/btr095},
+URL = { + http://dx.doi.org/10.1093/bioinformatics/btr095},
+eprint = {/oup/backfile/content_public/journal/bioinformatics/27/8/10.1093_bioinformatics_btr095/2/btr095.pdf}
+}
+
+
+CellProfiler for the Worm Toolbox:
+
+@article{Wahlby_image_2012,
+  title = {An Image Analysis Toolbox for High-Throughput {{{\emph{C}}}}{\emph{. Elegans}} Assays},
+  volume = {9},
+  copyright = {2012 Nature Publishing Group},
+  issn = {1548-7105},
+  doi = {10.1038/nmeth.1984},
+  abstract = {We present a toolbox for high-throughput screening of image-based Caenorhabditis elegans phenotypes. The image analysis algorithms measure morphological phenotypes in individual worms and are effective for a variety of assays and imaging systems. This WormToolbox is available through the open-source CellProfiler project and enables objective scoring of whole-worm high-throughput image-based assays of C. elegans for the study of diverse biological pathways that are relevant to human disease.},
+  language = {en},
+  number = {7},
+  urldate = {2018-02-06},
+  url = {https://www.nature.com/articles/nmeth.1984},
+  journal = {Nature Methods},
+  author = {W{\"a}hlby, Carolina and Kamentsky, Lee and Liu, Zihan H. and Riklin-Raviv, Tammy and Conery, Annie L. and O'Rourke, Eyleen J. and Sokolnicki, Katherine L. and Visvikis, Orane and Ljosa, Vebjorn and Irazoqui, Javier E. and Golland, Polina and Ruvkun, Gary and Ausubel, Frederick M. and Carpenter, Anne E.},
+  month = jul,
+  year = {2012},
+  pages = {714--716},
+  file = {/Users/katrinleinweber/Zotero/storage/H7CUV6S5/Wählby et al. - 2012 - An image analysis toolbox for high-throughput iC.pdf}
+}
+
+
+CellProfiler for other biological images:
+
+@article{Lamprecht_CellProfiler:_2007,
+  title = {{{CellProfiler}}: Free, Versatile Software for Automated Biological Image Analysis},
+  volume = {42},
+  issn = {0736-6205},
+  shorttitle = {{{CellProfiler}}},
+  abstract = {Careful visual examination of biological samples is quite powerful, but many visual analysis tasks done in the laboratory are repetitive, tedious, and subjective. Here we describe the use of the open-source software, CellProfiler, to automatically identify and measure a variety of biological objects in images. The applications demonstrated here include yeast colony counting and classifying, cell microarray annotation, yeast patch assays, mouse tumor quantification, wound healing assays, and tissue topology measurement. The software automatically identifies objects in digital images, counts them, and records a full spectrum of measurements for each object, including location within the image, size, shape, color intensity, degree of correlation between colors, texture (smoothness), and number of neighbors. Small numbers of images can be processed automatically on a personal computer and hundreds of thousands can be analyzed using a computing cluster. This free, easy-to-use software enables biologists to comprehensively and quantitatively address many questions that previously would have required custom programming, thereby facilitating discovery in a variety of biological fields of study.},
+  language = {eng},
+  number = {1},
+  journal = {BioTechniques},
+  author = {Lamprecht, Michael R. and Sabatini, David M. and Carpenter, Anne E.},
+  month = jan,
+  year = {2007},
+  keywords = {Software,Cell Count,Colony Count; Microbial,Cytological Techniques,Image Processing; Computer-Assisted,Saccharomyces cerevisiae,Tissue Array Analysis,Wound Healing},
+  pages = {71--75},
+  pmid = {17269487}
+}
+
+
+CellProfiler Analyst software in general:
+
+@article{Jones2008,
+  title = {{{CellProfiler Analyst}}: Data Exploration and Analysis Software for Complex Image-Based Screens},
+  volume = {9},
+  issn = {1471-2105},
+  doi = {10.1186/1471-2105-9-482},
+  abstract = {Image-based screens can produce hundreds of measured features for each of hundreds of millions of individual cells in a single experiment.},
+  number = {1},
+  url = {https://doi.org/10.1186/1471-2105-9-482},
+  journal = {BMC Bioinformatics},
+  author = {Jones, Thouis R. and Kang, In Han and Wheeler, Douglas B. and Lindquist, Robert A. and Papallo, Adam and Sabatini, David M. and Golland, Polina and Carpenter, Anne E.},
+  month = nov,
+  year = {2008},
+  pages = {482},
+  day = {15}
+}
+
+
+CellProfiler Analyst for scoring phenotypes by machine learning:
+
+@article{Jones1826,
+  title = {Scoring Diverse Cellular Morphologies in Image-Based Screens with Iterative Feedback and Machine Learning},
+  volume = {106},
+  issn = {0027-8424},
+  doi = {10.1073/pnas.0808843106},
+  abstract = {Many biological pathways were first uncovered by identifying mutants with visible phenotypes and by scoring every sample in a screen via tedious and subjective visual inspection. Now, automated image analysis can effectively score many phenotypes. In practical application, customizing an image-analysis algorithm or finding a sufficient number of example cells to train a machine learning algorithm can be infeasible, particularly when positive control samples are not available and the phenotype of interest is rare. Here we present a supervised machine learning approach that uses iterative feedback to readily score multiple subtle and complex morphological phenotypes in high-throughput, image-based screens. First, automated cytological profiling extracts hundreds of numerical descriptors for every cell in every image. Next, the researcher generates a rule (i.e., classifier) to recognize cells with a phenotype of interest during a short, interactive training session using iterative feedback. Finally, all of the cells in the experiment are automatically classified and each sample is scored based on the presence of cells displaying the phenotype. By using this approach, we successfully scored images in RNA interference screens in 2 organisms for the prevalence of 15 diverse cellular morphologies, some of which were previously intractable.},
+  number = {6},
+  url = {http://www.pnas.org/content/106/6/1826},
+  journal = {Proceedings of the National Academy of Sciences},
+  author = {Jones, Thouis R. and Carpenter, Anne E. and Lamprecht, Michael R. and Moffat, Jason and Silver, Serena J. and Grenier, Jennifer K. and Castoreno, Adam B. and Eggert, Ulrike S. and Root, David E. and Golland, Polina and Sabatini, David M.},
+  year = {2009},
+  pages = {1826--1831},
+  eprint = {http://www.pnas.org/content/106/6/1826.full.pdf}
+}


### PR DESCRIPTION
Hello!

As discussed in [#3480](https://github.com/CellProfiler/CellProfiler/issues/3480). I think I got all the BibTeX snippets of the papers on [cellprofiler.org/citations](http://cellprofiler.org/citations/). Where the publisher didn't offer BibTeX, I imported them to [Zotero](http://zotero.org/) & exported with [Better BibTeX](https://retorque.re/zotero-better-bibtex/).

Cheers :-)