### PR TITLE
Allow pre-labeled images to be used in ConvertImageToObjects

### DIFF
--- a/cellprofiler/modules/convertimagetoobjects.py
+++ b/cellprofiler/modules/convertimagetoobjects.py
@@ -5,6 +5,7 @@ import skimage.measure
 import cellprofiler.module
 import cellprofiler.setting
 
+
 HELP_BINARY_IMAGE = """\
 This module can also convert a grayscale image to binary before converting it to an object.
 Connected components of the binary image are assigned to the same object. This feature is 
@@ -39,7 +40,6 @@ YES          YES          NO
 """.format(**{
     "HELP_BINARY_IMAGE": HELP_BINARY_IMAGE
 })
-
 
 
 class ConvertImageToObjects(cellprofiler.module.ImageSegmentation):

--- a/cellprofiler/modules/convertimagetoobjects.py
+++ b/cellprofiler/modules/convertimagetoobjects.py
@@ -1,17 +1,32 @@
 # coding=utf-8
+import skimage
+import skimage.measure
 
+import cellprofiler.module
+import cellprofiler.setting
+
+HELP_BINARY_IMAGE = """\
+This module can also convert a grayscale image to binary before converting it to an object.
+Connected components of the binary image are assigned to the same object. This feature is 
+useful for identifying objects that can be cleanly distinguished using **Threshold**. 
+If you wish to distinguish clumped objects, see **Watershed** or the **Identify** modules.
+
+Note that grayscale images provided as input with this setting will be converted to binary 
+images. Pixel intensities below or equal to 50% of the input's full intensity range are 
+assigned to the background (i.e., assigned the value 0). Pixel intensities above 50% of 
+the input's full intensity range are assigned to the foreground (i.e., assigned the
+value 1).
 """
