### PR TITLE
UTF fixes

### DIFF
--- a/cellprofiler/pipeline.py
+++ b/cellprofiler/pipeline.py
@@ -138,7 +138,7 @@ FMT_MATLAB = "Matlab"
 FMT_NATIVE = "Native"
 
 '''The current pipeline file format version'''
-NATIVE_VERSION = 3
+NATIVE_VERSION = 4
 
 '''The version of the image plane descriptor section'''
 IMAGE_PLANE_DESCRIPTOR_VERSION = 1
@@ -880,6 +880,7 @@ class Pipeline(object):
             raise NotImplementedError('Invalid header: "%s"' % header)
         version = NATIVE_VERSION
         from_matlab = False
+        do_deprecated_utf16_decode = False
         do_utf16_decode = False
         has_image_plane_details = False
         git_hash = None
@@ -898,7 +899,9 @@ class Pipeline(object):
                 version = int(value)
                 if version > NATIVE_VERSION:
                     raise ValueError("Pipeline file version is {}.\nCellProfiler can only read version {} or less.\nPlease upgrade to the latest version of CellProfiler.".format(version, NATIVE_VERSION))
-                elif version > 1:
+                elif version > 1 and version < 4:
+                    do_deprecated_utf16_decode = True
+                elif version >= 4:
                     do_utf16_decode = True
             elif kwd in (H_SVN_REVISION, H_DATE_REVISION):
                 pipeline_version = int(value)
@@ -1005,8 +1008,10 @@ class Pipeline(object):
                         raise ValueError("Invalid format for setting: %s" % line)
                     text, setting = line.split(':')
                     setting = setting.decode('string_escape')
-                    if do_utf16_decode:
+                    if do_deprecated_utf16_decode:
                         setting = utf16decode(setting)
+                    elif do_utf16_decode:
+                        setting = setting.decode('utf-16')
                     settings.append(setting)
                 #
                 # Set up the module
@@ -1026,6 +1031,8 @@ class Pipeline(object):
                 attribute_strings = attribute_string[1:-1].split('|')
                 variable_revision_number = None
                 # make batch_state decodable from text pipelines
+                # NOTE: These variables are **necessary**, even though they aren't used anywhere obvious
+                # Removing them **will*
                 array = np.array
                 uint8 = np.uint8
                 for a in attribute_strings:
@@ -1188,12 +1195,14 @@ class Pipeline(object):
             for setting in module.settings():
                 setting_text = setting.text
                 if isinstance(setting_text, unicode):
+                    # setting_text = setting_text.encode('utf-16')
                     setting_text = setting_text.encode('utf-8')
                 else:
                     setting_text = str(setting_text)
                 fd.write('    %s:%s\n' % (
                     self.encode_txt(setting_text),
-                    self.encode_txt(utf16encode(setting.unicode_value))))
+                    # self.encode_txt(utf16encode(setting.unicode_value))))
+                    self.encode_txt(setting.unicode_value.encode('utf-16'))))
         if save_image_plane_details:
             fd.write("\n")
             write_file_list(fd, self.__file_list)

--- a/cellprofiler/pipeline.py
+++ b/cellprofiler/pipeline.py
@@ -1031,8 +1031,8 @@ class Pipeline(object):
                 attribute_strings = attribute_string[1:-1].split('|')
                 variable_revision_number = None
                 # make batch_state decodable from text pipelines
-                # NOTE: These variables are **necessary**, even though they aren't used anywhere obvious
-                # Removing them **will*
+                # NOTE, MAGIC HERE: These variables are **necessary**, even though they
+                # aren't used anywhere obvious. Removing them **will** break these unit tests.
                 array = np.array
                 uint8 = np.uint8
                 for a in attribute_strings:

--- a/cellprofiler/pipeline.py
+++ b/cellprofiler/pipeline.py
@@ -45,7 +45,7 @@ import cellprofiler.measurement as cpmeas
 import cellprofiler.object as cpo
 import cellprofiler.workspace as cpw
 import cellprofiler.setting as cps
-from cellprofiler.utilities.utf16encode import utf16encode, utf16decode
+import cellprofiler.utilities.utf16encode
 from bioformats.omexml import OMEXML
 from bioformats.formatreader import clear_image_reader_cache
 import javabridge as J
