### PR TITLE
Use 3D feature names for 3D image/object measurements

### DIFF
--- a/cellprofiler/modules/measureimagequality.py
+++ b/cellprofiler/modules/measureimagequality.py
@@ -89,7 +89,7 @@ Measurements made by this module
       absolute deviation (MAD) of pixel intensity values.
    -  *MinIntensity, MaxIntensity:* Minimum and maximum of pixel
       intensity values.
-   -  *TotalArea:* Number of pixels measured.
+   -  *TotalArea/TotalVolume:* Number of pixels (or voxels) measured.
    -  *Scaling*: if *Yes* is chosen for "Include the image rescaling value?",
       image’s rescaling value will be stored as a quality control metric.
       This is useful in confirming that all images are rescaled by the same value,
@@ -1005,6 +1005,9 @@ to the foreground pixels or the background pixels.""" % globals()))
         if image.has_mask:
             pixels = pixels[image.mask]
 
+        volumetric = workspace.pipeline.volumetric()
+        area_text, area_measurement = ("Volume", F_TOTAL_VOLUME) if volumetric else ("Area", F_TOTAL_AREA)
+
         result = []
         pixel_count = np.product(pixels.shape)
         if pixel_count == 0:
@@ -1025,7 +1028,7 @@ to the foreground pixels or the background pixels.""" % globals()))
             pixel_max = np.max(pixels)
 
         m = workspace.measurements
-        m.add_image_measurement("_".join((C_IMAGE_QUALITY, F_TOTAL_AREA, image_name)), pixel_count)
+        m.add_image_measurement("_".join((C_IMAGE_QUALITY, area_measurement, image_name)), pixel_count)
         m.add_image_measurement("_".join((C_IMAGE_QUALITY, F_TOTAL_INTENSITY, image_name)), pixel_sum)
         m.add_image_measurement("_".join((C_IMAGE_QUALITY, F_MEAN_INTENSITY, image_name)), pixel_mean)
         m.add_image_measurement("_".join((C_IMAGE_QUALITY, F_MEDIAN_INTENSITY, image_name)), pixel_median)
@@ -1044,7 +1047,7 @@ to the foreground pixels or the background pixels.""" % globals()))
                                               ('MAD intensity', pixel_mad),
                                               ('Min intensity', pixel_min),
                                               ('Max intensity', pixel_max),
-                                              ('Total area', pixel_count))]
+                                              ('Total {}'.format(area_text), pixel_count))]
         return result
 
     def calculate_power_spectrum(self, image_group, workspace):

--- a/cellprofiler/modules/measureimagequality.py
+++ b/cellprofiler/modules/measureimagequality.py
@@ -177,6 +177,7 @@ F_LOCAL_FOCUS_SCORE = 'LocalFocusScore'
 F_CORRELATION = 'Correlation'
 F_POWER_SPECTRUM_SLOPE = 'PowerLogLogSlope'
 F_TOTAL_AREA = 'TotalArea'
+F_TOTAL_VOLUME = 'TotalVolume'
 F_TOTAL_INTENSITY = 'TotalIntensity'
 F_MEAN_INTENSITY = 'MeanIntensity'
 F_MEDIAN_INTENSITY = 'MedianIntensity'
@@ -184,7 +185,7 @@ F_STD_INTENSITY = 'StdIntensity'
 F_MAD_INTENSITY = 'MADIntensity'
 F_MAX_INTENSITY = 'MaxIntensity'
 F_MIN_INTENSITY = 'MinIntensity'
-INTENSITY_FEATURES = [F_TOTAL_AREA, F_TOTAL_INTENSITY, F_MEAN_INTENSITY, F_MEDIAN_INTENSITY, F_STD_INTENSITY,
+INTENSITY_FEATURES = [F_TOTAL_INTENSITY, F_MEAN_INTENSITY, F_MEDIAN_INTENSITY, F_STD_INTENSITY,
                       F_MAD_INTENSITY, F_MAX_INTENSITY, F_MIN_INTENSITY]
 F_PERCENT_MAXIMAL = 'PercentMaximal'
 F_PERCENT_MINIMAL = 'PercentMinimal'
@@ -645,7 +646,8 @@ to the foreground pixels or the background pixels.""" % globals()))
             # Intensity measurements
             if image_group.check_intensity.value:
                 for image_name in selected_images:
-                    for feature in INTENSITY_FEATURES:
+                    area_measurement = [F_TOTAL_VOLUME if pipeline.volumetric() else F_TOTAL_AREA]
+                    for feature in area_measurement + INTENSITY_FEATURES:
                         measurement_name = image_name
                         columns.append((cpmeas.IMAGE,
                                         '%s_%s_%s' % (C_IMAGE_QUALITY, feature,
@@ -702,6 +704,7 @@ to the foreground pixels or the background pixels.""" % globals()))
             if self.any_blur():
                 result += [F_FOCUS_SCORE, F_LOCAL_FOCUS_SCORE, F_POWER_SPECTRUM_SLOPE, F_CORRELATION]
             if self.any_intensity():
+                result += [F_TOTAL_VOLUME if pipeline.volumetric() else F_TOTAL_AREA]
                 result += INTENSITY_FEATURES
             if self.any_saturation():
                 result += SATURATION_FEATURES
@@ -741,7 +744,7 @@ to the foreground pixels or the background pixels.""" % globals()))
                     result += self.images_to_process(image_group, None, pipeline)
             return result
 
-        if measurement in INTENSITY_FEATURES:
+        if measurement in INTENSITY_FEATURES + [F_TOTAL_AREA, F_TOTAL_VOLUME]:
             result = []
             for image_group in self.image_groups:
                 if image_group.check_intensity.value:

--- a/cellprofiler/modules/measureimagequality.py
+++ b/cellprofiler/modules/measureimagequality.py
@@ -1363,7 +1363,7 @@ to the foreground pixels or the background pixels.
                 threshold_image = setting_values[i + 1]
                 threshold_method = setting_values[i + 2]
                 if saturation_image != cellprofiler.setting.DO_NOT_USE:
-                    if d not in saturation_image:
+                    if saturation_image not in d:
                         d[saturation_image] = {"check_blur": check_blur,
                                                "check_saturation": cellprofiler.setting.YES,
                                                "check_threshold": cellprofiler.setting.NO,
@@ -1372,7 +1372,7 @@ to the foreground pixels or the background pixels.
                         d[saturation_image]["check_blur"] = check_blur
                         d[saturation_image]["check_saturation"] = cellprofiler.setting.YES
                 if threshold_image != cellprofiler.setting.DO_NOT_USE:
-                    if d not in threshold_image:
+                    if threshold_image not in d:
                         d[threshold_image] = {"check_blur": cellprofiler.setting.NO,
                                               "check_saturation": cellprofiler.setting.NO,
                                               "check_threshold": cellprofiler.setting.YES,

--- a/cellprofiler/modules/measureimagequality.py
+++ b/cellprofiler/modules/measureimagequality.py
@@ -1,6 +1,23 @@
 # coding=utf-8
 
-"""
+import logging
+import numpy
+import scipy.ndimage
+import scipy.linalg.basic
+import centrosome.cpmorphology
+import centrosome.haralick
+import centrosome.threshold
+import centrosome.radial_power_spectrum
+import centrosome.threshold
+import itertools
+import identify
+import loadimages
+import cellprofiler.preferences
+import cellprofiler.module
+import cellprofiler.measurement
+import cellprofiler.setting
+
+__doc__ = """\
 MeasureImageQuality
 ===================
 
@@ -132,31 +149,7 @@ References
    `(link) <https://doi.org/10.1002/jemt.20118>`__
 """
 
-import logging
-
-import numpy as np
-
 logger = logging.getLogger(__name__)
-import scipy.ndimage as scind
-from scipy.linalg.basic import lstsq
-from centrosome.cpmorphology import fixup_scipy_ndimage_result as fix
-import centrosome.haralick
-import cellprofiler.module as cpm
-import cellprofiler.measurement as cpmeas
-import cellprofiler.setting as cps
-from cellprofiler.setting import YES, NO
-import centrosome.threshold as cpthresh
-import itertools
-import centrosome.radial_power_spectrum as rps
-from identify import O_TWO_CLASS, O_THREE_CLASS, O_WEIGHTED_VARIANCE, O_ENTROPY
-from identify import O_FOREGROUND, O_BACKGROUND
-from centrosome.threshold import TM_MOG, TM_OTSU
-from loadimages import C_FILE_NAME, C_SCALING
-import cellprofiler.preferences as cpprefs
-from cellprofiler.preferences import \
-    DEFAULT_OUTPUT_FOLDER_NAME, DEFAULT_INPUT_FOLDER_NAME, ABSOLUTE_FOLDER_NAME, \
-    DEFAULT_INPUT_SUBFOLDER_NAME, DEFAULT_OUTPUT_SUBFOLDER_NAME
-from cellprofiler.modules._help import IO_FOLDER_CHOICE_HELP_TEXT
 
 ##############################################
 #
@@ -165,12 +158,12 @@ from cellprofiler.modules._help import IO_FOLDER_CHOICE_HELP_TEXT
 ##############################################
 
 # Setting variables
-'''Image selection'''
+"""Image selection"""
 O_ALL_LOADED = "All loaded images"  # Use all loaded images
 O_SELECT = "Select..."  # Select the images you want from a list, all treated the same
 
 # Measurement names
-'''Root module measurement name'''
+"""Root module measurement name"""
 C_IMAGE_QUALITY = 'ImageQuality'
 F_FOCUS_SCORE = 'FocusScore'
 F_LOCAL_FOCUS_SCORE = 'LocalFocusScore'
@@ -203,87 +196,112 @@ SETTINGS_PER_GROUP_V3 = 11
 IMAGE_GROUP_SETTING_OFFSET = 2
 
 
-class MeasureImageQuality(cpm.Module):
+class MeasureImageQuality(cellprofiler.module.Module):
     module_name = "MeasureImageQuality"
     category = "Measurement"
     variable_revision_number = 5
 
     def create_settings(self):
-        self.images_choice = cps.Choice(
-                "Calculate metrics for which images?",
-                [O_ALL_LOADED, O_SELECT], doc="""\
+        self.images_choice = cellprofiler.setting.Choice(
+            text="Calculate metrics for which images?",
+            choices=[O_ALL_LOADED, O_SELECT],
+            doc="""\
 This option lets you choose which images will have quality metrics
 calculated.
 
--  *%(O_ALL_LOADED)s:* Use all images loaded with the **Input**
+-  *{O_ALL_LOADED}:* Use all images loaded with the **Input**
    modules. The selected quality metrics will be applied to all
    loaded images.
--  *%(O_SELECT)s:* Select the desired images from a list. The quality
-   metric settings selected will be applied to the images chosen.""" % globals())
+-  *{O_SELECT}:* Select the desired images from a list. The quality
+   metric settings selected will be applied to the images chosen.
+""".format(**{
+                "O_ALL_LOADED": O_ALL_LOADED,
+                "O_SELECT": O_SELECT
+            }
+           )
+        )
 
-        self.divider = cps.Divider(line=True)
+        self.divider = cellprofiler.setting.Divider(line=True)
 
         self.image_groups = []
-        self.image_count = cps.HiddenCount(self.image_groups, "Image count")
+        self.image_count = cellprofiler.setting.HiddenCount(self.image_groups, "Image count")
         self.add_image_group(can_remove=False)
-        self.add_image_button = cps.DoSomething("", "Add another image list", self.add_image_group)
+        self.add_image_button = cellprofiler.setting.DoSomething("", "Add another image list", self.add_image_group)
 
     def add_image_group(self, can_remove=True):
-        group = cps.SettingsGroup()
+        group = cellprofiler.setting.SettingsGroup()
 
         group.can_remove = can_remove
         if can_remove:
-            group.append("divider", cps.Divider(line=True))
+            group.append("divider", cellprofiler.setting.Divider(line=True))
 
-        group.append("image_names", cps.ImageNameSubscriberMultiChoice(
-                "Select the images to measure", doc="""\
-*(Used only if “%(O_SELECT)s” is chosen for selecting images)*
+        group.append("image_names", cellprofiler.setting.ImageNameSubscriberMultiChoice(
+            text="Select the images to measure",
+            doc="""\
+*(Used only if “{O_SELECT}” is chosen for selecting images)*
 
 Choose one or more images from this list. You can select multiple images
 by clicking using the shift or command keys. In addition to loaded
-images, the list includes the images that were created by prior modules.""" % globals()))
+images, the list includes the images that were created by prior modules.
+""".format(**{
+                "O_SELECT": O_SELECT
+            }
+           )
+        ))
 
-        group.append("include_image_scalings", cps.Binary(
-                "Include the image rescaling value?",
-                True, doc="""\
-Select *%(YES)s* to add the image’s rescaling value as a quality control
+        group.append("include_image_scalings",
+                     cellprofiler.setting.Binary(
+                         text="Include the image rescaling value?",
+                         value=True,
+                         doc="""\
+Select *{YES}* to add the image’s rescaling value as a quality control
 metric. This value is recorded only for images loaded using the
 **Input** modules. This is useful in confirming that all images are
 rescaled by the same value, given that some acquisition device vendors may
 output this value differently. See **NamesAndTypes** for more
-information.""" % globals()))
+information.""".format(**{
+                             "YES": cellprofiler.setting.YES
+                         }
+                       )
+                     )
+                     )
 
-        group.append("check_blur", cps.Binary(
-                "Calculate blur metrics?",
-                True, doc="""\
-Select *%(YES)s* to compute a series of blur metrics. The blur metrics
+        group.append("check_blur", cellprofiler.setting.Binary(
+            text="Calculate blur metrics?",
+            value=True, doc="""\
+Select *{YES}* to compute a series of blur metrics. The blur metrics
 are described in the overall help for this module (select the module in
-the pipeline and press the "?" button).""" % globals()))
+the pipeline and press the "?" button).
+""".format(**{
+                "YES": cellprofiler.setting.YES
+            }
+           )
+        ))
 
-        group.append("include_local_blur", cps.Binary(
-                "Include local blur metrics?",
-                True, doc="""
-            """))
+        group.append("include_local_blur", cellprofiler.setting.Binary(
+            text="Include local blur metrics?",
+            value=True))
 
         group.scale_groups = []
 
-        group.scale_count = cps.HiddenCount(group.scale_groups, "Scale count")
+        group.scale_count = cellprofiler.setting.HiddenCount(group.scale_groups, "Scale count")
 
         def add_scale_group(can_remove=True):
             self.add_scale_group(group, can_remove)
 
         add_scale_group(False)
 
-        group.append("add_scale_button", cps.DoSomething("",
-                                                         "Add another scale",
-                                                         add_scale_group, doc="""
+        group.append("add_scale_button", cellprofiler.setting.DoSomething("",
+                                                                          "Add another scale",
+                                                                          add_scale_group, doc="""
             Press this button to add another scale setting."""))
 
-        group.append("check_saturation", cps.Binary(
-                "Calculate saturation metrics?",
-                True, doc="""\
-Select *%(YES)s* to calculate the saturation metrics
-*%(F_PERCENT_MAXIMAL)s* and *%(F_PERCENT_MINIMAL)s*, i.e., the
+        group.append("check_saturation", cellprofiler.setting.Binary(
+            text="Calculate saturation metrics?",
+            value=True,
+            doc="""\
+Select *{YES}* to calculate the saturation metrics
+*{F_PERCENT_MAXIMAL}* and *{F_PERCENT_MINIMAL}*, i.e., the
 percentage of pixels at the upper or lower limit of each individual
 image.
 
@@ -292,91 +310,122 @@ images often have undergone some kind of transformation such that no
 pixels ever reach the absolute maximum or minimum of the image format.
 Given the noise typical in images, both these measures should be a low
 percentage but if the images were saturated during imaging, a higher
-than usual *%(F_PERCENT_MAXIMAL)s* will be observed, and if there are
-no objects, the *%(F_PERCENT_MINIMAL)s* value will increase.""" % globals()))
+than usual *{F_PERCENT_MAXIMAL}* will be observed, and if there are
+no objects, the *{F_PERCENT_MINIMAL}* value will increase.
+""".format(**{
+                "YES": cellprofiler.setting.YES,
+                "F_PERCENT_MAXIMAL": F_PERCENT_MAXIMAL,
+                "F_PERCENT_MINIMAL": F_PERCENT_MINIMAL
+            }
+           )
+        ))
 
-        group.append("check_intensity", cps.Binary(
-                "Calculate intensity metrics?",
-                True, doc="""\
-Select *%(YES)s* to calculate image-based intensity measures, namely the
+        group.append("check_intensity", cellprofiler.setting.Binary(
+            text="Calculate intensity metrics?",
+            value=True,
+            doc="""\
+Select *{YES}* to calculate image-based intensity measures, namely the
 mean, maximum, minimum, standard deviation and median absolute deviation
 of pixel intensities. These measures are identical to those calculated
-by **MeasureImageIntensity**.""" % globals()))
+by **MeasureImageIntensity**.
+""".format(**{
+                "YES": cellprofiler.setting.YES
+            }
+           )
+        ))
 
-        group.append("calculate_threshold", cps.Binary(
-                "Calculate thresholds?",
-                True, doc="""\
+        group.append("calculate_threshold", cellprofiler.setting.Binary(
+            text="Calculate thresholds?",
+            value=True,
+            doc="""\
 Automatically calculate a suggested threshold for each image. One
 indicator of image quality is that these threshold values lie within a
 typical range. Outlier images with high or low thresholds often contain
 artifacts."""))
 
-        group.append("use_all_threshold_methods", cps.Binary(
-                "Use all thresholding methods?",
-                False, doc="""\
+        group.append("use_all_threshold_methods", cellprofiler.setting.Binary(
+            text="Use all thresholding methods?",
+            value=False,
+            doc="""\
 *(Used only if image thresholds are calculated)*
 
-Select *%(YES)s* to calculate thresholds using all the available
+Select *{YES}* to calculate thresholds using all the available
 methods. Only the global methods are used.
 While most methods are straightfoward, some methods have additional
 parameters that require special handling:
 
--  *%(TM_OTSU)s:* Thresholds for all combinations of class number,
+-  *{TM_OTSU}:* Thresholds for all combinations of class number,
    minimization parameter and middle class assignment are computed.
--  *Mixture of Gaussians (%(TM_MOG)s):* Thresholds for image coverage
+-  *Mixture of Gaussians ({TM_MOG}):* Thresholds for image coverage
    fractions of 0.05, 0.25, 0.75 and 0.95 are computed.
 
 See the **IdentifyPrimaryObjects** module for more information on
-thresholding methods.""" % globals()))
+thresholding methods.
+""".format(**{
+                "YES": cellprofiler.setting.YES,
+                "TM_OTSU": centrosome.threshold.TM_OTSU,
+                "TM_MOG": centrosome.threshold.TM_MOG
+            }
+           )
+        ))
 
         group.threshold_groups = []
 
-        group.threshold_count = cps.HiddenCount(group.threshold_groups, "Threshold count")
+        group.threshold_count = cellprofiler.setting.HiddenCount(group.threshold_groups, "Threshold count")
 
         def add_threshold_group(can_remove=True):
             self.add_threshold_group(group, can_remove)
 
         add_threshold_group(False)
 
-        group.append("add_threshold_button", cps.DoSomething("",
-                                                             "Add another threshold method",
-                                                             add_threshold_group, doc="""
+        group.append("add_threshold_button", cellprofiler.setting.DoSomething("",
+                                                                              "Add another threshold method",
+                                                                              add_threshold_group, doc="""
             Press this button to add another set of threshold settings."""))
 
         if can_remove:
             group.append("remove_button",
-                         cps.RemoveSettingButton("", "Remove this image list", self.image_groups, group))
+                         cellprofiler.setting.RemoveSettingButton("", "Remove this image list", self.image_groups,
+                                                                  group))
         self.image_groups.append(group)
         return group
 
     def add_scale_group(self, image_group, can_remove=True):
-        group = cps.SettingsGroup()
+        group = cellprofiler.setting.SettingsGroup()
         image_group.scale_groups.append(group)
 
         group.image_names = image_group.image_names
 
-        group.append("divider", cps.Divider(line=False))
+        group.append("divider", cellprofiler.setting.Divider(line=False))
 
-        group.append('scale', cps.Integer(
-                "Spatial scale for blur measurements",
-                len(image_group.scale_groups) * 10 + 10, doc="""\
+        group.append('scale', cellprofiler.setting.Integer(
+            text="Spatial scale for blur measurements",
+            value=len(image_group.scale_groups) * 10 + 10,
+            doc="""\
 *(Used only if blur measurements are to be calculated)*
 
 Enter an integer for the window size *N*, in units of pixels.
-The *%(F_LOCAL_FOCUS_SCORE)s* is measured within an *N × N* pixel
-window applied to the image, and the *%(F_CORRELATION)s* of a
+The *{F_LOCAL_FOCUS_SCORE}* is measured within an *N × N* pixel
+window applied to the image, and the *{F_CORRELATION}* of a
 pixel is measured with respect to its neighbors *N* pixels away.
 
 A higher number for the window size *N* measures larger patterns of image
 blur whereas smaller numbers measure more localized patterns of blur. We
 suggest selecting a window size that is on the order of the feature of
 interest (e.g., the object diameter). You can measure these metrics for
-multiple window sizes by selecting additional scales for each image.""" % globals()))
+multiple window sizes by selecting additional scales for each image.
+""".format(**{
+                "F_LOCAL_FOCUS_SCORE": F_LOCAL_FOCUS_SCORE,
+                "F_CORRELATION": F_CORRELATION
+            }
+           )
+        ))
 
         group.can_remove = can_remove
         if can_remove:
             group.append("remove_button",
-                         cps.RemoveSettingButton("", "Remove this scale", image_group.scale_groups, group))
+                         cellprofiler.setting.RemoveSettingButton("", "Remove this scale", image_group.scale_groups,
+                                                                  group))
 
     def add_threshold_group(self, image_group=None, can_remove=True):
         group = ImageQualitySettingsGroup()
@@ -385,34 +434,44 @@ multiple window sizes by selecting additional scales for each image.""" % global
             image_group.threshold_groups.append(group)
             group.image_names = image_group.image_names
 
-        group.append("divider", cps.Divider(line=False))
+        group.append("divider", cellprofiler.setting.Divider(line=False))
 
-        group.append("threshold_method", cps.Choice("Select a thresholding method",
-                                                    cpthresh.TM_METHODS,
-                                                    cpthresh.TM_OTSU, doc="""\
+        group.append("threshold_method", cellprofiler.setting.Choice("Select a thresholding method",
+                                                                     centrosome.threshold.TM_METHODS,
+                                                                     centrosome.threshold.TM_OTSU, doc="""\
 *(Used only if particular thresholds are to be calculated)*
 
 This setting allows you to apply automatic thresholding methods used in
 the **Identify** modules. Only the global methods are applied. For more
 help on thresholding, see the **Identify** modules."""))
 
-        group.append("object_fraction", cps.Float(
-                "Typical fraction of the image covered by objects", 0.1, 0, 1, doc="""\
-*(Used only if thresholds are calculated and %(TM_MOG)s thresholding is
+        group.append("object_fraction", cellprofiler.setting.Float(
+            text="Typical fraction of the image covered by objects",
+            value=0.1,
+            minval=0,
+            maxval=1,
+            doc="""\
+*(Used only if thresholds are calculated and {TM_MOG} thresholding is
 chosen)*
 
 Enter the approximate fraction of the typical image in the set that is
-covered by objects.""" % globals()))
+covered by objects.
+""".format(**{
+                "TM_MOG": centrosome.threshold.TM_MOG
+            }
+           )
+        ))
 
-        group.append("two_class_otsu", cps.Choice(
-                'Two-class or three-class thresholding?',
-                [O_TWO_CLASS, O_THREE_CLASS], doc="""\
-*(Used only if thresholds are calculated and the %(TM_OTSU)s
+        group.append("two_class_otsu", cellprofiler.setting.Choice(
+            text='Two-class or three-class thresholding?',
+            choices=[identify.O_TWO_CLASS, identify.O_THREE_CLASS],
+            doc="""\
+*(Used only if thresholds are calculated and the {TM_OTSU}
 thresholding method is used)*
 
-Select *%(O_TWO_CLASS)s* if the grayscale levels are readily
+Select *{O_TWO_CLASS}* if the grayscale levels are readily
 distinguishable into foreground (i.e., objects) and background. Select
-*%(O_THREE_CLASS)s* if there is a middle set of grayscale levels
+*{O_THREE_CLASS}* if there is a middle set of grayscale levels
 that belongs to neither the foreground nor background.
 
 For example, three-class thresholding may be useful for images in which
@@ -422,34 +481,49 @@ intermediate staining to the nuclei objects, three-class thresholding
 allows you to assign it to the foreground or background as desired.
 However, in extreme cases where either there are almost no objects or
 the entire field of view is covered with objects, three-class
-thresholding may perform worse than two-class.""" % globals()))
+thresholding may perform worse than two-class.
+""".format(**{
+                "TM_OTSU": centrosome.threshold.TM_OTSU,
+                "O_TWO_CLASS": identify.O_TWO_CLASS,
+                "O_THREE_CLASS": identify.O_THREE_CLASS
+            }
+           )
+        ))
 
-        group.append("use_weighted_variance", cps.Choice(
-                'Minimize the weighted variance or the entropy?',
-                [O_WEIGHTED_VARIANCE, O_ENTROPY], doc="""\
+        group.append("use_weighted_variance", cellprofiler.setting.Choice(
+            text='Minimize the weighted variance or the entropy?',
+            choices=[identify.O_WEIGHTED_VARIANCE, identify.O_ENTROPY],
+            doc="""\
 Choose whether to minimize the weighted variance or the entropy when selecting
 the threshold."""))
 
-        group.append("assign_middle_to_foreground", cps.Choice(
-                'Assign pixels in the middle intensity class to the foreground or the background?',
-                [O_FOREGROUND, O_BACKGROUND], doc="""\
-*(Used only if thresholds are calculated and the %(TM_OTSU)s
-thresholding method with %(O_THREE_CLASS)s is used)*
+        group.append("assign_middle_to_foreground", cellprofiler.setting.Choice(
+            text='Assign pixels in the middle intensity class to the foreground or the background?',
+            choices=[identify.O_FOREGROUND, identify.O_BACKGROUND],
+            doc="""\
+*(Used only if thresholds are calculated and the {TM_OTSU}
+thresholding method with {O_THREE_CLASS} is used)*
 
 Choose whether you want the middle grayscale intensities to be assigned
-to the foreground pixels or the background pixels.""" % globals()))
+to the foreground pixels or the background pixels.
+""".format(**{
+                "TM_OTSU": centrosome.threshold.TM_OTSU,
+                "O_THREE_CLASS": identify.O_THREE_CLASS
+            }
+           )
+        ))
 
         group.can_remove = can_remove
         if can_remove and image_group is not None:
-            group.append("remove_button", cps.RemoveSettingButton(
-                    "", "Remove this threshold method", image_group.threshold_groups, group))
+            group.append("remove_button", cellprofiler.setting.RemoveSettingButton(
+                "", "Remove this threshold method", image_group.threshold_groups, group))
 
         if image_group is None:
             return group
 
     def prepare_settings(self, setting_values):
-        '''Adjust image_groups and threshold_groups to account for the expected # of
-            images, scales, and threshold methods'''
+        """Adjust image_groups and threshold_groups to account for the expected # of
+            images, scales, and threshold methods"""
         image_group_count = int(setting_values[1])
         del self.image_groups[:]
         for i in range(image_group_count):
@@ -467,7 +541,7 @@ to the foreground pixels or the background pixels.""" % globals()))
                     fn(image_group, can_remove)
 
     def settings(self):
-        '''The settings in the save / load order'''
+        """The settings in the save / load order"""
         result = [self.images_choice]
         result += [self.image_count]
         for image_group in self.image_groups:
@@ -492,7 +566,7 @@ to the foreground pixels or the background pixels.""" % globals()))
         return result
 
     def visible_settings(self):
-        '''The settings as displayed to the user'''
+        """The settings as displayed to the user"""
         result = [self.images_choice]
         if self.images_choice.value == O_ALL_LOADED:
             del self.image_groups[1:]
@@ -539,12 +613,12 @@ to the foreground pixels or the background pixels.""" % globals()))
             if threshold_group.can_remove:
                 result += [threshold_group.divider]
             result += [threshold_group.threshold_method]