+
+__doc__ = """\
 ConvertImageToObjects
 =====================
 
-**ConvertImageToObjects** converts a binary image to objects. Connected components of the binary image are assigned to
-the same object. This module is useful for identifying objects that can be cleanly distinguished using **Threshold**.
-If you wish to distinguish clumped objects, see **Watershed** or the **Identify** modules.
+**ConvertImageToObjects** converts an image to objects. This module is useful for importing
+a previously segmented or labeled image into CellProfiler, as it will preserve the labels
+of an integer-labelled input. 
 
-Note that grayscale images provided as input to this module will be converted to binary images. Pixel intensities
-below or equal to 50% of the input's full intensity range are assigned to the background (i.e., assigned the value 0).
-Pixel intensities above 50% of the input's full intensity range are assigned to the foreground (i.e., assigned the
-value 1).
+{HELP_BINARY_IMAGE}
 
 |
 
@@ -21,22 +36,49 @@ Supports 2D? Supports 3D? Respects masks?
 YES          YES          NO
 ============ ============ ===============
 
-"""
+""".format(**{
+    "HELP_BINARY_IMAGE": HELP_BINARY_IMAGE
+})
 
-import skimage
-import skimage.measure
-
-import cellprofiler.module
 
 
 class ConvertImageToObjects(cellprofiler.module.ImageSegmentation):
-    category = "Advanced"
+    category = "Object Processing"
 
     module_name = "ConvertImageToObjects"
 
     variable_revision_number = 1
 
+    def create_settings(self):
+        super(ConvertImageToObjects, self).create_settings()
+
+        self.cast_to_bool = cellprofiler.setting.Binary(
+            text="Convert to boolean image",
+            value=False,
+            doc=HELP_BINARY_IMAGE
+        )
+
+    def settings(self):
+        __settings__ = super(ConvertImageToObjects, self).settings()
+
+        return __settings__ + [
+            self.cast_to_bool
+        ]
+
+    def visible_settings(self):
+        __settings__ = super(ConvertImageToObjects, self).visible_settings()
+
+        return __settings__ + [
+            self.cast_to_bool
+        ]
+
     def run(self, workspace):
-        self.function = lambda(x_data): skimage.measure.label(skimage.img_as_bool(x_data))
+        self.function = lambda data, cast_to_bool: \
+            convert_to_objects(data, cast_to_bool)
 
         super(ConvertImageToObjects, self).run(workspace)
+
+
+def convert_to_objects(data, cast_to_bool):
+    caster = skimage.img_as_bool if cast_to_bool else skimage.img_as_uint
+    return skimage.measure.label(caster(data))

--- a/tests/modules/test_convertimagetoobjects.py
+++ b/tests/modules/test_convertimagetoobjects.py
@@ -2,6 +2,7 @@ import numpy
 import numpy.random
 import pytest
 
+import cellprofiler.image
 import cellprofiler.measurement
 import cellprofiler.modules.convertimagetoobjects
 
@@ -34,6 +35,32 @@ def binary_volume():
     return data
 
 
+@pytest.fixture
+def labeled_image():
+    # Pre-labeled, connected image
+    data = numpy.zeros((100, 100), dtype=numpy.uint8)
+
+    data[10:30, 10:30] = 1
+
+    data[40:90, 40:50] = 2
+    data[40:50, 40:90] = 3
+
+    return data
+
+
+@pytest.fixture
+def labeled_volume():
+    # Pre-labeled, connected volume
+    data = numpy.zeros((10, 100, 100), dtype=numpy.uint8)
+
+    data[2:6, 10:30, 10:30] = 1
+
+    data[4:6, 40:90, 40:50] = 2
+    data[4:6, 40:50, 40:90] = 3
+
+    return data
+
+
 def binary_to_grayscale(binary):
     data = numpy.random.randint(0, 128, binary.shape).astype(numpy.uint8)
 
@@ -45,7 +72,7 @@ def binary_to_grayscale(binary):
 
 
 @pytest.fixture(
-    scope="module",
+    scope="function",
     params=[
         binary_image(),
         binary_to_grayscale(binary_image()),
@@ -67,16 +94,50 @@ def image(request):
     return cellprofiler.image.Image(image=data, dimensions=dimensions)
 
 
-def test_run(image, module, workspace):
+def test_run_boolean(image, module, workspace):
     module.x_name.value = "example"
 
     module.y_name.value = "labeled"
+
+    module.cast_to_bool.value = True
 
     module.run(workspace)
 
     objects = workspace.object_set.get_objects("labeled")
 
     assert len(numpy.unique(objects.segmented)) == 3
+
+    measurements = workspace.measurements
+
+    assert measurements.has_current_measurements("labeled", cellprofiler.measurement.M_LOCATION_CENTER_X)
+    assert measurements.has_current_measurements("labeled", cellprofiler.measurement.M_LOCATION_CENTER_Y)
+    assert measurements.has_current_measurements("labeled", cellprofiler.measurement.M_LOCATION_CENTER_Z)
+    assert measurements.has_current_measurements("labeled", cellprofiler.measurement.M_NUMBER_OBJECT_NUMBER)
+    assert measurements.has_current_measurements(
+        cellprofiler.measurement.IMAGE,
+        cellprofiler.measurement.FF_COUNT % "labeled"
+    )
+
+
+@pytest.mark.parametrize(
+    "image",
+    [cellprofiler.image.Image(image=d, dimensions=d.ndim) for d in [labeled_image(), labeled_volume()]],
+    ids=["labeled_image", "labeled_volume"]
+)
+def test_run_labels(image, module, workspace):
+    # Ensure that pre-labeled objects retain their labels
+    # even if they are connected
+    module.x_name.value = "example"
+
+    module.y_name.value = "labeled"
+
+    module.cast_to_bool.value = False
+
+    module.run(workspace)
+
+    objects = workspace.object_set.get_objects("labeled")
+
+    assert len(numpy.unique(objects.segmented)) == 4
 
     measurements = workspace.measurements
 


### PR DESCRIPTION
If the objects from a pipeline were saved, there was no way to easily import them into a different pipeline as objects. This extends `ConvertImageToObjects` to (logically) convert an integer labeled array into objects. This conversion respects previous labels - it doesn't force to connected but separately labeled objects into a single, shared label. 