@@ -1009,7 +1009,7 @@ class Pipeline(object):
                     text, setting = line.split(':')
                     setting = setting.decode('string_escape')
                     if do_deprecated_utf16_decode:
-                        setting = utf16decode(setting)
+                        setting = cellprofiler.utilities.utf16encode.utf16decode(setting)
                     elif do_utf16_decode:
                         setting = setting.decode('utf-16')
                     settings.append(setting)

--- a/cellprofiler/preferences.py
+++ b/cellprofiler/preferences.py
@@ -52,9 +52,6 @@ class HeadlessConfig(object):
     def Write(self, kwd, value):
         self.__preferences[kwd] = value
 
-    WriteInt = Write
-    WriteBool = Write
-
     def Exists(self, kwd):
         return self.__preferences.has_key(kwd)
 
@@ -177,8 +174,6 @@ def config_read(key):
     Only read from the registry once. This is both technically efficient
     and keeps parallel running instances of CellProfiler from overwriting
     each other's values for things like the current output directory.
-
-    Decode escaped config sequences too.
     '''
     global __cached_values
     if not __is_headless:
@@ -203,21 +198,12 @@ def config_read(key):
         value = get_config().Read(key)
     else:
         value = None
-    if value is not None:
-        try:
-            value = cellprofiler.utilities.utf16encode.utf16decode(value)
-        except:
-            logger.warning(
-                    "Failed to decode preference (%s=%s), assuming 2.0" %
-                    (key, value))
     __cached_values[key] = value
     return value
 
 
 def config_write(key, value):
     '''Write the given configuration value
-
-    Encode escaped config sequences.
     '''
     if not __is_headless:
         #
@@ -226,8 +212,6 @@ def config_write(key, value):
         import wx
         shutup = wx.LogNull()
     __cached_values[key] = value
-    if value is not None:
-        value = value.encode('utf-16')
     get_config().Write(key, value)
 
 
@@ -1040,7 +1024,7 @@ def get_show_sampling():
 
 def set_show_sampling(value):
     global __show_sampling
-    get_config().WriteBool(SHOW_SAMPLING, bool(value))
+    get_config().Write(SHOW_SAMPLING, bool(value))
     __show_sampling = bool(value)
 
 
@@ -1201,7 +1185,7 @@ def get_telemetry():
 
 
 def set_telemetry(val):
-    get_config().WriteBool(TELEMETRY, val)
+    get_config().Write(TELEMETRY, val)
 
 
 def get_telemetry_prompt():
@@ -1212,7 +1196,7 @@ def get_telemetry_prompt():
 
 
 def set_telemetry_prompt(val):
-    get_config().WriteBool(TELEMETRY_PROMPT, val)
+    get_config().Write(TELEMETRY_PROMPT, val)
 
 
 def get_startup_blurb():
@@ -1222,7 +1206,7 @@ def get_startup_blurb():
 
 
 def set_startup_blurb(val):
-    get_config().WriteBool(STARTUPBLURB, val)
+    get_config().Write(STARTUPBLURB, val)
 
 
 def get_primary_outline_color():
@@ -1546,7 +1530,7 @@ def get_max_workers():
 def set_max_workers(value):
     '''Set the maximum number of worker processes allowed during analysis'''
     global __max_workers
-    get_config().WriteInt(MAX_WORKERS, value)
+    get_config().Write(MAX_WORKERS, value)
     __max_workers = value
 
 

--- a/cellprofiler/preferences.py
+++ b/cellprofiler/preferences.py
@@ -17,13 +17,12 @@ import traceback
 import uuid
 import weakref
 
-import pkg_resources
 import sys
 import time
 
 import cellprofiler
 import cellprofiler.gui.help.content
-from cellprofiler.utilities.utf16encode import utf16encode, utf16decode
+import cellprofiler.utilities.utf16encode
 
 logger = logging.getLogger(__name__)
 
@@ -206,7 +205,7 @@ def config_read(key):
         value = None
     if value is not None:
         try:
-            value = utf16decode(value)
+            value = cellprofiler.utilities.utf16encode.utf16decode(value)
         except:
             logger.warning(
                     "Failed to decode preference (%s=%s), assuming 2.0" %
@@ -228,7 +227,7 @@ def config_write(key, value):
         shutup = wx.LogNull()
     __cached_values[key] = value
     if value is not None:
-        value = utf16encode(value)
+        value = value.encode('utf-16')
     get_config().Write(key, value)
 
 

--- a/cellprofiler/setting.py
+++ b/cellprofiler/setting.py
@@ -20,7 +20,6 @@ from cellprofiler.preferences import \
     standardize_default_folder_names
 import cellprofiler.measurement
 
-from cellprofiler.utilities.utf16encode import utf16encode
 import skimage.morphology
 
 '''Matlab CellProfiler uses this string for settings to be excluded'''
@@ -190,7 +189,7 @@ class Setting(object):
         NOTE: strings are deprecated, use unicode_value instead.
         '''
         if isinstance(self.__value, unicode):