-            if threshold_group.threshold_method.value == cpthresh.TM_MOG:
+            if threshold_group.threshold_method.value == centrosome.threshold.TM_MOG:
                 result += [threshold_group.object_fraction]
-            elif threshold_group.threshold_method.value == cpthresh.TM_OTSU:
+            elif threshold_group.threshold_method.value == centrosome.threshold.TM_OTSU:
                 result += [threshold_group.use_weighted_variance,
                            threshold_group.two_class_otsu]
-                if threshold_group.two_class_otsu.value == O_THREE_CLASS:
+                if threshold_group.two_class_otsu.value == identify.O_THREE_CLASS:
                     result += [threshold_group.assign_middle_to_foreground]
             if threshold_group.can_remove:
                 result += [threshold_group.remove_button]
@@ -552,54 +626,56 @@ to the foreground pixels or the background pixels.""" % globals()))
         return result
 
     def validate_module(self, pipeline):
-        '''Make sure a measurement is selected in image_names'''
+        """Make sure a measurement is selected in image_names"""
         if self.images_choice.value == O_SELECT:
             for image_group in self.image_groups:
                 if not image_group.image_names.get_selections():
-                    raise cps.ValidationError("Please choose at least one image", image_group.image_names)
+                    raise cellprofiler.setting.ValidationError("Please choose at least one image",
+                                                               image_group.image_names)
 
-        '''Make sure settings are compatible. In particular, we make sure that no measurements are duplicated'''
+        """Make sure settings are compatible. In particular, we make sure that no measurements are duplicated"""
         measurements, sources = self.get_measurement_columns(pipeline, return_sources=True)
         d = {}
         for m, s in zip(measurements, sources):
             m = (m[0], m[1])
             if m in d:
-                raise cps.ValidationError("Measurement %s for image %s made twice." % (m[1], s[1]), s[0])
+                raise cellprofiler.setting.ValidationError("Measurement {} for image {} made twice.".format(m[1], s[1]),
+                                                           s[0])
             d[m] = True
 
     def prepare_run(self, workspace):
-        if cpprefs.get_headless():
+        if cellprofiler.preferences.get_headless():
             logger.warning(
-                    "Experiment-wide values for mean threshold, etc calculated by MeasureImageQuality may be incorrect if the run is split into subsets of images.")
+                "Experiment-wide values for mean threshold, etc calculated by MeasureImageQuality may be incorrect if the run is split into subsets of images.")
         return True
 
     def any_scaling(self):
-        '''True if some image has its rescaling value calculated'''
+        """True if some image has its rescaling value calculated"""
         return any([image_group.include_image_scalings.value
                     for image_group in self.image_groups])
 
     def any_threshold(self):
-        '''True if some image has its threshold calculated'''
+        """True if some image has its threshold calculated"""
         return any([image_group.calculate_threshold.value
                     for image_group in self.image_groups])
 
     def any_saturation(self):
-        '''True if some image has its saturation calculated'''
+        """True if some image has its saturation calculated"""
         return any([image_group.check_saturation.value
                     for image_group in self.image_groups])
 
     def any_blur(self):
-        '''True if some image has its blur calculated'''
+        """True if some image has its blur calculated"""
         return any([image_group.check_blur.value
                     for image_group in self.image_groups])
 
     def any_intensity(self):
-        '''True if some image has its intensity calculated'''
+        """True if some image has its intensity calculated"""
         return any([image_group.check_intensity.value
                     for image_group in self.image_groups])
 
     def get_measurement_columns(self, pipeline, return_sources=False):
-        '''Return column definitions for all measurements'''
+        """Return column definitions for all measurements"""
         columns = []
         sources = []
         for image_group in self.image_groups:
@@ -607,40 +683,40 @@ to the foreground pixels or the background pixels.""" % globals()))
             # Image scalings
             if image_group.include_image_scalings.value:
                 for image_name in selected_images:
-                    columns.append((cpmeas.IMAGE,
-                                    '%s_%s_%s' % (C_IMAGE_QUALITY, C_SCALING,
-                                                  image_name),
-                                    cpmeas.COLTYPE_FLOAT))
+                    columns.append((cellprofiler.measurement.IMAGE,
+                                    '{}_{}_{}'.format(C_IMAGE_QUALITY, loadimages.C_SCALING,
+                                                      image_name),
+                                    cellprofiler.measurement.COLTYPE_FLOAT))
                     sources.append([image_group.include_image_scalings, image_name])
 
             # Blur measurements
             if image_group.check_blur.value:
                 for image_name in selected_images:
-                    columns.append((cpmeas.IMAGE,
-                                    '%s_%s_%s' % (C_IMAGE_QUALITY, F_FOCUS_SCORE,
-                                                  image_name),
-                                    cpmeas.COLTYPE_FLOAT))
+                    columns.append((cellprofiler.measurement.IMAGE,
+                                    '{}_{}_{}'.format(C_IMAGE_QUALITY, F_FOCUS_SCORE,
+                                                      image_name),
+                                    cellprofiler.measurement.COLTYPE_FLOAT))
                     sources.append([image_group.check_blur, image_name])
 
-                    columns.append((cpmeas.IMAGE,
-                                    '%s_%s_%s' % (C_IMAGE_QUALITY, F_POWER_SPECTRUM_SLOPE,
-                                                  image_name),
-                                    cpmeas.COLTYPE_FLOAT))
+                    columns.append((cellprofiler.measurement.IMAGE,
+                                    '{}_{}_{}'.format(C_IMAGE_QUALITY, F_POWER_SPECTRUM_SLOPE,
+                                                      image_name),
+                                    cellprofiler.measurement.COLTYPE_FLOAT))
                     sources.append([image_group.check_blur, image_name])
 
                     for scale_group in image_group.scale_groups:
-                        columns.append((cpmeas.IMAGE,
-                                        '%s_%s_%s_%d' % (C_IMAGE_QUALITY, F_LOCAL_FOCUS_SCORE,
-                                                         image_name,
-                                                         scale_group.scale.value),
-                                        cpmeas.COLTYPE_FLOAT))
+                        columns.append((cellprofiler.measurement.IMAGE,
+                                        '{}_{}_{}_{:d}'.format(C_IMAGE_QUALITY, F_LOCAL_FOCUS_SCORE,
+                                                               image_name,
+                                                               scale_group.scale.value),
+                                        cellprofiler.measurement.COLTYPE_FLOAT))
                         sources.append([scale_group.scale, image_name])
 
-                        columns.append((cpmeas.IMAGE,
-                                        '%s_%s_%s_%d' % (C_IMAGE_QUALITY, F_CORRELATION,
-                                                         image_name,
-                                                         scale_group.scale.value),
-                                        cpmeas.COLTYPE_FLOAT))
+                        columns.append((cellprofiler.measurement.IMAGE,
+                                        '{}_{}_{}_{:d}'.format(C_IMAGE_QUALITY, F_CORRELATION,
+                                                               image_name,
+                                                               scale_group.scale.value),
+                                        cellprofiler.measurement.COLTYPE_FLOAT))
                         sources.append([scale_group.scale, image_name])
 
             # Intensity measurements
@@ -649,20 +725,20 @@ to the foreground pixels or the background pixels.""" % globals()))
                     area_measurement = [F_TOTAL_VOLUME if pipeline.volumetric() else F_TOTAL_AREA]
                     for feature in area_measurement + INTENSITY_FEATURES:
                         measurement_name = image_name
-                        columns.append((cpmeas.IMAGE,
-                                        '%s_%s_%s' % (C_IMAGE_QUALITY, feature,
-                                                      measurement_name),
-                                        cpmeas.COLTYPE_FLOAT))
+                        columns.append((cellprofiler.measurement.IMAGE,
+                                        '{}_{}_{}'.format(C_IMAGE_QUALITY, feature,
+                                                          measurement_name),
+                                        cellprofiler.measurement.COLTYPE_FLOAT))
                         sources.append([image_group.check_intensity, image_name])
 
             # Saturation measurements
             if image_group.check_saturation.value:
                 for image_name in selected_images:
                     for feature in SATURATION_FEATURES:
-                        columns.append((cpmeas.IMAGE,
-                                        '%s_%s_%s' % (C_IMAGE_QUALITY, feature,
-                                                      image_name),
-                                        cpmeas.COLTYPE_FLOAT))
+                        columns.append((cellprofiler.measurement.IMAGE,
+                                        '{}_{}_{}'.format(C_IMAGE_QUALITY, feature,
+                                                          image_name),
+                                        cellprofiler.measurement.COLTYPE_FLOAT))
                         sources.append([image_group.check_saturation, image_name])
 
             # Threshold measurements
@@ -671,13 +747,14 @@ to the foreground pixels or the background pixels.""" % globals()))
                 for image_name in selected_images:
                     for threshold_group in all_threshold_groups:
                         feature = threshold_group.threshold_feature_name(image_name)
