### PR TITLE
Make image saving work with 5+ channels

### DIFF
--- a/cellprofiler/modules/saveimages.py
+++ b/cellprofiler/modules/saveimages.py
@@ -632,6 +632,13 @@ store images in the subfolder, "*date*\/*plate-name*".""")
             elif self.get_bit_depth() == BIT_DEPTH_FLOAT:
                 pixels = skimage.util.img_as_float(pixels).astype(numpy.float32)
 
+            # skimage will save out color images (M,N,3) or (M,N,4) appropriately
+            # but any more than that will need to be transposed so they conform to the
+            # CYX convention rather than YXC
+            # http://scikit-image.org/docs/dev/api/skimage.io.html#skimage.io.imsave
+            if not image.volumetric and len(pixels.shape) > 2 and  pixels.shape[2] > 4:
+                pixels = numpy.transpose(pixels, (2, 0, 1))
+
             skimage.io.imsave(filename, pixels)
 
         if self.show_window:

--- a/tests/modules/test_saveimages.py
+++ b/tests/modules/test_saveimages.py
@@ -476,3 +476,38 @@ def test_save_volume_npy(tmpdir, volume, module, workspace):
     data = numpy.load(os.path.join(directory, "example_volume.npy"))
 
     numpy.testing.assert_array_equal(data, volume.pixel_data)
+
+
+@pytest.mark.parametrize(
+    "volume",
+    [cellprofiler.image.Image(image=numpy.ones((100, 100, 5)))]
+)
+def test_save_5_plus_channel_tiff_uint16(tmpdir, volume, module, workspace):
+    directory = str(tmpdir.mkdir("images"))
+
+    workspace.image_set.add("example_volume", volume)
+
+    module.save_image_or_figure.value = cellprofiler.modules.saveimages.IF_IMAGE
+
+    module.image_name.value = "example_volume"
+
+    module.file_name_method.value = cellprofiler.modules.saveimages.FN_SINGLE_NAME
+
+    module.single_file_name.value = "example_volume"
+
+    module.pathname.value = "{}|{}".format(cellprofiler.setting.ABSOLUTE_FOLDER_NAME, directory)
+
+    module.file_format.value = cellprofiler.modules.saveimages.FF_TIFF
+
+    module.bit_depth.value = cellprofiler.modules.saveimages.BIT_DEPTH_16
+
+    module.run(workspace)
+
+    assert os.path.exists(os.path.join(directory, "example_volume.tiff"))
+
+    data = skimage.io.imread(os.path.join(directory, "example_volume.tiff"))
+
+    assert data.dtype == numpy.uint16
+
+    numpy.testing.assert_array_equal(data, numpy.transpose(skimage.util.img_as_uint(volume.pixel_data), (2, 0, 1)))
+


### PR DESCRIPTION
Previously, images were being stacked as YXC for images with greater than 5 channels. Most image handlers can handle `(M, N, 3)` or `(M, N, 4)` arrays, but beyond that they assume CYX ordering. For non-volumetric images with the 3rd dimension greater than 5, this flips the ordering when saving so it gets saved appropriately.

Also with added unit tests :nerd_face: 

Resolves #3509 