-            return str(utf16encode(self.__value))
+            return str(self.__value.encode('utf-16'))
         if not isinstance(self.__value, str):
             raise ValidationError("%s was not a string" % self.__value, self)
         return self.__value

--- a/cellprofiler/utilities/utf16encode.py
+++ b/cellprofiler/utilities/utf16encode.py
@@ -1,37 +1,13 @@
-'''utf16encode.py - encode unicode strings as escaped utf16
-'''
-
-
-def utf16encode(x):
-    '''Encode a unicode string in 7-bit US ascii
-
-    x - unicode string to be encoded
-
-    returns utf8-escape-encoded string
-
-    The escapes:
-
-    \ (backslash) -> \\
-
-    0x20 <= c < 0xff -> c
-
-    all others -> \u####
-    '''
-    y = ''
-    for z in x:
-        t = ord(z)
-        if t < 0x20 or t >= 0x7f:
-            y += "\\u%04x" % t
-        elif z == "\\":
-            y += "\\\\"
-        else:
-            y += str(z)
-    return y
+"""
+/!\ WARNING - DEPRECATED /!\
+utf16encode.py - encode unicode strings as escaped utf16
+This is only used for pipeline version < 3 files
+"""
 
 
 def utf16decode(x):
-    '''Decode an escaped utf8-encoded string
-    '''
+    """Decode an escaped utf8-encoded string
+    """
     y = u""
     state = -1
     for z in x:

--- a/tests/resources/pipelineV3.cppipe
+++ b/tests/resources/pipelineV3.cppipe
@@ -1,0 +1,9 @@
+CellProfiler Pipeline: http://www.cellprofiler.org
+Version:3
+DateRevision:300
+GitHash:
+ModuleCount:1
+HasImagePlaneDetails:False
+
+TestModuleWithMeasurement:[module_num:1|svn_version:\'Unknown\'|variable_revision_number:1|show_window:False|notes:u\'\\u03b1\\\\\\u03b2\'|batch_state:array([], dtype=uint8)|enabled:True|wants_pause:False]
+    :\\\\\\u2211

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -679,7 +679,7 @@ HasImagePlaneDetails:False"""
         #
         # unicode encoding:
         #     backslash: \\ (BOM encoding)
-        #     unicode character: \u
+        #     unicode character: \u2211 (n-ary summation)
         #
         # escape encoding:
         #     utf-16 to byte: \xff\xfe\\\x00\x11"

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -62,6 +62,14 @@ class TestPreferences(unittest.TestCase):
         result = cpprefs.config_read("test_preferences")
         self.assertEqual(result, gotcha)
 
+    def test_01_05_unicode_value(self):
+        # If the item is already in unicode, don't re-decode
+        gotcha = u"c:\\users\\default"
+        cpprefs.set_preferences_from_dict({})  # clear cache
+        cpprefs.get_config().Write("test_preferences", gotcha)
+        result = cpprefs.config_read("test_preferences")
+        self.assertEqual(result, gotcha)
+
 
 class TestPreferences_02(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Resolves #2538 
Pipeline files will now be written out as version `4`, which will be in strictly string-escaped utf-16 format (rather than the homebrewed utf-16 conversion). 

Unit tests were adjusted to reflect these changes. 