-                        columns.append((cpmeas.IMAGE, feature, cpmeas.COLTYPE_FLOAT))
+                        columns.append(
+                            (cellprofiler.measurement.IMAGE, feature, cellprofiler.measurement.COLTYPE_FLOAT))
                         for agg in ("Mean", "Median", "Std"):
                             feature = threshold_group.threshold_feature_name(
-                                    image_name, agg)
+                                image_name, agg)
                             columns.append(
-                                    (cpmeas.EXPERIMENT, feature, cpmeas.COLTYPE_FLOAT,
-                                     {cpmeas.MCA_AVAILABLE_POST_RUN: True}))
+                                (cellprofiler.measurement.EXPERIMENT, feature, cellprofiler.measurement.COLTYPE_FLOAT,
+                                 {cellprofiler.measurement.MCA_AVAILABLE_POST_RUN: True}))
 
                         if image_group.use_all_threshold_methods:
                             sources.append([image_group.use_all_threshold_methods, image_name])
@@ -690,17 +767,17 @@ to the foreground pixels or the background pixels.""" % globals()))
             return columns
 
     def get_categories(self, pipeline, object_name):
-        if object_name == cpmeas.IMAGE:
+        if object_name == cellprofiler.measurement.IMAGE:
             return [C_IMAGE_QUALITY]
-        elif object_name == cpmeas.EXPERIMENT and self.any_threshold():
+        elif object_name == cellprofiler.measurement.EXPERIMENT and self.any_threshold():
             return [C_IMAGE_QUALITY]
         return []
 
     def get_measurements(self, pipeline, object_name, category):
-        if object_name == cpmeas.IMAGE and category == C_IMAGE_QUALITY:
+        if object_name == cellprofiler.measurement.IMAGE and category == C_IMAGE_QUALITY:
             result = []
             if self.any_scaling():
-                result += [C_SCALING]
+                result += [loadimages.C_SCALING]
             if self.any_blur():
                 result += [F_FOCUS_SCORE, F_LOCAL_FOCUS_SCORE, F_POWER_SPECTRUM_SLOPE, F_CORRELATION]
             if self.any_intensity():
@@ -720,7 +797,7 @@ to the foreground pixels or the background pixels.""" % globals()))
                 result += sorted(list(set(thresholds)))
 
             return result
-        elif object_name == cpmeas.EXPERIMENT and category == C_IMAGE_QUALITY:
+        elif object_name == cellprofiler.measurement.EXPERIMENT and category == C_IMAGE_QUALITY:
             return [MEAN_THRESH_ALL_IMAGES, MEDIAN_THRESH_ALL_IMAGES,
                     STD_THRESH_ALL_IMAGES]
         return []
@@ -728,7 +805,7 @@ to the foreground pixels or the background pixels.""" % globals()))
     def get_measurement_images(self, pipeline, object_name, category,
                                measurement):
 
-        if object_name != cpmeas.IMAGE or category != C_IMAGE_QUALITY:
+        if object_name != cellprofiler.measurement.IMAGE or category != C_IMAGE_QUALITY:
             return []
         if measurement in (F_FOCUS_SCORE, F_LOCAL_FOCUS_SCORE, F_POWER_SPECTRUM_SLOPE, F_CORRELATION):
             result = []
@@ -759,14 +836,14 @@ to the foreground pixels or the background pixels.""" % globals()))
                     else image_group.threshold_groups
                 for threshold_group in all_threshold_groups:
                     if (image_group.calculate_threshold.value and
-                                measurement == F_THRESHOLD + threshold_group.threshold_algorithm):
+                            measurement == F_THRESHOLD + threshold_group.threshold_algorithm):
                         result += self.images_to_process(image_group, None, pipeline)
             return result
 
     def get_measurement_scales(self, pipeline, object_name, category,
                                measurement, image_names):
-        '''Get the scales (window_sizes) for the given measurement'''
-        if object_name == cpmeas.IMAGE and category == C_IMAGE_QUALITY:
+        """Get the scales (window_sizes) for the given measurement"""
+        if object_name == cellprofiler.measurement.IMAGE and category == C_IMAGE_QUALITY:
             if measurement in (F_LOCAL_FOCUS_SCORE, F_CORRELATION):
                 result = []
                 for image_group in self.image_groups:
@@ -787,7 +864,7 @@ to the foreground pixels or the background pixels.""" % globals()))
         return []
 
     def run(self, workspace):
-        '''Calculate statistics over all image groups'''
+        """Calculate statistics over all image groups"""
         statistics = []
         for image_group in self.image_groups:
             statistics += self.run_on_image_group(image_group, workspace)
@@ -800,13 +877,13 @@ to the foreground pixels or the background pixels.""" % globals()))
             figure.subplot_table(0, 0, statistics)
 
     def post_run(self, workspace):
-        '''Calculate the experiment statistics at the end of a run'''
+        """Calculate the experiment statistics at the end of a run"""
         statistics = []
         for image_group in self.image_groups:
             statistics += self.calculate_experiment_threshold(image_group, workspace)
 
     def run_on_image_group(self, image_group, workspace):
-        '''Calculate statistics for a particular image'''
+        """Calculate statistics for a particular image"""
         statistics = []
         if image_group.include_image_scalings.value:
             statistics += self.retrieve_image_scalings(image_group, workspace)
@@ -824,20 +901,20 @@ to the foreground pixels or the background pixels.""" % globals()))
         return statistics
 
     def retrieve_image_scalings(self, image_group, workspace):
-        '''Grab the scalings from the image '''
+        """Grab the scalings from the image """
 
         result = []
         for image_name in self.images_to_process(image_group, workspace):
-            feature = "%s_%s_%s" % (C_IMAGE_QUALITY, C_SCALING, image_name)
+            feature = "{}_{}_{}".format(C_IMAGE_QUALITY, loadimages.C_SCALING, image_name)
             value = workspace.image_set.get_image(image_name).scale
             if not value:  # Set to NaN if not defined, such as for derived images
-                value = np.NaN
-            workspace.add_measurement(cpmeas.IMAGE, feature, value)
-            result += [["%s scaling" % image_name, value]]
+                value = numpy.NaN
+            workspace.add_measurement(cellprofiler.measurement.IMAGE, feature, value)
+            result += [["{} scaling".format(image_name), value]]
         return result
 
     def calculate_focus_scores(self, image_group, workspace):
-        '''Calculate a local blur measurement and a image-wide one'''
+        """Calculate a local blur measurement and a image-wide one"""
 
         result = []
         for image_name in self.images_to_process(image_group, workspace):
@@ -855,43 +932,44 @@ to the foreground pixels or the background pixels.""" % globals()))
 
                 focus_score = 0
                 if len(pixel_data):
-                    mean_image_value = np.mean(pixel_data)
+                    mean_image_value = numpy.mean(pixel_data)
                     squared_normalized_image = (pixel_data - mean_image_value) ** 2
                     if mean_image_value > 0:
-                        focus_score = (np.sum(squared_normalized_image) /
-                                       (np.product(pixel_data.shape) * mean_image_value))
+                        focus_score = (numpy.sum(squared_normalized_image) /
+                                       (numpy.product(pixel_data.shape) * mean_image_value))
                 #
                 # Create a labels matrix that grids the image to the dimensions
                 # of the window size
                 #
                 if image.dimensions is 2:
-                    i, j = np.mgrid[0:shape[0], 0:shape[1]].astype(float)
-                    m, n = (np.array(shape) + scale - 1) / scale
+                    i, j = numpy.mgrid[0:shape[0], 0:shape[1]].astype(float)
+                    m, n = (numpy.array(shape) + scale - 1) / scale
                     i = (i * float(m) / float(shape[0])).astype(int)
                     j = (j * float(n) / float(shape[1])).astype(int)
                     grid = i * n + j + 1
                 else:
-                    k, i, j = np.mgrid[0:shape[0], 0:shape[1], 0:shape[2]].astype(float)
-                    o, m, n = (np.array(shape) + scale - 1) / scale
+                    k, i, j = numpy.mgrid[0:shape[0], 0:shape[1], 0:shape[2]].astype(float)
+                    o, m, n = (numpy.array(shape) + scale - 1) / scale
                     k = (k * float(o) / float(shape[0])).astype(int)
                     i = (i * float(m) / float(shape[1])).astype(int)
                     j = (j * float(n) / float(shape[2])).astype(int)
                     grid = k * o + i * n + j + 1  # hmm
 
                 if image.has_mask:
-                    grid[np.logical_not(image.mask)] = 0
-                grid_range = np.arange(0, m * n + 1, dtype=np.int32)
+                    grid[numpy.logical_not(image.mask)] = 0
+                grid_range = numpy.arange(0, m * n + 1, dtype=numpy.int32)
                 #
                 # Do the math per label
                 #
-                local_means = fix(scind.mean(image.pixel_data, grid, grid_range))
+                local_means = centrosome.cpmorphology.fixup_scipy_ndimage_result(
+                    scipy.ndimage.mean(image.pixel_data, grid, grid_range))
                 local_squared_normalized_image = (image.pixel_data -
                                                   local_means[grid]) ** 2
                 #
                 # Compute the sum of local_squared_normalized_image values for each
                 # grid for means > 0. Exclude grid label = 0 because that's masked
                 #
-                grid_mask = (local_means != 0) & ~ np.isnan(local_means)
+                grid_mask = (local_means != 0) & ~ numpy.isnan(local_means)
                 nz_grid_range = grid_range[grid_mask]
                 if len(nz_grid_range) and nz_grid_range[0] == 0:
                     nz_grid_range = nz_grid_range[1:]
@@ -899,40 +977,42 @@ to the foreground pixels or the background pixels.""" % globals()))
                     grid_mask = grid_mask[1:]
                 local_focus_score += [0]  # assume the worst - that we can't calculate it
                 if len(nz_grid_range):
-                    sums = fix(scind.sum(local_squared_normalized_image, grid,
-                                         nz_grid_range))
-                    pixel_counts = fix(scind.sum(np.ones(shape), grid, nz_grid_range))
+                    sums = centrosome.cpmorphology.fixup_scipy_ndimage_result(
+                        scipy.ndimage.sum(local_squared_normalized_image, grid,
+                                          nz_grid_range))
+                    pixel_counts = centrosome.cpmorphology.fixup_scipy_ndimage_result(
+                        scipy.ndimage.sum(numpy.ones(shape), grid, nz_grid_range))
                     local_norm_var = (sums /
                                       (pixel_counts * local_means[grid_mask]))
-                    local_norm_median = np.median(local_norm_var)
-                    if np.isfinite(local_norm_median) and local_norm_median > 0:
-                        local_focus_score[-1] = np.var(local_norm_var) / local_norm_median
+                    local_norm_median = numpy.median(local_norm_var)
+                    if numpy.isfinite(local_norm_median) and local_norm_median > 0:
+                        local_focus_score[-1] = numpy.var(local_norm_var) / local_norm_median
 
             #
             # Add the measurements
             #
-            focus_score_name = "%s_%s_%s" % (C_IMAGE_QUALITY, F_FOCUS_SCORE,
-                                             image_name)
-            workspace.add_measurement(cpmeas.IMAGE, focus_score_name,
+            focus_score_name = "{}_{}_{}".format(C_IMAGE_QUALITY, F_FOCUS_SCORE,
+                                                 image_name)
+            workspace.add_measurement(cellprofiler.measurement.IMAGE, focus_score_name,
                                       focus_score)
-            result += [["%s focus score @%d" % (image_name,
-                                                scale), focus_score]]
+            result += [["{} focus score @{:d}".format(image_name,
+                                                      scale), focus_score]]
 
             for idx, scale_group in enumerate(image_group.scale_groups):
                 scale = scale_group.scale.value
-                local_focus_score_name = "%s_%s_%s_%d" % (C_IMAGE_QUALITY,
-                                                          F_LOCAL_FOCUS_SCORE,
-                                                          image_name,
-                                                          scale)
-                workspace.add_measurement(cpmeas.IMAGE, local_focus_score_name,
+                local_focus_score_name = "{}_{}_{}_{:d}".format(C_IMAGE_QUALITY,
+                                                                F_LOCAL_FOCUS_SCORE,
+                                                                image_name,
+                                                                scale)
+                workspace.add_measurement(cellprofiler.measurement.IMAGE, local_focus_score_name,
                                           local_focus_score[idx])
-                result += [["%s local focus score @%d" % (image_name,
-                                                          scale), local_focus_score[idx]]]
+                result += [["{} local focus score @{:d}".format(image_name,
+                                                                scale), local_focus_score[idx]]]
 
         return result
 
     def calculate_correlation(self, image_group, workspace):
-        '''Calculate a correlation measure from the Harlick feature set'''
+        """Calculate a correlation measure from the Harlick feature set"""
         result = []
         for image_name in self.images_to_process(image_group, workspace):
             image = workspace.image_set.get_image(image_name,
@@ -940,24 +1020,24 @@ to the foreground pixels or the background pixels.""" % globals()))
             pixel_data = image.pixel_data
 
             # Compute Haralick's correlation texture for the given scales
-            image_labels = np.ones(pixel_data.shape, int)
+            image_labels = numpy.ones(pixel_data.shape, int)
             if image.has_mask:
                 image_labels[~image.mask] = 0
             for scale_group in image_group.scale_groups:
                 scale = scale_group.scale.value
 
                 value = centrosome.haralick.Haralick(pixel_data, image_labels, 0, scale).H3()
-                if not np.isfinite(value):
+                if not numpy.isfinite(value):
                     value = 0.0
-                workspace.add_measurement(cpmeas.IMAGE, "%s_%s_%s_%d" %
-                                          (C_IMAGE_QUALITY, F_CORRELATION,
-                                           image_name, scale),
+                workspace.add_measurement(cellprofiler.measurement.IMAGE, "{}_{}_{}_{:d}"
+                                          .format(C_IMAGE_QUALITY, F_CORRELATION,
+                                                  image_name, scale),
                                           float(value))
-                result += [["%s %s @%d" % (image_name, F_CORRELATION, scale), "%.2f" % (float(value))]]
+                result += [["{} {} @{:d}".format(image_name, F_CORRELATION, scale), "{:.2f}".format(float(value))]]
         return result
 
     def calculate_saturation(self, image_group, workspace):
-        '''Count the # of pixels at saturation'''
+        """Count the # of pixels at saturation"""
 
         result = []
         for image_name in self.images_to_process(image_group, workspace):
@@ -966,32 +1046,31 @@ to the foreground pixels or the background pixels.""" % globals()))
             pixel_data = image.pixel_data
             if image.has_mask:
                 pixel_data = pixel_data[image.mask]
-            pixel_count = np.product(pixel_data.shape)
+            pixel_count = numpy.product(pixel_data.shape)
             if pixel_count == 0:
-                percent_saturation = 0
                 percent_maximal = 0
                 percent_minimal = 0
             else:
-                number_pixels_maximal = np.sum(pixel_data == np.max(pixel_data))
-                number_pixels_minimal = np.sum(pixel_data == np.min(pixel_data))
+                number_pixels_maximal = numpy.sum(pixel_data == numpy.max(pixel_data))
+                number_pixels_minimal = numpy.sum(pixel_data == numpy.min(pixel_data))
                 percent_maximal = (100.0 * float(number_pixels_maximal) /
                                    float(pixel_count))
                 percent_minimal = (100.0 * float(number_pixels_minimal) /
                                    float(pixel_count))
-            percent_maximal_name = "%s_%s_%s" % (C_IMAGE_QUALITY, F_PERCENT_MAXIMAL,
-                                                 image_name)
-            percent_minimal_name = "%s_%s_%s" % (C_IMAGE_QUALITY, F_PERCENT_MINIMAL,
-                                                 image_name)
-            workspace.add_measurement(cpmeas.IMAGE, percent_maximal_name,
+            percent_maximal_name = "{}_{}_{}".format(C_IMAGE_QUALITY, F_PERCENT_MAXIMAL,
+                                                     image_name)
+            percent_minimal_name = "{}_{}_{}".format(C_IMAGE_QUALITY, F_PERCENT_MINIMAL,
+                                                     image_name)
+            workspace.add_measurement(cellprofiler.measurement.IMAGE, percent_maximal_name,
                                       percent_maximal)
-            workspace.add_measurement(cpmeas.IMAGE, percent_minimal_name,
+            workspace.add_measurement(cellprofiler.measurement.IMAGE, percent_minimal_name,
                                       percent_minimal)
-            result += [["%s maximal" % image_name, "%.1f %%" % percent_maximal],
-                       ["%s minimal" % image_name, "%.1f %%" % percent_minimal]]
+            result += [["{} maximal".format(image_name), "{:.1f} %".format(percent_maximal)],
+                       ["{} minimal".format(image_name), "{:.1f} %".format(percent_minimal)]]
         return result
 
     def calculate_image_intensity(self, image_group, workspace):
-        '''Calculate intensity-based metrics, mostly from MeasureImageIntensity'''
+        """Calculate intensity-based metrics, mostly from MeasureImageIntensity"""
 
         result = []
         for image_name in self.images_to_process(image_group, workspace):
@@ -1008,8 +1087,7 @@ to the foreground pixels or the background pixels.""" % globals()))
         volumetric = workspace.pipeline.volumetric()
         area_text, area_measurement = ("Volume", F_TOTAL_VOLUME) if volumetric else ("Area", F_TOTAL_AREA)
 
-        result = []
-        pixel_count = np.product(pixels.shape)
+        pixel_count = numpy.product(pixels.shape)
         if pixel_count == 0:
             pixel_sum = 0
             pixel_mean = 0
@@ -1019,13 +1097,13 @@ to the foreground pixels or the background pixels.""" % globals()))
             pixel_min = 0
             pixel_max = 0
         else:
-            pixel_sum = np.sum(pixels)
+            pixel_sum = numpy.sum(pixels)
             pixel_mean = pixel_sum / float(pixel_count)
-            pixel_std = np.std(pixels)
-            pixel_median = np.median(pixels)
-            pixel_mad = np.median(np.abs(pixels - pixel_median))
-            pixel_min = np.min(pixels)
-            pixel_max = np.max(pixels)
+            pixel_std = numpy.std(pixels)
+            pixel_median = numpy.median(pixels)
+            pixel_mad = numpy.median(numpy.abs(pixels - pixel_median))
+            pixel_min = numpy.min(pixels)
+            pixel_max = numpy.max(pixels)
 
         m = workspace.measurements
         m.add_image_measurement("_".join((C_IMAGE_QUALITY, area_measurement, image_name)), pixel_count)
@@ -1037,9 +1115,9 @@ to the foreground pixels or the background pixels.""" % globals()))
         m.add_image_measurement("_".join((C_IMAGE_QUALITY, F_MAX_INTENSITY, image_name)), pixel_max)
         m.add_image_measurement("_".join((C_IMAGE_QUALITY, F_MIN_INTENSITY, image_name)), pixel_min)
 
-        result = [["%s %s" % (image_name,
-                              feature_name),
-                   "%.2f" % value]
+        result = [["{} {}".format(image_name,
+                                  feature_name),
+                   "{:.2f}".format(value)]
                   for feature_name, value in (('Total intensity', pixel_sum),
                                               ('Mean intensity', pixel_mean),
                                               ('Median intensity', pixel_median),
@@ -1063,38 +1141,38 @@ to the foreground pixels or the background pixels.""" % globals()))
             pixel_data = image.pixel_data
 
             if image.has_mask:
-                pixel_data = np.array(pixel_data)  # make a copy
+                pixel_data = numpy.array(pixel_data)  # make a copy
                 masked_pixels = pixel_data[image.mask]
-                pixel_count = np.product(masked_pixels.shape)
+                pixel_count = numpy.product(masked_pixels.shape)
                 if pixel_count > 0:
-                    pixel_data[~ image.mask] = np.mean(masked_pixels)
+                    pixel_data[~ image.mask] = numpy.mean(masked_pixels)
                 else:
                     pixel_data[~ image.mask] = 0
 
-            radii, magnitude, power = rps.rps(pixel_data)
-            if sum(magnitude) > 0 and len(np.unique(pixel_data)) > 1:
+            radii, magnitude, power = centrosome.radial_power_spectrum.rps(pixel_data)
+            if sum(magnitude) > 0 and len(numpy.unique(pixel_data)) > 1:
                 valid = (magnitude > 0)
                 radii = radii[valid].reshape((-1, 1))
-                magnitude = magnitude[valid].reshape((-1, 1))
                 power = power[valid].reshape((-1, 1))
                 if radii.shape[0] > 1:
-                    idx = np.isfinite(np.log(power))
+                    idx = numpy.isfinite(numpy.log(power))
                     powerslope = \
-                        lstsq(np.hstack((np.log(radii)[idx][:, np.newaxis], np.ones(radii.shape)[idx][:, np.newaxis])),
-                              np.log(power)[idx][:, np.newaxis])[0][0]
+                        scipy.linalg.basic.lstsq(numpy.hstack(
+                            (numpy.log(radii)[idx][:, numpy.newaxis], numpy.ones(radii.shape)[idx][:, numpy.newaxis])),
+                                                 numpy.log(power)[idx][:, numpy.newaxis])[0][0]
                 else:
                     powerslope = 0
             else:
                 powerslope = 0
 
-            workspace.add_measurement(cpmeas.IMAGE,
-                                      "%s_%s_%s" % (C_IMAGE_QUALITY, F_POWER_SPECTRUM_SLOPE, image_name),
+            workspace.add_measurement(cellprofiler.measurement.IMAGE,
+                                      "{}_{}_{}".format(C_IMAGE_QUALITY, F_POWER_SPECTRUM_SLOPE, image_name),
                                       powerslope)
-            result += [["%s %s" % (image_name, F_POWER_SPECTRUM_SLOPE), "%.1f" % powerslope]]
+            result += [["{} {}".format(image_name, F_POWER_SPECTRUM_SLOPE), "{:.1f}".format(float(powerslope))]]
         return result
 
     def calculate_thresholds(self, image_group, workspace):
-        '''Calculate a threshold for this image'''
+        """Calculate a threshold for this image"""
         result = []
         all_threshold_groups = self.get_all_threshold_groups(image_group)
 
@@ -1103,101 +1181,109 @@ to the foreground pixels or the background pixels.""" % globals()))
                                                   must_be_grayscale=True)
 
             # TODO: works on 2D slice of image, i suspect the thresholding methods in centrosome aren't working in 3D
-            pixel_data = image.pixel_data.astype(np.float32)
+            pixel_data = image.pixel_data.astype(numpy.float32)
 
             for threshold_group in all_threshold_groups:
                 threshold_method = threshold_group.threshold_algorithm
                 object_fraction = threshold_group.object_fraction.value
-                two_class_otsu = (threshold_group.two_class_otsu.value == O_TWO_CLASS)
-                use_weighted_variance = (threshold_group.use_weighted_variance.value == O_WEIGHTED_VARIANCE)
-                assign_middle_to_foreground = (threshold_group.assign_middle_to_foreground.value == O_FOREGROUND)
+                two_class_otsu = (threshold_group.two_class_otsu.value == identify.O_TWO_CLASS)
+                use_weighted_variance = (threshold_group.use_weighted_variance.value == identify.O_WEIGHTED_VARIANCE)
+                assign_middle_to_foreground = (
+                            threshold_group.assign_middle_to_foreground.value == identify.O_FOREGROUND)
                 (local_threshold, global_threshold) = \
-                    (cpthresh.get_threshold(threshold_method,
-                                            cpthresh.TM_GLOBAL,
-                                            pixel_data,
-                                            mask=image.mask,
-                                            object_fraction=object_fraction,
-                                            two_class_otsu=two_class_otsu,
-                                            use_weighted_variance=use_weighted_variance,
-                                            assign_middle_to_foreground=assign_middle_to_foreground)
+                    (centrosome.threshold.get_threshold(threshold_method,
+                                                        centrosome.threshold.TM_GLOBAL,
+                                                        pixel_data,
+                                                        mask=image.mask,
+                                                        object_fraction=object_fraction,
+                                                        two_class_otsu=two_class_otsu,
+                                                        use_weighted_variance=use_weighted_variance,
+                                                        assign_middle_to_foreground=assign_middle_to_foreground)
                      if image.has_mask
                      else
-                     cpthresh.get_threshold(threshold_method,
-                                            cpthresh.TM_GLOBAL,
-                                            pixel_data,
-                                            object_fraction=object_fraction,
-                                            two_class_otsu=two_class_otsu,
-                                            use_weighted_variance=use_weighted_variance,
-                                            assign_middle_to_foreground=assign_middle_to_foreground))
+                     centrosome.threshold.get_threshold(threshold_method,
+                                                        centrosome.threshold.TM_GLOBAL,
+                                                        pixel_data,
+                                                        object_fraction=object_fraction,
+                                                        two_class_otsu=two_class_otsu,
+                                                        use_weighted_variance=use_weighted_variance,
+                                                        assign_middle_to_foreground=assign_middle_to_foreground))
 
                 scale = threshold_group.threshold_scale
                 if scale is None:
                     threshold_description = threshold_method
                 else:
                     threshold_description = threshold_method + " " + scale
-                workspace.add_measurement(cpmeas.IMAGE, threshold_group.threshold_feature_name(image_name),
+                workspace.add_measurement(cellprofiler.measurement.IMAGE,
+                                          threshold_group.threshold_feature_name(image_name),
                                           global_threshold)
-                result += [["%s %s threshold" % (image_name, threshold_description), str(global_threshold)]]
+                result += [["{} {} threshold".format(image_name, threshold_description), str(global_threshold)]]
 
         return result
 
     def get_all_threshold_groups(self, image_group):
-        '''Get all threshold groups to apply to an image group
+        """Get all threshold groups to apply to an image group
 
         image_group - the image group to try thresholding on
-        '''
+        """
         if image_group.use_all_threshold_methods.value:
             return self.build_threshold_parameter_list()
         return image_group.threshold_groups
 
     def calculate_experiment_threshold(self, image_group, workspace):
-        '''Calculate experiment-wide threshold mean, median and standard-deviation'''
+        """Calculate experiment-wide threshold mean, median and standard-deviation"""
         m = workspace.measurements
         statistics = []
         all_threshold_groups = self.get_all_threshold_groups(image_group)
         if image_group.calculate_threshold.value:
             for image_name in self.images_to_process(image_group, workspace):
                 for threshold_group in all_threshold_groups:
-                    values = m.get_all_measurements(cpmeas.IMAGE,
+                    values = m.get_all_measurements(cellprofiler.measurement.IMAGE,
                                                     threshold_group.threshold_feature_name(image_name))
 
-                    values = values[np.isfinite(values)]
+                    values = values[numpy.isfinite(values)]
 
                     for feature in (F_THRESHOLD,):
-                        for fn, agg in ((np.mean, AGG_MEAN),
-                                        (np.median, AGG_MEDIAN),
-                                        (np.std, AGG_STD)):
+                        for fn, agg in ((numpy.mean, AGG_MEAN),
+                                        (numpy.median, AGG_MEDIAN),
+                                        (numpy.std, AGG_STD)):
                             feature_name = threshold_group.threshold_feature_name(
-                                    image_name, agg=agg)
+                                image_name, agg=agg)
                             feature_description = threshold_group.threshold_description(
-                                    image_name, agg=agg)
+                                image_name, agg=agg)
                             val = fn(values)
                             m.add_experiment_measurement(feature_name, val)
                         statistics.append([feature_description, str(val)])
         return statistics
 
     def build_threshold_parameter_list(self):
-        '''Build a set of temporary threshold groups containing all the threshold methods to be tested'''
+        """Build a set of temporary threshold groups containing all the threshold methods to be tested"""
 
-        # Produce a list of meaningful combinations of threshold settings.'''
+        # Produce a list of meaningful combinations of threshold settings."""
         threshold_args = []
         object_fraction = [0.05, 0.25, 0.75, 0.95]
         # Produce list of combinations of the special thresholding method parameters: Otsu, MoG
-        z = itertools.product([cpthresh.TM_OTSU], [0], [O_WEIGHTED_VARIANCE, O_ENTROPY], [O_THREE_CLASS],
-                    [O_FOREGROUND, O_BACKGROUND])
+        z = itertools.product([centrosome.threshold.TM_OTSU], [0], [identify.O_WEIGHTED_VARIANCE, identify.O_ENTROPY],
+                              [identify.O_THREE_CLASS],
+                              [identify.O_FOREGROUND, identify.O_BACKGROUND])
         threshold_args += [i for i in z]
-        z = itertools.product([cpthresh.TM_OTSU], [0], [O_WEIGHTED_VARIANCE, O_ENTROPY], [O_TWO_CLASS], [O_FOREGROUND])
+        z = itertools.product([centrosome.threshold.TM_OTSU], [0], [identify.O_WEIGHTED_VARIANCE, identify.O_ENTROPY],
+                              [identify.O_TWO_CLASS], [identify.O_FOREGROUND])
         threshold_args += [i for i in z]
-        z = itertools.product([cpthresh.TM_MOG], object_fraction, [O_WEIGHTED_VARIANCE], [O_TWO_CLASS], [O_FOREGROUND])
+        z = itertools.product([centrosome.threshold.TM_MOG], object_fraction, [identify.O_WEIGHTED_VARIANCE],
+                              [identify.O_TWO_CLASS], [identify.O_FOREGROUND])
         threshold_args += [i for i in z]
         # Tack on the remaining simpler methods
-        leftover_methods = [i for i in cpthresh.TM_METHODS if i not in [cpthresh.TM_OTSU, cpthresh.TM_MOG]]
-        z = itertools.product(leftover_methods, [0], [O_WEIGHTED_VARIANCE], [O_TWO_CLASS], [O_FOREGROUND])
+        leftover_methods = [i for i in centrosome.threshold.TM_METHODS if
+                            i not in [centrosome.threshold.TM_OTSU, centrosome.threshold.TM_MOG]]
+        z = itertools.product(leftover_methods, [0], [identify.O_WEIGHTED_VARIANCE], [identify.O_TWO_CLASS],
+                              [identify.O_FOREGROUND])
         threshold_args += [i for i in z]
 
         # Assign the threshold values to a temporary threshold group
         threshold_groups = []
-        for threshold_method, object_fraction, use_weighted_variance, two_class_otsu, assign_middle_to_foreground in threshold_args:
+        for threshold_method, object_fraction, use_weighted_variance, two_class_otsu, assign_middle_to_foreground \
+                in threshold_args:
             threshold_groups.append(self.add_threshold_group(None, False))
             threshold_groups[-1].threshold_method.value = threshold_method
             threshold_groups[-1].object_fraction.value = object_fraction
@@ -1208,7 +1294,7 @@ to the foreground pixels or the background pixels.""" % globals()))
         return threshold_groups
 
     def images_to_process(self, image_group, workspace, pipeline=None):
-        '''Return a list of input image names appropriate to the setting choice '''
+        """Return a list of input image names appropriate to the setting choice """
         if self.images_choice.value == O_SELECT:
             return image_group.image_names.get_selections()
         elif self.images_choice.value == O_ALL_LOADED:
@@ -1220,24 +1306,24 @@ to the foreground pixels or the background pixels.""" % globals()))
             # Get a dictionary of image name to (module, setting)
             #
             image_providers = pipeline.get_provider_dictionary(
-                    cps.IMAGE_GROUP, self)
+                cellprofiler.setting.IMAGE_GROUP, self)
             for image_name in image_providers:
                 for module, setting in image_providers[image_name]:
                     if (module.is_load_module() and
-                            ((not isinstance(setting, cps.ImageNameProvider)) or
-                                     cps.FILE_IMAGE_ATTRIBUTE in setting.provided_attributes)):
+                            ((not isinstance(setting, cellprofiler.setting.ImageNameProvider)) or
+                             cellprofiler.setting.FILE_IMAGE_ATTRIBUTE in setting.provided_attributes)):
                         accepted_image_list.append(image_name)
             return accepted_image_list
 
     def upgrade_settings(self, setting_values, variable_revision_number,
                          module_name, from_matlab):
-        '''Upgrade from previous versions of setting formats'''
+        """Upgrade from previous versions of setting formats"""
 
         if (from_matlab and variable_revision_number == 4 and
-                    module_name == 'MeasureImageSaturationBlur'):
+                module_name == 'MeasureImageSaturationBlur'):
             image_names = []
             for image_name in setting_values[:6]:
-                if image_name != cps.DO_NOT_USE:
+                if image_name != cellprofiler.setting.DO_NOT_USE:
                     image_names.append(image_name)
             wants_blur = setting_values[-2]
             local_focus_score = setting_values[-1]
@@ -1246,17 +1332,17 @@ to the foreground pixels or the background pixels.""" % globals()))
                 setting_values += [image_name,
                                    wants_blur,
                                    local_focus_score,
-                                   cps.YES,  # check saturation
-                                   cps.NO,  # calculate threshold
-                                   cpthresh.TM_OTSU_GLOBAL,
+                                   cellprofiler.setting.YES,  # check saturation
+                                   cellprofiler.setting.NO,  # calculate threshold
+                                   centrosome.threshold.TM_OTSU_GLOBAL,
                                    .1,  # object fraction
-                                   cps.NO]  # compute power spectrum
+                                   cellprofiler.setting.NO]  # compute power spectrum
             variable_revision_number = 2
             from_matlab = False
             module_name = 'MeasureImageQuality'
 
         if (from_matlab and variable_revision_number == 1 and
-                    module_name == 'MeasureImageQuality'):
+                module_name == 'MeasureImageQuality'):
             # Slot 0 asked if blur should be checked on all images
             # Slot 1 had the window size for all images
             # Slots 2-4, 5-7, 8-10, 11-13 contain triples of:
@@ -1276,23 +1362,23 @@ to the foreground pixels or the background pixels.""" % globals()))
                 saturation_image = setting_values[i]
                 threshold_image = setting_values[i + 1]
                 threshold_method = setting_values[i + 2]
-                if saturation_image != cps.DO_NOT_USE:
-                    if not d.has_key(saturation_image):
+                if saturation_image != cellprofiler.setting.DO_NOT_USE:
+                    if d not in saturation_image:
                         d[saturation_image] = {"check_blur": check_blur,
-                                               "check_saturation": cps.YES,
-                                               "check_threshold": cps.NO,
+                                               "check_saturation": cellprofiler.setting.YES,
+                                               "check_threshold": cellprofiler.setting.NO,
                                                "threshold_method": threshold_method}
                     else:
                         d[saturation_image]["check_blur"] = check_blur
-                        d[saturation_image]["check_saturation"] = cps.YES
-                if threshold_image != cps.DO_NOT_USE:
-                    if not d.has_key(threshold_image):
-                        d[threshold_image] = {"check_blur": cps.NO,
-                                              "check_saturation": cps.NO,
-                                              "check_threshold": cps.YES,
+                        d[saturation_image]["check_saturation"] = cellprofiler.setting.YES
+                if threshold_image != cellprofiler.setting.DO_NOT_USE:
+                    if d not in threshold_image:
+                        d[threshold_image] = {"check_blur": cellprofiler.setting.NO,
+                                              "check_saturation": cellprofiler.setting.NO,
+                                              "check_threshold": cellprofiler.setting.YES,
                                               "threshold_method": threshold_method}
                     else:
-                        d[threshold_image]["check_threshold"] = cps.YES
+                        d[threshold_image]["check_threshold"] = cellprofiler.setting.YES
                         d[threshold_image]["threshold_method"] = threshold_method
             setting_values = []
             for image_name in d.keys():
@@ -1313,7 +1399,7 @@ to the foreground pixels or the background pixels.""" % globals()))
             new_settings = []
             for idx in range(num_images):
                 new_settings += setting_values[(idx * 7):(idx * 7 + 7)]
-                new_settings += [cps.YES]
+                new_settings += [cellprofiler.setting.YES]
             setting_values = new_settings
             variable_revision_number = 2
 
@@ -1324,8 +1410,8 @@ to the foreground pixels or the background pixels.""" % globals()))
             new_settings = []
             for idx in range(num_images):
                 new_settings += setting_values[(idx * 8):(idx * 8 + 8)]
-                new_settings += [O_TWO_CLASS, O_WEIGHTED_VARIANCE,
-                                 O_FOREGROUND]
+                new_settings += [identify.O_TWO_CLASS, identify.O_WEIGHTED_VARIANCE,
+                                 identify.O_FOREGROUND]
             setting_values = new_settings
             variable_revision_number = 3
 
@@ -1334,8 +1420,8 @@ to the foreground pixels or the background pixels.""" % globals()))
             assert len(setting_values) % SETTINGS_PER_GROUP_V3 == 0
             num_images = len(setting_values) / SETTINGS_PER_GROUP_V3
 
-            '''Since some settings are new/consolidated and can be repeated, handle
-            the old settings by using a dict'''
+            """Since some settings are new/consolidated and can be repeated, handle
+            the old settings by using a dict"""
             # Initialize the dictionary by image name
             d = {}
             unique_image_names = []
@@ -1361,10 +1447,12 @@ to the foreground pixels or the background pixels.""" % globals()))
                               (idx * SETTINGS_PER_GROUP_V3):(idx * SETTINGS_PER_GROUP_V3 + SETTINGS_PER_GROUP_V3)]
                 image_name = im_settings[0]
                 # Set blur and thresholds if the user sets any of the setting groups.
-                d[image_name]["wants_saturation"] = d[image_name]["wants_saturation"] or (im_settings[3] == cps.YES)
+                d[image_name]["wants_saturation"] = d[image_name]["wants_saturation"] or (
+                            im_settings[3] == cellprofiler.setting.YES)
                 d[image_name]["wants_blur"] = d[image_name]["wants_blur"] or (
-                    im_settings[1] == cps.YES or im_settings[7] == cps.YES)
-                d[image_name]["wants_threshold"] = d[image_name]["wants_threshold"] or (im_settings[4] == cps.YES)
+                        im_settings[1] == cellprofiler.setting.YES or im_settings[7] == cellprofiler.setting.YES)
+                d[image_name]["wants_threshold"] = d[image_name]["wants_threshold"] or (
+                            im_settings[4] == cellprofiler.setting.YES)
                 #  Collect blur scales and threshold methods
                 d[image_name]["blur_scales"] += [im_settings[2]]
                 d[image_name]["threshold_methods"] += [im_settings[5:7] + im_settings[8:]]
@@ -1383,24 +1471,33 @@ to the foreground pixels or the background pixels.""" % globals()))
                              unique_image_names]  # threshold_count
             for image_name in unique_image_names:
                 new_settings += [image_name,  # image_name
-                                 cps.YES if d[image_name]["wants_scaling"] else cps.NO,  # include_image_scalings
-                                 cps.YES if d[image_name]["wants_blur"]    else cps.NO]  # check_blur
+                                 cellprofiler.setting.YES if d[image_name][
+                                     "wants_scaling"] else cellprofiler.setting.NO,  # include_image_scalings
+                                 cellprofiler.setting.YES if d[image_name][
+                                     "wants_blur"] else cellprofiler.setting.NO]  # check_blur
                 new_settings += [k for k in d[image_name]["blur_scales"]]  # scale
-                new_settings += [cps.YES if d[image_name]["wants_saturation"] else cps.NO,  # check_saturation
-                                 cps.YES if d[image_name]["wants_intensity"]  else cps.NO,  # check_intensity
-                                 cps.YES if d[image_name]["wants_threshold"]  else cps.NO,  # calculate_threshold,
-                                 cps.NO]  # use_all_threshold_methods
+                new_settings += [
+                    cellprofiler.setting.YES if d[image_name]["wants_saturation"] else cellprofiler.setting.NO,
+                    # check_saturation
+                    cellprofiler.setting.YES if d[image_name]["wants_intensity"] else cellprofiler.setting.NO,
+                    # check_intensity
+                    cellprofiler.setting.YES if d[image_name]["wants_threshold"] else cellprofiler.setting.NO,
+                    # calculate_threshold,
+                    cellprofiler.setting.NO]  # use_all_threshold_methods
                 for k in d[image_name]["threshold_methods"]:
-                    new_settings += k  # threshold_method, object_fraction, two_class_otsu, use_weighted_variance, assign_middle_to_foreground
+                    # threshold_method, object_fraction, two_class_otsu,
+                    # use_weighted_variance, assign_middle_to_foreground
+                    new_settings += k
 
             setting_values = new_settings
             variable_revision_number = 4
 
         if (not from_matlab) and variable_revision_number == 4:
             # Thresholding method name change: Strip off "Global"
-            thresh_dict = dict(zip(cpthresh.TM_GLOBAL_METHODS, cpthresh.TM_METHODS))
+            thresh_dict = dict(zip(centrosome.threshold.TM_GLOBAL_METHODS, centrosome.threshold.TM_METHODS))
             # Naturally, this method assumes that the user didn't name their images "Otsu Global" or something similar
-            setting_values = [thresh_dict[x] if x in cpthresh.TM_GLOBAL_METHODS else x for x in setting_values]
+            setting_values = [thresh_dict[x] if x in centrosome.threshold.TM_GLOBAL_METHODS else x for x in
+                              setting_values]
             variable_revision_number = 5
 
         return setting_values, variable_revision_number, from_matlab
@@ -1409,70 +1506,70 @@ to the foreground pixels or the background pixels.""" % globals()))
         return True
 
 
-class ImageQualitySettingsGroup(cps.SettingsGroup):
+class ImageQualitySettingsGroup(cellprofiler.setting.SettingsGroup):
     @property
     def threshold_algorithm(self):
-        '''The thresholding algorithm to run'''
+        """The thresholding algorithm to run"""
         return self.threshold_method.value.split(' ')[0]
 
     def threshold_feature_name(self, image_name, agg=None):
-        '''The feature name of the threshold measurement generated'''
+        """The feature name of the threshold measurement generated"""
         scale = self.threshold_scale
         if agg is None:
             hdr = F_THRESHOLD
         else:
             hdr = F_THRESHOLD + agg
         if scale is None:
-            return "%s_%s%s_%s" % (C_IMAGE_QUALITY, hdr,
-                                   self.threshold_algorithm,
-                                   image_name)
+            return "{}_{}{}_{}".format(C_IMAGE_QUALITY, hdr,
+                                       self.threshold_algorithm,
+                                       image_name)
         else:
-            return "%s_%s%s_%s_%s" % (C_IMAGE_QUALITY, hdr,
-                                      self.threshold_algorithm,
-                                      image_name,
-                                      scale)
+            return "{}_{}{}_{}_{}".format(C_IMAGE_QUALITY, hdr,
+                                          self.threshold_algorithm,
+                                          image_name,
+                                          scale)
 
     @property
     def threshold_scale(self):
-        '''The "scale" for the threshold = minor parameterizations'''
+        """The "scale" for the threshold = minor parameterizations"""
         #
         # Distinguish Otsu choices from each other
         #
         threshold_algorithm = self.threshold_algorithm
-        if threshold_algorithm == cpthresh.TM_OTSU:
-            if self.two_class_otsu == O_TWO_CLASS:
+        if threshold_algorithm == centrosome.threshold.TM_OTSU:
+            if self.two_class_otsu == identify.O_TWO_CLASS:
                 scale = "2"
             else:
                 scale = "3"
-                if self.assign_middle_to_foreground == O_FOREGROUND:
+                if self.assign_middle_to_foreground == identify.O_FOREGROUND:
                     scale += "F"
                 else:
                     scale += "B"
-            if self.use_weighted_variance == O_WEIGHTED_VARIANCE:
+            if self.use_weighted_variance == identify.O_WEIGHTED_VARIANCE:
                 scale += "W"
             else:
                 scale += "S"
             return scale
-        elif threshold_algorithm == cpthresh.TM_MOG:
+        elif threshold_algorithm == centrosome.threshold.TM_MOG:
             return str(int(self.object_fraction.value * 100))
 
     def threshold_description(self, image_name, agg=None):
-        '''Return a description of the threshold meant to be seen by the user
+        """Return a description of the threshold meant to be seen by the user
 
         image_name - name of thresholded image
 
         agg - if present, the aggregating method, e.g., "Mean"
-        '''
-        if self.threshold_algorithm == cpthresh.TM_OTSU:
-            if self.use_weighted_variance == O_WEIGHTED_VARIANCE:
+        """
+        if self.threshold_algorithm == centrosome.threshold.TM_OTSU:
+            if self.use_weighted_variance == identify.O_WEIGHTED_VARIANCE:
                 wvorentropy = "WV"
             else:
                 wvorentropy = "S"
-            if self.two_class_otsu == O_TWO_CLASS:
-                result = "Otsu %s 2 cls" % wvorentropy
+            if self.two_class_otsu == identify.O_TWO_CLASS:
+                result = "Otsu {} 2 cls".format(wvorentropy)
             else:
-                result = "Otsu %s 3 cls" % wvorentropy
-                if self.assign_middle_to_foreground == O_FOREGROUND:
+                result = "Otsu {} 3 cls".format(wvorentropy)
+                if self.assign_middle_to_foreground == identify.O_FOREGROUND:
                     result += " Fg"
                 else:
                     result += " Bg"

--- a/cellprofiler/modules/measureobjectsizeshape.py
+++ b/cellprofiler/modules/measureobjectsizeshape.py
@@ -297,12 +297,18 @@ module.""".format(**{
         """
         return "Zernike_%d_%d" % (zernike_index[0], zernike_index[1])
 
-    def get_feature_names(self):
+    def get_feature_names(self, pipeline):
         """Return the names of the features measured"""
-        result = list(F_STANDARD)
-        result.extend([self.get_zernike_name(index)
-                       for index in self.get_zernike_numbers()])
-        return result
+        feature_names = list(F_STANDARD)
+
+        if pipeline.volumetric():
+            feature_names += list(F_STD_3D)
+        else:
+            feature_names += list(F_STD_2D)
+
+        feature_names += [self.get_zernike_name(index) for index in self.get_zernike_numbers()]
+
+        return feature_names
 
     def get_measurements(self, pipeline, object_name, category):
         """Return the measurements that this module produces
@@ -313,7 +319,7 @@ module.""".format(**{
         """
         if (category == AREA_SHAPE and
                 self.get_categories(pipeline, object_name)):
-            return self.get_feature_names()
+            return self.get_feature_names(pipeline)
         return []
 
     def run(self, workspace):
@@ -488,7 +494,7 @@ module.""".format(**{
             else:
                 self.record_measurement(workspace, object_name, F_PERIMETER, perimeters)
 
-            for feature in self.get_feature_names():
+            for feature in self.get_feature_names(workspace.pipeline):
                 if feature in [F_AREA, F_EXTENT, F_CENTER_X, F_CENTER_Y, F_CENTER_Z, F_PERIMETER]:
                     continue
 
@@ -561,7 +567,7 @@ module.""".format(**{
         '''Return measurement column definitions.
         All cols returned as float even though "Area" will only ever be int'''
         object_names = [s.value for s in self.settings()][:-1]
-        measurement_names = self.get_feature_names()
+        measurement_names = self.get_feature_names(pipeline)
         cols = []
         for oname in object_names:
             for mname in measurement_names:

--- a/cellprofiler/modules/measureobjectsizeshape.py
+++ b/cellprofiler/modules/measureobjectsizeshape.py
@@ -55,9 +55,12 @@ See the *Technical Notes* below for an explanation of a key step
 underlying many of the following metrics: creating an
 ellipse with the same second-moments as each object.
 
--  *Area:* The number of pixels (2D) or voxels (3D) in the region.
--  *Perimeter:* The total number of pixels (2D) or voxels (3D) around the boundary of each
-   region in the image. In 3D, this is more commonly described as the surface area.
+-  *Area:* *(2D only)* The number of pixels in the region.
+-  *Volume:* *(3D only)* The number of voxels in the region.
+-  *Perimeter:* *(2D only)* The total number of pixels around the boundary of each
+   region in the image.
+-  *Surface Area:* *(3D only)# The total number of voxels around the boundary of
+   each region in the image.
 -  *FormFactor:* *(2D only)* Calculated as 4\*π\*Area/Perimeter\ :sup:`2`. Equals 1
    for a perfectly circular object.
 -  *Solidity:* *(2D only)* The proportion of the pixels in the convex hull that are

--- a/cellprofiler/modules/measureobjectsizeshape.py
+++ b/cellprofiler/modules/measureobjectsizeshape.py
@@ -455,7 +455,7 @@ module.""".format(**{
             # Area
             areas = [prop.area for prop in props]
 
-            self.record_measurement(workspace, object_name, F_AREA, areas)
+            self.record_measurement(workspace, object_name, F_VOLUME, areas)
 
             # Extent
             extents = [prop.extent for prop in props]
@@ -473,8 +473,8 @@ module.""".format(**{
 
             self.record_measurement(workspace, object_name, F_CENTER_Z, center_z)
 
-            # Perimeters
-            perimeters = []
+            # SurfaceArea
+            surface_areas = []
 
             for label in numpy.unique(labels):
                 if label == 0:
@@ -490,15 +490,15 @@ module.""".format(**{
                     level=0
                 )
 
-                perimeters += [skimage.measure.mesh_surface_area(verts, faces)]
+                surface_areas += [skimage.measure.mesh_surface_area(verts, faces)]
 
-            if len(perimeters) == 0:
-                self.record_measurement(workspace, object_name, F_PERIMETER, [0])
+            if len(surface_areas) == 0:
+                self.record_measurement(workspace, object_name, F_SURFACE_AREA, [0])
             else:
-                self.record_measurement(workspace, object_name, F_PERIMETER, perimeters)
+                self.record_measurement(workspace, object_name, F_SURFACE_AREA, surface_areas)
 
             for feature in self.get_feature_names(workspace.pipeline):
-                if feature in [F_AREA, F_EXTENT, F_CENTER_X, F_CENTER_Y, F_CENTER_Z, F_PERIMETER]:
+                if feature in [F_VOLUME, F_EXTENT, F_CENTER_X, F_CENTER_Y, F_CENTER_Z, F_SURFACE_AREA]:
                     continue
 
                 self.record_measurement(workspace, object_name, feature, [numpy.nan])

--- a/cellprofiler/modules/measureobjectsizeshape.py
+++ b/cellprofiler/modules/measureobjectsizeshape.py
@@ -2,28 +2,16 @@
 import cellprofiler.gui.help.content
 import cellprofiler.icons
 
-import numpy as np
-import scipy.ndimage as scind
+import numpy
+import scipy.ndimage
 
-import cellprofiler.module as cpm
-import cellprofiler.object as cpo
-import cellprofiler.setting as cps
-from cellprofiler.setting import YES, NO
-import centrosome.zernike as cpmz
-from centrosome.cpmorphology import fixup_scipy_ndimage_result as fix
-from centrosome.cpmorphology import ellipse_from_second_moments_ijv
-from centrosome.cpmorphology import calculate_extents
-from centrosome.cpmorphology import calculate_perimeters
-from centrosome.cpmorphology import calculate_solidity
-from centrosome.cpmorphology import euler_number
-from centrosome.cpmorphology import distance_to_edge
-from centrosome.cpmorphology import maximum_position_of_labels
-from centrosome.cpmorphology import median_of_labels
-from centrosome.cpmorphology import feret_diameter
-from centrosome.cpmorphology import convex_hull_ijv
-from cellprofiler.measurement import COLTYPE_FLOAT
+import cellprofiler.module
+import cellprofiler.object
+import cellprofiler.setting
+import cellprofiler.measurement
+import centrosome.zernike
+import centrosome.cpmorphology
 import skimage.measure
-import _help
 
 __doc__ = """\
 MeasureObjectSizeShape
@@ -206,7 +194,7 @@ F_STANDARD = [F_ECCENTRICITY, F_SOLIDITY, F_EXTENT, F_EULER_NUMBER,
               F_MIN_FERET_DIAMETER, F_MAX_FERET_DIAMETER]
 
 
-class MeasureObjectSizeShape(cpm.Module):
+class MeasureObjectSizeShape(cellprofiler.module.Module):
     module_name = "MeasureObjectSizeShape"
     variable_revision_number = 1
     category = 'Measurement'
@@ -219,28 +207,34 @@ class MeasureObjectSizeShape(cpm.Module):
         """
         self.object_groups = []
         self.add_object(can_remove=False)
-        self.spacer = cps.Divider(line=True)
-        self.add_objects = cps.DoSomething("", "Add another object", self.add_object)
+        self.spacer = cellprofiler.setting.Divider(line=True)
+        self.add_objects = cellprofiler.setting.DoSomething("", "Add another object", self.add_object)
 
-        self.calculate_zernikes = cps.Binary(
-                'Calculate the Zernike features?', True, doc="""\
-Select *%(YES)s* to calculate the Zernike shape features. Because the
+        self.calculate_zernikes = cellprofiler.setting.Binary(
+            text='Calculate the Zernike features?',
+            value=True,
+            doc="""\
+Select *{YES}* to calculate the Zernike shape features. Because the
 first 10 Zernike polynomials (from order 0 to order 9) are calculated,
 this operation can be time consuming if the image contains a lot of
-objects. Select *%(NO)s* if you are measuring 3D objects with this
-module.""" % globals())
+objects. Select *{NO}* if you are measuring 3D objects with this
+module.""".format(**{
+                "YES": cellprofiler.setting.YES,
+                "NO": cellprofiler.setting.NO
+            })
+        )
 
     def add_object(self, can_remove=True):
         """Add a slot for another object"""
-        group = cps.SettingsGroup()
+        group = cellprofiler.setting.SettingsGroup()
         if can_remove:
-            group.append("divider", cps.Divider(line=False))
+            group.append("divider", cellprofiler.setting.Divider(line=False))
 
-        group.append("name", cps.ObjectNameSubscriber(
-                "Select objects to measure", cps.NONE, doc="""Select the objects that you want to measure."""))
+        group.append("name", cellprofiler.setting.ObjectNameSubscriber(
+                "Select objects to measure", cellprofiler.setting.NONE, doc="""Select the objects that you want to measure."""))
 
         if can_remove:
-            group.append("remove", cps.RemoveSettingButton("", "Remove this object", self.object_groups, group))
+            group.append("remove", cellprofiler.setting.RemoveSettingButton("", "Remove this object", self.object_groups, group))
 
         self.object_groups.append(group)
 
@@ -272,7 +266,7 @@ module.""" % globals())
         objects = set()
         for group in self.object_groups:
             if group.name.value in objects:
-                raise cps.ValidationError(
+                raise cellprofiler.setting.ValidationError(
                         "%s has already been selected" % group.name.value,
                         group.name)
             objects.add(group.name.value)
@@ -292,7 +286,7 @@ module.""" % globals())
     def get_zernike_numbers(self):
         """The Zernike numbers measured by this module"""
         if self.calculate_zernikes.value:
-            return cpmz.get_zernike_indexes(ZERNIKE_N + 1)
+            return centrosome.zernike.get_zernike_indexes(ZERNIKE_N + 1)
         else:
             return []
 
@@ -344,7 +338,7 @@ module.""" % globals())
             i, j, l = objects.ijv.transpose()
             centers, eccentricity, major_axis_length, minor_axis_length, \
             theta, compactness = \
-                ellipse_from_second_moments_ijv(i, j, 1, l, objects.indices, True)
+                centrosome.cpmorphology.ellipse_from_second_moments_ijv(i, j, 1, l, objects.indices, True)
             del i
             del j
             del l
@@ -355,82 +349,82 @@ module.""" % globals())
             self.record_measurement(workspace, object_name,
                                     F_MINOR_AXIS_LENGTH, minor_axis_length)
             self.record_measurement(workspace, object_name, F_ORIENTATION,
-                                    theta * 180 / np.pi)
+                                    theta * 180 / numpy.pi)
             self.record_measurement(workspace, object_name, F_COMPACTNESS,
                                     compactness)
             is_first = False
             if len(objects.indices) == 0:
                 nobjects = 0
             else:
-                nobjects = np.max(objects.indices)
-            mcenter_x = np.zeros(nobjects)
-            mcenter_y = np.zeros(nobjects)
-            mextent = np.zeros(nobjects)
-            mperimeters = np.zeros(nobjects)
-            msolidity = np.zeros(nobjects)
-            euler = np.zeros(nobjects)
-            max_radius = np.zeros(nobjects)
-            median_radius = np.zeros(nobjects)
-            mean_radius = np.zeros(nobjects)
-            min_feret_diameter = np.zeros(nobjects)
-            max_feret_diameter = np.zeros(nobjects)
+                nobjects = numpy.max(objects.indices)
+            mcenter_x = numpy.zeros(nobjects)
+            mcenter_y = numpy.zeros(nobjects)
+            mextent = numpy.zeros(nobjects)
+            mperimeters = numpy.zeros(nobjects)
+            msolidity = numpy.zeros(nobjects)
+            euler = numpy.zeros(nobjects)
+            max_radius = numpy.zeros(nobjects)
+            median_radius = numpy.zeros(nobjects)
+            mean_radius = numpy.zeros(nobjects)
+            min_feret_diameter = numpy.zeros(nobjects)
+            max_feret_diameter = numpy.zeros(nobjects)
             zernike_numbers = self.get_zernike_numbers()
             zf = {}
             for n, m in zernike_numbers:
-                zf[(n, m)] = np.zeros(nobjects)
+                zf[(n, m)] = numpy.zeros(nobjects)
             if nobjects > 0:
-                chulls, chull_counts = convex_hull_ijv(objects.ijv, objects.indices)
+                chulls, chull_counts = centrosome.cpmorphology.convex_hull_ijv(objects.ijv, objects.indices)
                 for labels, indices in objects.get_labels():
                     to_indices = indices - 1
-                    distances = distance_to_edge(labels)
+                    distances = centrosome.cpmorphology.distance_to_edge(labels)
                     mcenter_y[to_indices], mcenter_x[to_indices] = \
-                        maximum_position_of_labels(distances, labels, indices)
-                    max_radius[to_indices] = fix(scind.maximum(
+                        centrosome.cpmorphology.maximum_position_of_labels(distances, labels, indices)
+                    max_radius[to_indices] = centrosome.cpmorphology.fixup_scipy_ndimage_result(scipy.ndimage.maximum(
                             distances, labels, indices))
-                    mean_radius[to_indices] = fix(scind.mean(
+                    mean_radius[to_indices] = centrosome.cpmorphology.fixup_scipy_ndimage_result(scipy.ndimage.mean(
                             distances, labels, indices))
-                    median_radius[to_indices] = median_of_labels(
+                    median_radius[to_indices] = centrosome.cpmorphology.median_of_labels(
                             distances, labels, indices)
                     #
                     # The extent (area / bounding box area)
                     #
-                    mextent[to_indices] = calculate_extents(labels, indices)
+                    mextent[to_indices] = centrosome.cpmorphology.calculate_extents(labels, indices)
                     #
                     # The perimeter distance
                     #
-                    mperimeters[to_indices] = calculate_perimeters(labels, indices)
+                    mperimeters[to_indices] = centrosome.cpmorphology.calculate_perimeters(labels, indices)
                     #
                     # Solidity
                     #
-                    msolidity[to_indices] = calculate_solidity(labels, indices)
+                    msolidity[to_indices] = centrosome.cpmorphology.calculate_solidity(labels, indices)
                     #
                     # Euler number
                     #
-                    euler[to_indices] = euler_number(labels, indices)
+                    euler[to_indices] = centrosome.cpmorphology.euler_number(labels, indices)
                     #
                     # Zernike features
                     #
                     if self.calculate_zernikes.value:
-                        zf_l = cpmz.zernike(zernike_numbers, labels, indices)
+                        zf_l = centrosome.zernike.zernike(zernike_numbers, labels, indices)
                         for (n, m), z in zip(zernike_numbers, zf_l.transpose()):
                             zf[(n, m)][to_indices] = z
                 #
                 # Form factor
                 #
-                ff = 4.0 * np.pi * objects.areas / mperimeters ** 2
+                ff = 4.0 * numpy.pi * objects.areas / mperimeters ** 2
                 #
                 # Feret diameter
                 #
                 min_feret_diameter, max_feret_diameter = \
-                    feret_diameter(chulls, chull_counts, objects.indices)
+                    centrosome.cpmorphology.feret_diameter(chulls, chull_counts, objects.indices)
 
             else:
-                ff = np.zeros(0)
+                ff = numpy.zeros(0)
 
             for f, m in ([(F_AREA, objects.areas),
                           (F_CENTER_X, mcenter_x),
                           (F_CENTER_Y, mcenter_y),
-                          (F_CENTER_Z, np.ones_like(mcenter_x)),
+                          (F_CENTER_Z, numpy.ones_like(mcenter_x)),
                           (F_EXTENT, mextent),
                           (F_PERIMETER, mperimeters),
                           (F_SOLIDITY, msolidity),
@@ -473,11 +467,11 @@ module.""" % globals())
             # Perimeters
             perimeters = []
 
-            for label in np.unique(labels):
+            for label in numpy.unique(labels):
                 if label == 0:
                     continue
 
-                volume = np.zeros_like(labels, dtype='bool')
+                volume = numpy.zeros_like(labels, dtype='bool')
 
                 volume[labels == label] = True
 
@@ -498,7 +492,7 @@ module.""" % globals())
                 if feature in [F_AREA, F_EXTENT, F_CENTER_X, F_CENTER_Y, F_CENTER_Z, F_PERIMETER]:
                     continue
 
-                self.record_measurement(workspace, object_name, feature, [np.nan])
+                self.record_measurement(workspace, object_name, feature, [numpy.nan])
 
     def display(self, workspace, figure):
         figure.set_subplots((1, 1))
@@ -524,7 +518,7 @@ module.""" % globals())
         if len(objects.indices) > 0:
             data = objects.fn_of_label_and_index(function)
         else:
-            data = np.zeros((0,))
+            data = numpy.zeros((0,))
         self.record_measurement(workspace, object_name, feature_name, data)
 
     def perform_ndmeasurement(self, workspace, function,
@@ -545,23 +539,23 @@ module.""" % globals())
         if len(objects.indices) > 0:
             data = objects.fn_of_ones_label_and_index(function)
         else:
-            data = np.zeros((0,))
+            data = numpy.zeros((0,))
         self.record_measurement(workspace, object_name, feature_name, data)
 
     def record_measurement(self, workspace,
                            object_name, feature_name, result):
         """Record the result of a measurement in the workspace's measurements"""
-        data = fix(result)
+        data = centrosome.cpmorphology.fixup_scipy_ndimage_result(result)
         workspace.add_measurement(object_name,
                                   "%s_%s" % (AREA_SHAPE, feature_name),
                                   data)
-        if self.show_window and np.any(np.isfinite(data)) > 0:
-            data = data[np.isfinite(data)]
+        if self.show_window and numpy.any(numpy.isfinite(data)) > 0:
+            data = data[numpy.isfinite(data)]
             workspace.display_data.statistics.append(
                     (object_name, feature_name,
-                     "%.2f" % np.mean(data),
-                     "%.2f" % np.median(data),
-                     "%.2f" % np.std(data)))
+                     "%.2f" % numpy.mean(data),
+                     "%.2f" % numpy.median(data),
+                     "%.2f" % numpy.std(data)))
 
     def get_measurement_columns(self, pipeline):
         '''Return measurement column definitions.
@@ -571,7 +565,7 @@ module.""" % globals())
         cols = []
         for oname in object_names:
             for mname in measurement_names:
-                cols += [(oname, AREA_SHAPE + '_' + mname, COLTYPE_FLOAT)]
+                cols += [(oname, AREA_SHAPE + '_' + mname, cellprofiler.measurement.COLTYPE_FLOAT)]
         return cols
 
     def upgrade_settings(self, setting_values, variable_revision_number,
@@ -590,14 +584,14 @@ module.""" % globals())
         if from_matlab and variable_revision_number == 2:
             # Added Zernike question at revision # 2
             setting_values = list(setting_values)
-            setting_values.append(cps.NO)
+            setting_values.append(cellprofiler.setting.NO)
             variable_revision_number = 3
 
         if from_matlab and variable_revision_number == 3:
             # Remove the "Do not use" objects from the list
-            setting_values = np.array(setting_values)
+            setting_values = numpy.array(setting_values)
             setting_values = list(setting_values[setting_values !=
-                                                 cps.DO_NOT_USE])
+                                                 cellprofiler.setting.DO_NOT_USE])
             variable_revision_number = 1
             from_matlab = False
         return setting_values, variable_revision_number, from_matlab
@@ -609,10 +603,10 @@ module.""" % globals())
 def form_factor(objects):
     """FormFactor = 4/pi*Area/Perimeter^2, equals 1 for a perfectly circular"""
     if len(objects.indices) > 0:
-        perimeter = objects.fn_of_label_and_index(calculate_perimeters)
-        return 4.0 * np.pi * objects.areas / perimeter ** 2
+        perimeter = objects.fn_of_label_and_index(centrosome.cpmorphology.calculate_perimeters)
+        return 4.0 * numpy.pi * objects.areas / perimeter ** 2
     else:
-        return np.zeros((0,))
+        return numpy.zeros((0,))
 
 
 MeasureObjectAreaShape = MeasureObjectSizeShape

--- a/cellprofiler/modules/measureobjectsizeshape.py
+++ b/cellprofiler/modules/measureobjectsizeshape.py
@@ -59,7 +59,7 @@ ellipse with the same second-moments as each object.
 -  *Volume:* *(3D only)* The number of voxels in the region.
 -  *Perimeter:* *(2D only)* The total number of pixels around the boundary of each
    region in the image.
--  *Surface Area:* *(3D only)# The total number of voxels around the boundary of
+-  *SurfaceArea:* *(3D only)# The total number of voxels around the boundary of
    each region in the image.
 -  *FormFactor:* *(2D only)* Calculated as 4\*π\*Area/Perimeter\ :sup:`2`. Equals 1
    for a perfectly circular object.
@@ -168,7 +168,7 @@ ZERNIKE_N = 9
 F_AREA = 'Area'
 F_PERIMETER = 'Perimeter'
 F_VOLUME = 'Volume'
-F_SURFACE_AREA = 'Surface Area'
+F_SURFACE_AREA = 'SurfaceArea'
 F_ECCENTRICITY = 'Eccentricity'
 F_SOLIDITY = 'Solidity'
 F_EXTENT = 'Extent'

--- a/cellprofiler/modules/measureobjectsizeshape.py
+++ b/cellprofiler/modules/measureobjectsizeshape.py
@@ -174,7 +174,10 @@ AREA_SHAPE = 'AreaShape'
 """Calculate Zernike features for N,M where N=0 through ZERNIKE_N"""
 ZERNIKE_N = 9
 
-F_AREA = "Area"
+F_AREA = 'Area'
+F_PERIMETER = 'Perimeter'
+F_VOLUME = 'Volume'
+F_SURFACE_AREA = 'Surface Area'
 F_ECCENTRICITY = 'Eccentricity'
 F_SOLIDITY = 'Solidity'
 F_EXTENT = 'Extent'
@@ -182,7 +185,6 @@ F_CENTER_X = 'Center_X'
 F_CENTER_Y = 'Center_Y'
 F_CENTER_Z = 'Center_Z'
 F_EULER_NUMBER = 'EulerNumber'
-F_PERIMETER = 'Perimeter'
 F_FORM_FACTOR = 'FormFactor'
 F_MAJOR_AXIS_LENGTH = 'MajorAxisLength'
 F_MINOR_AXIS_LENGTH = 'MinorAxisLength'
@@ -195,9 +197,10 @@ F_MIN_FERET_DIAMETER = 'MinFeretDiameter'
 F_MAX_FERET_DIAMETER = 'MaxFeretDiameter'
 
 """The non-Zernike features"""
-F_STANDARD = [F_AREA, F_ECCENTRICITY, F_SOLIDITY, F_EXTENT,
-              F_EULER_NUMBER, F_PERIMETER, F_FORM_FACTOR,
-              F_MAJOR_AXIS_LENGTH, F_MINOR_AXIS_LENGTH,
+F_STD_2D = [F_AREA, F_PERIMETER]
+F_STD_3D = [F_VOLUME, F_SURFACE_AREA]
+F_STANDARD = [F_ECCENTRICITY, F_SOLIDITY, F_EXTENT, F_EULER_NUMBER,
+              F_FORM_FACTOR, F_MAJOR_AXIS_LENGTH, F_MINOR_AXIS_LENGTH,
               F_ORIENTATION, F_COMPACTNESS, F_CENTER_X, F_CENTER_Y, F_CENTER_Z,
               F_MAXIMUM_RADIUS, F_MEAN_RADIUS, F_MEDIAN_RADIUS,
               F_MIN_FERET_DIAMETER, F_MAX_FERET_DIAMETER]

--- a/tests/modules/test_measureimageareaoccupied.py
+++ b/tests/modules/test_measureimageareaoccupied.py
@@ -99,7 +99,7 @@ class TestMeasureImageArea(unittest.TestCase):
         module = cellprofiler.modules.measureimageareaoccupied.MeasureImageAreaOccupied()
         module.operands[0].operand_objects.value = OBJECTS_NAME
         module.operands[0].operand_choice.value = "Objects"
-        columns = module.get_measurement_columns(None)
+        columns = module.get_measurement_columns(cellprofiler.pipeline.Pipeline())
         expected = ((cellprofiler.measurement.IMAGE, "AreaOccupied_AreaOccupied_%s" % OBJECTS_NAME,
                      cellprofiler.measurement.COLTYPE_FLOAT),
                     (cellprofiler.measurement.IMAGE, "AreaOccupied_Perimeter_%s" % OBJECTS_NAME,
@@ -121,6 +121,7 @@ class TestMeasureImageArea(unittest.TestCase):
         expected_total_area = 500
 
         workspace = self.make_workspace(labels)
+        workspace.pipeline.set_volumetric(True)
 
         module = workspace.module
         module.operands[0].operand_choice.value = "Objects"
@@ -131,18 +132,18 @@ class TestMeasureImageArea(unittest.TestCase):
             return "AreaOccupied_%s_%s" % (x, module.operands[0].operand_objects.value)
 
         numpy.testing.assert_array_equal(
-            workspace.measurements.get_current_measurement("Image", mn("AreaOccupied")),
+            workspace.measurements.get_current_measurement("Image", mn("VolumeOccupied")),
             expected_area
         )
 
         numpy.testing.assert_array_almost_equal(
-            workspace.measurements.get_current_measurement("Image", mn("Perimeter")),
+            workspace.measurements.get_current_measurement("Image", mn("SurfaceArea")),
             expected_perimeter,
             decimal=0
         )
 
         numpy.testing.assert_array_equal(
-            workspace.measurements.get_current_measurement("Image", mn("TotalArea")),
+            workspace.measurements.get_current_measurement("Image", mn("TotalVolume")),
             expected_total_area
         )
 
@@ -158,6 +159,7 @@ class TestMeasureImageArea(unittest.TestCase):
         expected_total_area = 500
 
         workspace = self.make_workspace(numpy.zeros_like(pixel_data), parent_image=image)
+        workspace.pipeline.set_volumetric(True)
         workspace.image_set.add("MyBinaryImage", image)
 
         module = workspace.module
@@ -170,18 +172,18 @@ class TestMeasureImageArea(unittest.TestCase):
             return "AreaOccupied_%s_%s" % (x, module.operands[0].binary_name.value)
 
         numpy.testing.assert_array_equal(
-            workspace.measurements.get_current_measurement("Image", mn("AreaOccupied")),
+            workspace.measurements.get_current_measurement("Image", mn("VolumeOccupied")),
             expected_area
         )
 
         numpy.testing.assert_array_almost_equal(
-            workspace.measurements.get_current_measurement("Image", mn("Perimeter")),
+            workspace.measurements.get_current_measurement("Image", mn("SurfaceArea")),
             expected_perimeter,
             decimal=0
         )
 
         numpy.testing.assert_array_equal(
-            workspace.measurements.get_current_measurement("Image", mn("TotalArea")),
+            workspace.measurements.get_current_measurement("Image", mn("TotalVolume")),
             expected_total_area
         )
 

--- a/tests/modules/test_measureimagequality.py
+++ b/tests/modules/test_measureimagequality.py
@@ -83,14 +83,14 @@ class TestMeasureImageQuality(unittest.TestCase):
                 self.assertEqual(m_value, value,
                                  "Measured value, %f, for feature %s was not %f" %
                                  (m_value, feature_name, value))
-        self.features_and_columns_match(m, q)
+        self.features_and_columns_match(m, q, pipeline=workspace.pipeline)
 
     def features_and_columns_match(self, measurements, module,
-                                   object_name=cpmeas.IMAGE):
+                                   object_name=cpmeas.IMAGE, pipeline=None):
         self.assertTrue(object_name in measurements.get_object_names())
         features = measurements.get_feature_names(object_name)
         columns = filter((lambda x: x[0] == object_name),
-                         module.get_measurement_columns(None))
+                         module.get_measurement_columns(pipeline))
         self.assertEqual(len(features), len(columns))
         for column in columns:
             self.assertTrue(column[1] in features, 'features_and_columns_match, %s not in %s' % (column[1], features))
@@ -433,7 +433,7 @@ class TestMeasureImageQuality(unittest.TestCase):
 
         m.add_all_measurements(cpmeas.IMAGE, feature, dlist)
         module.post_run(workspace)
-        self.features_and_columns_match(m, module, cpmeas.EXPERIMENT)
+        self.features_and_columns_match(m, module, cpmeas.EXPERIMENT, pipeline=workspace.pipeline)
 
         # Check threshold algorithms
         threshold_group = module.image_groups[0].threshold_groups[0]

--- a/tests/modules/test_measureimagequality.py
+++ b/tests/modules/test_measureimagequality.py
@@ -12,45 +12,47 @@ from cellprofiler.preferences import set_headless
 
 set_headless()
 
-import cellprofiler.modules.measureimagequality as miq
+import cellprofiler.modules.measureimagequality as M
 import cellprofiler.modules.namesandtypes
 import cellprofiler.modules.loadsingleimage
 import cellprofiler.modules.smooth
-import cellprofiler.pipeline as cpp
-import cellprofiler.workspace as cpw
-import cellprofiler.image as cpi
-import cellprofiler.object as cpo
-import cellprofiler.measurement as cpmeas
-import centrosome.threshold as cpthresh
+import cellprofiler.pipeline
+import cellprofiler.workspace
+import cellprofiler.image
+import cellprofiler.object
+import cellprofiler.measurement
+import cellprofiler.modules.identify
+import centrosome.threshold
 
 IMAGES_NAME = "my_image"
 OBJECTS_NAME = "my_objects"
 
 
 class TestMeasureImageQuality(unittest.TestCase):
+
     def make_workspace(self, pixel_data, mask=None, objects=None, dimensions=2):
-        image_set_list = cpi.ImageSetList()
+        image_set_list = cellprofiler.image.ImageSetList()
         image_set = image_set_list.get_image_set(0)
-        object_set = cpo.ObjectSet()
-        image = cpi.Image(pixel_data, dimensions=dimensions)
+        object_set = cellprofiler.object.ObjectSet()
+        image = cellprofiler.image.Image(pixel_data, dimensions=dimensions)
         if not mask is None:
             image.mask = mask
         image_set.add(IMAGES_NAME, image)
         if not objects is None:
-            o = cpo.Objects()
+            o = cellprofiler.object.Objects()
             o.segmented = objects
             object_set.add_objects(o, OBJECTS_NAME)
-        module = miq.MeasureImageQuality()
-        module.images_choice.value = miq.O_SELECT
+        module = M.MeasureImageQuality()
+        module.images_choice.value = M.O_SELECT
         module.image_groups[0].include_image_scalings.value = False
         module.image_groups[0].image_names.value = IMAGES_NAME
         module.image_groups[0].use_all_threshold_methods.value = False
         module.module_num = 1
-        pipeline = cpp.Pipeline()
+        pipeline = cellprofiler.pipeline.Pipeline()
         pipeline.add_module(module)
-        workspace = cpw.Workspace(pipeline, module, image_set,
-                                  object_set,
-                                  cpmeas.Measurements(), image_set_list)
+        workspace = cellprofiler.workspace.Workspace(pipeline, module, image_set,
+                                                     object_set,
+                                                     cellprofiler.measurement.Measurements(), image_set_list)
         return workspace
 
     def test_00_00_zeros(self):
@@ -76,9 +78,9 @@ class TestMeasureImageQuality(unittest.TestCase):
                                     ("ImageQuality_MADIntensity_my_image", 0),
                                     ("ImageQuality_MaxIntensity_my_image", 0),
                                     ("ImageQuality_MinIntensity_my_image", 0)):
-            self.assertTrue(m.has_current_measurements(cpmeas.IMAGE, feature_name),
+            self.assertTrue(m.has_current_measurements(cellprofiler.measurement.IMAGE, feature_name),
                             "Missing feature %s" % feature_name)
-            m_value = m.get_current_measurement(cpmeas.IMAGE, feature_name)
+            m_value = m.get_current_measurement(cellprofiler.measurement.IMAGE, feature_name)
             if not value is None:
                 self.assertEqual(m_value, value,
                                  "Measured value, %f, for feature %s was not %f" %
@@ -86,7 +88,7 @@ class TestMeasureImageQuality(unittest.TestCase):
         self.features_and_columns_match(m, q, pipeline=workspace.pipeline)
 
     def features_and_columns_match(self, measurements, module,
-                                   object_name=cpmeas.IMAGE, pipeline=None):
+                                   object_name=cellprofiler.measurement.IMAGE, pipeline=None):
         self.assertTrue(object_name in measurements.get_object_names())
         features = measurements.get_feature_names(object_name)
         columns = filter((lambda x: x[0] == object_name),
@@ -94,8 +96,8 @@ class TestMeasureImageQuality(unittest.TestCase):
         self.assertEqual(len(features), len(columns))
         for column in columns:
             self.assertTrue(column[1] in features, 'features_and_columns_match, %s not in %s' % (column[1], features))
-            self.assertTrue(column[2] == cpmeas.COLTYPE_FLOAT,
-                            'features_and_columns_match, %s type not %s' % (column[2], cpmeas.COLTYPE_FLOAT))
+            self.assertTrue(column[2] == cellprofiler.measurement.COLTYPE_FLOAT,
+                            'features_and_columns_match, %s type not %s' % (column[2], cellprofiler.measurement.COLTYPE_FLOAT))
 
     def test_00_01_zeros_and_mask(self):
         workspace = self.make_workspace(np.zeros((100, 100)),
@@ -121,9 +123,9 @@ class TestMeasureImageQuality(unittest.TestCase):
                                     ("ImageQuality_MADIntensity_my_image", 0),
                                     ("ImageQuality_MaxIntensity_my_image", 0),
                                     ("ImageQuality_MinIntensity_my_image", 0)):
-            self.assertTrue(m.has_current_measurements(cpmeas.IMAGE, feature_name),
+            self.assertTrue(m.has_current_measurements(cellprofiler.measurement.IMAGE, feature_name),
                             "Missing feature %s" % feature_name)
-            m_value = m.get_current_measurement(cpmeas.IMAGE, feature_name)
+            m_value = m.get_current_measurement(cellprofiler.measurement.IMAGE, feature_name)
             self.assertEqual(m_value, value,
                              "Measured value, %f, for feature %s was not %f" % (m_value, feature_name, value))
 
@@ -152,13 +154,13 @@ class TestMeasureImageQuality(unittest.TestCase):
                                     ("ImageQuality_PercentSaturation_my_image", None),
                                     ("ImageQuality_PercentMaximal_my_image", None)):
             if value is None:
-                self.assertFalse(m.has_current_measurements(cpmeas.IMAGE, feature_name),
+                self.assertFalse(m.has_current_measurements(cellprofiler.measurement.IMAGE, feature_name),
                                  "Feature %s should not be present" % feature_name)
             else:
-                self.assertTrue(m.has_current_measurements(cpmeas.IMAGE, feature_name),
+                self.assertTrue(m.has_current_measurements(cellprofiler.measurement.IMAGE, feature_name),
                                 "Missing feature %s" % feature_name)
 
-                m_value = m.get_current_measurement(cpmeas.IMAGE, feature_name)
+                m_value = m.get_current_measurement(cellprofiler.measurement.IMAGE, feature_name)
                 self.assertAlmostEqual(m_value, value, 2,
                                        "Measured value, %f, for feature %s was not %f" % (m_value, feature_name, value))
         self.features_and_columns_match(m, q)
@@ -184,7 +186,7 @@ class TestMeasureImageQuality(unittest.TestCase):
         q.image_groups[0].scale_groups[0].scale.value = 500
         q.run(workspace)
         m = workspace.measurements
-        value = m.get_current_measurement(cpmeas.IMAGE, "ImageQuality_LocalFocusScore_my_image_500")
+        value = m.get_current_measurement(cellprofiler.measurement.IMAGE, "ImageQuality_LocalFocusScore_my_image_500")
         self.assertAlmostEqual(value, expected_value, 3)
 
     def test_01_03_focus_score_with_mask(self):
@@ -204,7 +206,7 @@ class TestMeasureImageQuality(unittest.TestCase):
         q.image_groups[0].scale_groups[0].scale.value = 500
         q.run(workspace)
         m = workspace.measurements
-        value = m.get_current_measurement(cpmeas.IMAGE, "ImageQuality_FocusScore_my_image")
+        value = m.get_current_measurement(cellprofiler.measurement.IMAGE, "ImageQuality_FocusScore_my_image")
         self.assertAlmostEqual(value, expected_value, 3)
 
     def test_01_04_local_focus_score_with_mask(self):
@@ -225,7 +227,7 @@ class TestMeasureImageQuality(unittest.TestCase):
         q.image_groups[0].scale_groups[0].scale.value = 500
         q.run(workspace)
         m = workspace.measurements
-        value = m.get_current_measurement(cpmeas.IMAGE, "ImageQuality_LocalFocusScore_my_image_500")
+        value = m.get_current_measurement(cellprofiler.measurement.IMAGE, "ImageQuality_LocalFocusScore_my_image_500")
         self.assertAlmostEqual(value, expected_value, 3)
 
     def test_02_01_saturation(self):
@@ -243,14 +245,14 @@ class TestMeasureImageQuality(unittest.TestCase):
         for feature_name in ("ImageQuality_ThresholdOtsu_my_image",
                              "ImageQuality_FocusScore_my_image",
                              "ImageQuality_LocalFocusScore_my_image_20"):
-            self.assertFalse(m.has_current_measurements(cpmeas.IMAGE,
+            self.assertFalse(m.has_current_measurements(cellprofiler.measurement.IMAGE,
                                                         feature_name),
                              "%s should not be present" % feature_name)
         for (feature_name, expected_value) in (("ImageQuality_PercentMaximal_my_image", 25),
                                                ("ImageQuality_PercentMinimal_my_image", 75)):
-            self.assertTrue(m.has_current_measurements(cpmeas.IMAGE,
+            self.assertTrue(m.has_current_measurements(cellprofiler.measurement.IMAGE,
                                                        feature_name))
-            self.assertAlmostEqual(m.get_current_measurement(cpmeas.IMAGE,
+            self.assertAlmostEqual(m.get_current_measurement(cellprofiler.measurement.IMAGE,
                                                              feature_name),
                                    expected_value)
         self.features_and_columns_match(m, q)
@@ -269,7 +271,7 @@ class TestMeasureImageQuality(unittest.TestCase):
         q.run(workspace)
         m = workspace.measurements
         self.assertAlmostEqual(expected_value,
-                               m.get_current_measurement(cpmeas.IMAGE, "ImageQuality_PercentMaximal_my_image"))
+                               m.get_current_measurement(cellprofiler.measurement.IMAGE, "ImageQuality_PercentMaximal_my_image"))
 
     def test_02_03_saturation_mask(self):
         '''Test percent saturation with mask'''
@@ -291,16 +293,16 @@ class TestMeasureImageQuality(unittest.TestCase):
         for feature_name in ("ImageQuality_ThresholdOtsu_my_image",
                              "ImageQuality_FocusScore_my_image",
                              "ImageQuality_LocalFocusScore_my_image_20"):
-            self.assertFalse(m.has_current_measurements(cpmeas.IMAGE,
+            self.assertFalse(m.has_current_measurements(cellprofiler.measurement.IMAGE,
                                                         feature_name),
                              "%s should not be present" % feature_name)
         for (feature_name, expected_value) in (("ImageQuality_PercentMaximal_my_image", 100.0 / 3),
                                                ("ImageQuality_PercentMinimal_my_image", 200.0 / 3)):
-            self.assertTrue(m.has_current_measurements(cpmeas.IMAGE,
+            self.assertTrue(m.has_current_measurements(cellprofiler.measurement.IMAGE,
                                                        feature_name))
-            print feature_name, expected_value, m.get_current_measurement(cpmeas.IMAGE,
+            print feature_name, expected_value, m.get_current_measurement(cellprofiler.measurement.IMAGE,
                                                                           feature_name)
-            self.assertAlmostEqual(m.get_current_measurement(cpmeas.IMAGE,
+            self.assertAlmostEqual(m.get_current_measurement(cellprofiler.measurement.IMAGE,
                                                              feature_name),
                                    expected_value)
 
@@ -320,7 +322,7 @@ class TestMeasureImageQuality(unittest.TestCase):
         q.run(workspace)
         m = workspace.measurements
         self.assertAlmostEqual(expected_value,
-                               m.get_current_measurement(cpmeas.IMAGE, "ImageQuality_PercentMaximal_my_image"))
+                               m.get_current_measurement(cellprofiler.measurement.IMAGE, "ImageQuality_PercentMaximal_my_image"))
 
     def test_03_01_threshold(self):
         '''Test all thresholding methods
@@ -342,8 +344,8 @@ class TestMeasureImageQuality(unittest.TestCase):
         workspace = self.make_workspace(image)
         q = workspace.module
 
-        for tm, idx in zip(cpthresh.TM_GLOBAL_METHODS,
-                           range(len(cpthresh.TM_GLOBAL_METHODS))):
+        for tm, idx in zip(centrosome.threshold.TM_GLOBAL_METHODS,
+                           range(len(centrosome.threshold.TM_GLOBAL_METHODS))):
             if idx != 0:
                 q.add_image_group()
             q.image_groups[idx].image_names.value = "my_image"
@@ -356,26 +358,26 @@ class TestMeasureImageQuality(unittest.TestCase):
             t = q.image_groups[idx].threshold_groups[0]
             t.threshold_method.value = tm
             t.object_fraction.value = object_fraction
-            t.two_class_otsu.value = miq.O_THREE_CLASS
-            t.assign_middle_to_foreground.value = miq.O_FOREGROUND
-            t.use_weighted_variance.value = miq.O_WEIGHTED_VARIANCE
+            t.two_class_otsu.value = cellprofiler.modules.identify.O_THREE_CLASS
+            t.assign_middle_to_foreground.value = cellprofiler.modules.identify.O_FOREGROUND
+            t.use_weighted_variance.value = cellprofiler.modules.identify.O_WEIGHTED_VARIANCE
         q.run(workspace)
         m = workspace.measurements
         for feature_name in ("ImageQuality_FocusScore_my_image",
                              "ImageQuality_LocalFocusScore_my_image_20",
                              "ImageQuality_PercentSaturation_my_image",
                              "ImageQuality_PercentMaximal_my_image"):
-            self.assertFalse(m.has_current_measurements(cpmeas.IMAGE,
+            self.assertFalse(m.has_current_measurements(cellprofiler.measurement.IMAGE,
                                                         feature_name))
-        for tm, idx in zip(cpthresh.TM_GLOBAL_METHODS,
-                           range(len(cpthresh.TM_GLOBAL_METHODS))):
-            if tm == cpthresh.TM_OTSU_GLOBAL:
+        for tm, idx in zip(centrosome.threshold.TM_GLOBAL_METHODS,
+                           range(len(centrosome.threshold.TM_GLOBAL_METHODS))):
+            if tm == centrosome.threshold.TM_OTSU_GLOBAL:
                 feature_name = "ImageQuality_ThresholdOtsu_my_image_3FW"
-            elif tm == cpthresh.TM_MOG_GLOBAL:
+            elif tm == centrosome.threshold.TM_MOG_GLOBAL:
                 feature_name = "ImageQuality_ThresholdMoG_my_image_20"
             else:
                 feature_name = "ImageQuality_Threshold%s_my_image" % tm.split(' ')[0]
-            self.assertTrue(m.has_current_measurements(cpmeas.IMAGE,
+            self.assertTrue(m.has_current_measurements(cellprofiler.measurement.IMAGE,
                                                        feature_name))
         self.features_and_columns_match(m, q)
 
@@ -383,15 +385,15 @@ class TestMeasureImageQuality(unittest.TestCase):
         '''Test experiment-wide thresholds'''
         np.random.seed(32)
         workspace = self.make_workspace(np.zeros((10, 10)))
-        self.assertTrue(isinstance(workspace, cpw.Workspace))
+        self.assertTrue(isinstance(workspace, cellprofiler.workspace.Workspace))
         module = workspace.module
-        self.assertTrue(isinstance(module, miq.MeasureImageQuality))
+        self.assertTrue(isinstance(module, M.MeasureImageQuality))
         m = workspace.measurements
-        self.assertTrue(isinstance(m, cpmeas.Measurements))
+        self.assertTrue(isinstance(m, cellprofiler.measurement.Measurements))
         image_name = module.image_groups[0].image_names.get_selections()[0]
         feature = module.image_groups[0].threshold_groups[0].threshold_feature_name(image_name)
         data = np.random.uniform(size=100)
-        m.add_all_measurements(cpmeas.IMAGE, feature, data.tolist())
+        m.add_all_measurements(cellprofiler.measurement.IMAGE, feature, data.tolist())
         module.post_run(workspace)
 
         # Check threshold algorithms
@@ -399,7 +401,7 @@ class TestMeasureImageQuality(unittest.TestCase):
         threshold_algorithm = threshold_group.threshold_algorithm
         f_mean, f_median, f_std = [
             threshold_group.threshold_feature_name(image_name, agg)
-            for agg in miq.AGG_MEAN, miq.AGG_MEDIAN, miq.AGG_STD]
+            for agg in M.AGG_MEAN, M.AGG_MEDIAN, M.AGG_STD]
 
         expected = ((f_mean, np.mean(data)),
                     (f_median, np.median(data)),
@@ -413,11 +415,11 @@ class TestMeasureImageQuality(unittest.TestCase):
 
         np.random.seed(33)
         workspace = self.make_workspace(np.zeros((10, 10)))
-        self.assertTrue(isinstance(workspace, cpw.Workspace))
+        self.assertTrue(isinstance(workspace, cellprofiler.workspace.Workspace))
         module = workspace.module
-        self.assertTrue(isinstance(module, miq.MeasureImageQuality))
+        self.assertTrue(isinstance(module, M.MeasureImageQuality))
         m = workspace.measurements
-        self.assertTrue(isinstance(m, cpmeas.Measurements))
+        self.assertTrue(isinstance(m, cellprofiler.measurement.Measurements))
         image_name = module.image_groups[0].image_names.get_selections()[0]
         feature = module.image_groups[0].threshold_groups[0].threshold_feature_name(image_name)
         data = np.random.uniform(size=100)
@@ -431,9 +433,9 @@ class TestMeasureImageQuality(unittest.TestCase):
         for e in eraser:
             dlist[e] = None
 
-        m.add_all_measurements(cpmeas.IMAGE, feature, dlist)
+        m.add_all_measurements(cellprofiler.measurement.IMAGE, feature, dlist)
         module.post_run(workspace)
-        self.features_and_columns_match(m, module, cpmeas.EXPERIMENT, pipeline=workspace.pipeline)
+        self.features_and_columns_match(m, module, cellprofiler.measurement.EXPERIMENT, pipeline=workspace.pipeline)
 
         # Check threshold algorithms
         threshold_group = module.image_groups[0].threshold_groups[0]
@@ -441,7 +443,7 @@ class TestMeasureImageQuality(unittest.TestCase):
         image_name = module.image_groups[0].image_names.value
         f_mean, f_median, f_std = [
             threshold_group.threshold_feature_name(image_name, agg)
-            for agg in miq.AGG_MEAN, miq.AGG_MEDIAN, miq.AGG_STD]
+            for agg in M.AGG_MEAN, M.AGG_MEDIAN, M.AGG_STD]
 
         expected = ((f_mean, np.mean(data[mask])),
                     (f_median, np.median(data[mask])),
@@ -474,15 +476,15 @@ class TestMeasureImageQuality(unittest.TestCase):
                              'ImageQuality_ThresholdRobustBackground_my_image',
                              'ImageQuality_ThresholdKapur_my_image',
                              'ImageQuality_ThresholdRidlerCalvard_my_image']:
-            self.assertTrue(m.has_current_measurements(cpmeas.IMAGE,
+            self.assertTrue(m.has_current_measurements(cellprofiler.measurement.IMAGE,
                                                        feature_name))
         self.features_and_columns_match(m, q)
 
     def check_error(self, caller, event):
-        self.assertFalse(isinstance(event, cpp.LoadExceptionEvent))
+        self.assertFalse(isinstance(event, cellprofiler.pipeline.LoadExceptionEvent))
 
     def test_04_01_load_matlab_pipeline(self):
-        p = cpp.Pipeline()
+        p = cellprofiler.pipeline.Pipeline()
         p.add_listener(self.check_error)
         data = 'TUFUTEFCIDUuMCBNQVQtZmlsZSwgUGxhdGZvcm06IFBDV0lOLCBDcmVhdGVkIG9uOiBXZWQgQXByIDE1IDE1OjI2OjU0IDIwMDkgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAABSU0PAAAAFwIAAHic7VbNTuMwEJ60aVV2RWDLZSX2kONedpefC8eyArGVaMufkJD24rZusJTGVeJULU/Ao/AYvAMvsY+wR2xIUscCknojKNI6sqxx5vtmxh57bAHAnxWAKh9rvJfgsVUi2ZC6kE8xY8RzggqY8Dmav+X9HPkEdV18jtwQB5C0eL7pDejZdJT8atF+6OI2GsrKvLXDYRf7QWcQA6PfR2SC3VNyhSHdYrUTPCYBoV6Ej/jV2cQuZYpdi/eb2mwdDGUdxLrUpXmh34CZvvnEuq1K+qtRP8MT9m1/gnrMHiLWuxQ8Gxk85RRPGS6473lwZgpnwt7uUTMPrpTClWBr4zHenQxcDdLxCrnjE+cnT4ki8Fnr/UHBC3mP2h5ldhhEibNIfujwtOiBfeDSLnL/jacof/7zzHg+KjxC7rAglDdsEePKug+MFI8B2wsaRxZP3v35lcHzSeERMvH6ZEz6IXJtMkROUl1ec5/Ue7tN3zZPvueMv6hzs6TwCNnx0TToITd+N1jSqFt38+Kf2w9d+94PlML/Lb/8XlmW5q0cYyPDn6feMw/J7vg0HNn8COCRbr7NeOb3Ky9fUfEtun9F+TNvnO89P3Tjfit/b+H586/eP7p2DynqN6WClqc+rik8Qm5hFIQ+fqA65lWSsGnCJ9+D1Yw4SvyrW3r1aFPTXsWYH2fy7/eXu3WBu4b59unrC/px09W/B+9W/qo='
         p.load(StringIO.StringIO(base64.b64decode(data)))
@@ -497,7 +499,7 @@ class TestMeasureImageQuality(unittest.TestCase):
         self.assertEqual(sg.scale.value, 20)
         self.assertTrue(ig.check_saturation.value)
         self.assertTrue(ig.calculate_threshold.value)
-        self.assertEqual(tg.threshold_algorithm, cpthresh.TM_MOG)
+        self.assertEqual(tg.threshold_algorithm, centrosome.threshold.TM_MOG)
 
     def test_04_02_load_saturation_blur(self):
         data = r"""CellProfiler Pipeline: http://www.cellprofiler.org
@@ -515,16 +517,16 @@ MeasureImageSaturationBlur:[module_num:1|svn_version:\'8913\'|variable_revision_
     Do you want to also check the above images for image quality (called blur earlier)?:Yes
     If you chose to check images for image quality above, enter the window size of LocalFocusScore measurement (A suggested value is 2 times ObjectSize)?:25
 """
-        pipeline = cpp.Pipeline()
+        pipeline = cellprofiler.pipeline.Pipeline()
 
         def callback(caller, event):
-            self.assertFalse(isinstance(event, cpp.LoadExceptionEvent))
+            self.assertFalse(isinstance(event, cellprofiler.pipeline.LoadExceptionEvent))
 
         pipeline.add_listener(callback)
         pipeline.load(StringIO.StringIO(data))
         self.assertEqual(len(pipeline.modules()), 1)
         module = pipeline.modules()[0]
-        self.assertTrue(isinstance(module, miq.MeasureImageQuality))
+        self.assertTrue(isinstance(module, M.MeasureImageQuality))
         self.assertEqual(len(module.image_groups), 3)
         for i in range(3):
             group = module.image_groups[i]
@@ -563,16 +565,16 @@ MeasureImageQuality:[module_num:1|svn_version:\'9143\'|variable_revision_number:
     Minimize the weighted variance or the entropy?:Entropy
     Assign pixels in the middle intensity class to the foreground or the background?:Background
 """
-        pipeline = cpp.Pipeline()
+        pipeline = cellprofiler.pipeline.Pipeline()
 
         def callback(caller, event):
-            self.assertFalse(isinstance(event, cpp.LoadExceptionEvent))
+            self.assertFalse(isinstance(event, cellprofiler.pipeline.LoadExceptionEvent))
 
         pipeline.add_listener(callback)
         pipeline.load(StringIO.StringIO(data))
         self.assertEqual(len(pipeline.modules()), 1)
         module = pipeline.modules()[0]
-        self.assertTrue(isinstance(module, miq.MeasureImageQuality))
+        self.assertTrue(isinstance(module, M.MeasureImageQuality))
         self.assertEqual(len(module.image_groups), 2)
 
         group = module.image_groups[0]
@@ -582,11 +584,11 @@ MeasureImageQuality:[module_num:1|svn_version:\'9143\'|variable_revision_number:
         self.assertEqual(group.scale_groups[0].scale, 25)
         self.assertTrue(group.check_saturation)
         self.assertTrue(group.calculate_threshold)
-        self.assertEqual(thr.threshold_method, miq.cpthresh.TM_OTSU)
+        self.assertEqual(thr.threshold_method, centrosome.threshold.TM_OTSU)
         self.assertAlmostEqual(thr.object_fraction.value, 0.2)
-        self.assertEqual(thr.two_class_otsu, miq.O_THREE_CLASS)
-        self.assertEqual(thr.use_weighted_variance, miq.O_WEIGHTED_VARIANCE)
-        self.assertEqual(thr.assign_middle_to_foreground, miq.O_FOREGROUND)
+        self.assertEqual(thr.two_class_otsu, cellprofiler.modules.identify.O_THREE_CLASS)
+        self.assertEqual(thr.use_weighted_variance, cellprofiler.modules.identify.O_WEIGHTED_VARIANCE)
+        self.assertEqual(thr.assign_middle_to_foreground, cellprofiler.modules.identify.O_FOREGROUND)
 
         group = module.image_groups[1]
         thr = group.threshold_groups[0]
@@ -595,11 +597,11 @@ MeasureImageQuality:[module_num:1|svn_version:\'9143\'|variable_revision_number:
         self.assertEqual(group.scale_groups[0].scale, 15)
         self.assertFalse(group.check_saturation)
         self.assertFalse(group.calculate_threshold)
-        self.assertEqual(thr.threshold_method, miq.cpthresh.TM_MOG)
+        self.assertEqual(thr.threshold_method, centrosome.threshold.TM_MOG)
         self.assertAlmostEqual(thr.object_fraction.value, 0.3)
-        self.assertEqual(thr.two_class_otsu, miq.O_TWO_CLASS)
-        self.assertEqual(thr.use_weighted_variance, miq.O_ENTROPY)
-        self.assertEqual(thr.assign_middle_to_foreground, miq.O_BACKGROUND)
+        self.assertEqual(thr.two_class_otsu, cellprofiler.modules.identify.O_TWO_CLASS)
+        self.assertEqual(thr.use_weighted_variance, cellprofiler.modules.identify.O_ENTROPY)
+        self.assertEqual(thr.assign_middle_to_foreground, cellprofiler.modules.identify.O_BACKGROUND)
 
     def test_04_04_load_v4(self):
         data = r"""CellProfiler Pipeline: http://www.cellprofiler.org
@@ -717,22 +719,22 @@ MeasureImageQuality:[module_num:5|svn_version:\'10368\'|variable_revision_number
     Minimize the weighted variance or the entropy?:Weighted variance
     Assign pixels in the middle intensity class to the foreground or the background?:Foreground
 """
-        pipeline = cpp.Pipeline()
+        pipeline = cellprofiler.pipeline.Pipeline()
 
         def callback(caller, event):
-            self.assertFalse(isinstance(event, cpp.LoadExceptionEvent))
+            self.assertFalse(isinstance(event, cellprofiler.pipeline.LoadExceptionEvent))
 
         pipeline.add_listener(callback)
         pipeline.load(StringIO.StringIO(data))
         self.assertEqual(len(pipeline.modules()), 5)
         for module in pipeline.modules():
-            self.assertTrue(isinstance(module, miq.MeasureImageQuality))
+            self.assertTrue(isinstance(module, M.MeasureImageQuality))
 
         module = pipeline.modules()[0]
         self.assertEqual(len(module.image_groups), 1)
         group = module.image_groups[0]
         self.assertEqual(group.threshold_groups, [])
-        self.assertEqual(module.images_choice, miq.O_ALL_LOADED)
+        self.assertEqual(module.images_choice, M.O_ALL_LOADED)
         self.assertTrue(group.check_blur)
         self.assertEqual(group.scale_groups[0].scale, 20)
         self.assertTrue(group.check_saturation)
@@ -743,44 +745,44 @@ MeasureImageQuality:[module_num:5|svn_version:\'10368\'|variable_revision_number
         module = pipeline.modules()[1]
         self.assertEqual(len(module.image_groups), 1)
         group = module.image_groups[0]
-        self.assertEqual(module.images_choice, miq.O_SELECT)
+        self.assertEqual(module.images_choice, M.O_SELECT)
         self.assertEqual(group.image_names, "Alpha")
 
         module = pipeline.modules()[2]
         self.assertEqual(len(module.image_groups), 1)
         group = module.image_groups[0]
-        self.assertEqual(module.images_choice, miq.O_SELECT)
+        self.assertEqual(module.images_choice, M.O_SELECT)
         self.assertEqual(group.image_names, "Delta,Beta")
 
         module = pipeline.modules()[3]
         self.assertEqual(len(module.image_groups), 2)
         group = module.image_groups[0]
-        self.assertEqual(module.images_choice, miq.O_SELECT)
+        self.assertEqual(module.images_choice, M.O_SELECT)
         self.assertEqual(group.image_names, "Delta")
         self.assertTrue(group.check_intensity)
         self.assertFalse(group.use_all_threshold_methods)
         thr = group.threshold_groups[0]
-        self.assertEqual(thr.threshold_method, miq.cpthresh.TM_OTSU)
-        self.assertEqual(thr.use_weighted_variance, miq.O_WEIGHTED_VARIANCE)
-        self.assertEqual(thr.two_class_otsu, miq.O_TWO_CLASS)
+        self.assertEqual(thr.threshold_method, centrosome.threshold.TM_OTSU)
+        self.assertEqual(thr.use_weighted_variance, cellprofiler.modules.identify.O_WEIGHTED_VARIANCE)
+        self.assertEqual(thr.two_class_otsu, cellprofiler.modules.identify.O_TWO_CLASS)
         group = module.image_groups[1]
         self.assertEqual(group.image_names, "Epsilon")
 
         module = pipeline.modules()[4]
         self.assertEqual(len(module.image_groups), 1)
         group = module.image_groups[0]
-        self.assertEqual(module.images_choice, miq.O_SELECT)
+        self.assertEqual(module.images_choice, M.O_SELECT)
         self.assertEqual(group.image_names, "Zeta")
         self.assertFalse(group.use_all_threshold_methods)
         thr = group.threshold_groups[0]
-        self.assertEqual(thr.threshold_method, miq.cpthresh.TM_OTSU)
-        self.assertEqual(thr.use_weighted_variance, miq.O_WEIGHTED_VARIANCE)
-        self.assertEqual(thr.two_class_otsu, miq.O_TWO_CLASS)
+        self.assertEqual(thr.threshold_method, centrosome.threshold.TM_OTSU)
+        self.assertEqual(thr.use_weighted_variance, cellprofiler.modules.identify.O_WEIGHTED_VARIANCE)
+        self.assertEqual(thr.two_class_otsu, cellprofiler.modules.identify.O_TWO_CLASS)
         thr = group.threshold_groups[1]
-        self.assertEqual(thr.threshold_method, miq.cpthresh.TM_OTSU)
-        self.assertEqual(thr.use_weighted_variance, miq.O_WEIGHTED_VARIANCE)
-        self.assertEqual(thr.two_class_otsu, miq.O_THREE_CLASS)
-        self.assertEqual(thr.assign_middle_to_foreground, miq.O_FOREGROUND)
+        self.assertEqual(thr.threshold_method, centrosome.threshold.TM_OTSU)
+        self.assertEqual(thr.use_weighted_variance, cellprofiler.modules.identify.O_WEIGHTED_VARIANCE)
+        self.assertEqual(thr.two_class_otsu, cellprofiler.modules.identify.O_THREE_CLASS)
+        self.assertEqual(thr.assign_middle_to_foreground, cellprofiler.modules.identify.O_FOREGROUND)
 
     def test_05_01_intensity_image(self):
         '''Test operation on a single unmasked image'''
@@ -795,9 +797,9 @@ MeasureImageQuality:[module_num:5|svn_version:\'10368\'|variable_revision_number
         q.image_groups[0].calculate_threshold.value = False
         q.run(workspace)
         m = workspace.measurements
-        self.assertEqual(m.get_current_measurement(cpmeas.IMAGE, "ImageQuality_TotalIntensity_my_image"),
+        self.assertEqual(m.get_current_measurement(cellprofiler.measurement.IMAGE, "ImageQuality_TotalIntensity_my_image"),
                          np.sum(pixels))
-        self.assertEqual(m.get_current_measurement(cpmeas.IMAGE, "ImageQuality_MeanIntensity_my_image"),
+        self.assertEqual(m.get_current_measurement(cellprofiler.measurement.IMAGE, "ImageQuality_MeanIntensity_my_image"),
                          np.sum(pixels) / 100.0)
         self.assertEqual(m.get_current_image_measurement('ImageQuality_MinIntensity_my_image'),
                          np.min(pixels))
@@ -809,7 +811,7 @@ MeasureImageQuality:[module_num:5|svn_version:\'10368\'|variable_revision_number
         image_set_list = workspace.image_set_list
         image_set = image_set_list.get_image_set(0)
         for i in range(1, 5):
-            image_set.add("my_image%s" % i, cpi.Image(np.zeros((100, 100))))
+            image_set.add("my_image%s" % i, cellprofiler.image.Image(np.zeros((100, 100))))
 
         q = workspace.module
         # Set my_image1 and my_image2 settings: Saturation only
@@ -835,23 +837,23 @@ MeasureImageQuality:[module_num:5|svn_version:\'10368\'|variable_revision_number
         for i in [1, 2]:
             for feature_name in (("ImageQuality_PercentMaximal_my_image%s" % i),
                                  ("ImageQuality_PercentMinimal_my_image%s" % i)):
-                self.assertTrue(m.has_current_measurements(cpmeas.IMAGE, feature_name),
+                self.assertTrue(m.has_current_measurements(cellprofiler.measurement.IMAGE, feature_name),
                                 "Missing feature %s" % feature_name)
 
             for feature_name in (("ImageQuality_FocusScore_my_image%s" % i),
                                  ("ImageQuality_LocalFocusScore_my_image%s_20" % i),
                                  ("ImageQuality_PowerLogLogSlope_my_image%s" % i)):
-                self.assertFalse(m.has_current_measurements(cpmeas.IMAGE, feature_name),
+                self.assertFalse(m.has_current_measurements(cellprofiler.measurement.IMAGE, feature_name),
                                  "Erroneously present feature %s" % feature_name)
         for i in [3, 4]:
             for feature_name in (("ImageQuality_FocusScore_my_image%s" % i),
                                  ("ImageQuality_LocalFocusScore_my_image%s_20" % i),
                                  ("ImageQuality_PowerLogLogSlope_my_image%s" % i)):
-                self.assertTrue(m.has_current_measurements(cpmeas.IMAGE, feature_name),
+                self.assertTrue(m.has_current_measurements(cellprofiler.measurement.IMAGE, feature_name),
                                 "Missing feature %s" % feature_name)
             for feature_name in (("ImageQuality_PercentMaximal_my_image%s" % i),
                                  ("ImageQuality_PercentMinimal_my_image%s" % i)):
-                self.assertFalse(m.has_current_measurements(cpmeas.IMAGE, feature_name),
+                self.assertFalse(m.has_current_measurements(cellprofiler.measurement.IMAGE, feature_name),
                                  "Erroneously present feature %s" % feature_name)
 
     def test_06_01_images_to_process(self):
@@ -860,7 +862,7 @@ MeasureImageQuality:[module_num:5|svn_version:\'10368\'|variable_revision_number
         # variety of image providers.
         #
         expected_names = ["foo", "bar"]
-        pipeline = cpp.Pipeline()
+        pipeline = cellprofiler.pipeline.Pipeline()
         module1 = cellprofiler.modules.namesandtypes.NamesAndTypes()
         module1.module_num = 1
         module1.assignment_method.value = \
@@ -888,9 +890,9 @@ MeasureImageQuality:[module_num:5|svn_version:\'10368\'|variable_revision_number
         module2.filtered_image_name.value = "henry"
         pipeline.add_module(module2)
 
-        miq_module = miq.MeasureImageQuality()
+        miq_module = M.MeasureImageQuality()
         miq_module.module_num = 3
-        miq_module.images_choice.value = miq.O_ALL_LOADED
+        miq_module.images_choice.value = M.O_ALL_LOADED
         image_names = miq_module.images_to_process(
                 miq_module.image_groups[0], None, pipeline)
         self.assertEqual(len(image_names), len(expected_names))
@@ -909,15 +911,15 @@ MeasureImageQuality:[module_num:5|svn_version:\'10368\'|variable_revision_number
         module.run(workspace)
 
         # Names and values will be associated directly
-        names = ["_".join([miq.C_IMAGE_QUALITY, feature, IMAGES_NAME])
-                 for feature in [miq.F_TOTAL_VOLUME,
-                                 miq.F_TOTAL_INTENSITY,
-                                 miq.F_MEAN_INTENSITY,
-                                 miq.F_MEDIAN_INTENSITY,
-                                 miq.F_STD_INTENSITY,
-                                 miq.F_MAD_INTENSITY,
-                                 miq.F_MAX_INTENSITY,
-                                 miq.F_MIN_INTENSITY]]
+        names = ["_".join([M.C_IMAGE_QUALITY, feature, IMAGES_NAME])
+                 for feature in [M.F_TOTAL_VOLUME,
+                                 M.F_TOTAL_INTENSITY,
+                                 M.F_MEAN_INTENSITY,
+                                 M.F_MEDIAN_INTENSITY,
+                                 M.F_STD_INTENSITY,
+                                 M.F_MAD_INTENSITY,
+                                 M.F_MAX_INTENSITY,
+                                 M.F_MIN_INTENSITY]]
         values = [8000,
                   3.9607843137254903,
                   0.0004950980392156863,
@@ -930,12 +932,12 @@ MeasureImageQuality:[module_num:5|svn_version:\'10368\'|variable_revision_number
 
         for feature, value in expected.items():
             assert workspace.measurements.has_current_measurements(
-                cpmeas.IMAGE,
+                cellprofiler.measurement.IMAGE,
                 feature
             )
 
             actual = workspace.measurements.get_current_measurement(
-                cpmeas.IMAGE,
+                cellprofiler.measurement.IMAGE,
                 feature
             )
 


### PR DESCRIPTION
Resolves #3489 

E.g., use "Volume" and "SurfaceArea" instead of "Area" and "Perimeter". This is a breaking change that should be documented in the 3.1.0 release.