### PR TITLE
PNG compression solves the storage issue

### DIFF
--- a/cellprofiler/modules/savecroppedobjects.py
+++ b/cellprofiler/modules/savecroppedobjects.py
@@ -78,8 +78,8 @@ class SaveCroppedObjects(cellprofiler.module.Module):
 
             filename = os.path.join(
                 directory,
-                "{}_{:04d}_{}.png".format(self.objects_name.value, label, int(time.time()))
-            )
+                "{}_{}.png".format(self.objects_name.value, label)
+                )
 
             skimage.io.imsave(filename, skimage.img_as_ubyte(mask))
 

--- a/cellprofiler/modules/savecroppedobjects.py
+++ b/cellprofiler/modules/savecroppedobjects.py
@@ -78,7 +78,7 @@ class SaveCroppedObjects(cellprofiler.module.Module):
 
             filename = os.path.join(
                 directory,
-                "{}_{:04d}_{}.tiff".format(self.objects_name.value, label, int(time.time()))
+                "{}_{:04d}_{}.png".format(self.objects_name.value, label, int(time.time()))
             )
 
             skimage.io.imsave(filename, skimage.img_as_ubyte(mask))

--- a/cellprofiler/modules/savecroppedobjects.py
+++ b/cellprofiler/modules/savecroppedobjects.py
@@ -8,7 +8,7 @@ SaveCroppedObjects
 the value 255. All other pixels (i.e., background pixels and pixels corresponding to other objects) are assigned the
 value 0. The dimensions of each image are the same as the original image.
 
-The filename for an exported image is formatted as "{object name}_{label index}.tiff", where *object name*
+The filename for an exported image is formatted as "{object name}_{label index}.{image_format}", where *object name*
 is the name of the exported objects, *label index* is the integer label of the object exported in the image (starting
 from 1).
 
@@ -30,6 +30,8 @@ import time
 import cellprofiler.module
 import cellprofiler.setting
 
+O_PNG = "png"
+O_TIFF = "tiff"
 
 class SaveCroppedObjects(cellprofiler.module.Module):
     category = "File Processing"
@@ -53,12 +55,12 @@ class SaveCroppedObjects(cellprofiler.module.Module):
         self.file_format = cellprofiler.setting.Choice(
             "Saved file format",
             [
-                "png",
-                "tiff"
+                O_PNG,
+                O_TIFF
             ],
-            value="tiff",
+            value=O_TIFF,
             doc="""\
-png files do not support 3D. tiff files use zlib compression level 6."""
+**%(O_PNG)** files do not support 3D. **%(O_TIFF)** files use zlib compression level 6."""
         )
 
     def display(self, workspace, figure):
@@ -86,18 +88,18 @@ png files do not support 3D. tiff files use zlib compression level 6."""
         for label in unique_labels:
             mask = labels == label
 
-            if self.file_format.value == "png":
+            if self.file_format.value == O_PNG:
                 filename = os.path.join(
                     directory,
-                    "{}_{}.png".format(self.objects_name.value, label)
+                    "{}_{}.{}".format(self.objects_name.value, label, O_PNG)
                     )
 
                 skimage.io.imsave(filename, skimage.img_as_ubyte(mask))
 
-            elif self.file_format.value == "tiff":
+            elif self.file_format.value == O_TIFF:
                 filename = os.path.join(
                     directory,
-                    "{}_{}.tiff".format(self.objects_name.value, label)
+                    "{}_{}.{}".format(self.objects_name.value, label, O_TIFF)
                     )
 
                 skimage.io.imsave(filename, skimage.img_as_ubyte(mask), compress=6)

--- a/tests/modules/test_savecroppedobjects.py
+++ b/tests/modules/test_savecroppedobjects.py
@@ -43,7 +43,7 @@ def test_run(image, module, image_set, workspace, object_set, tmpdir):
 
         mask = skimage.img_as_ubyte(mask)
 
-        filename = glob.glob(os.path.join(directory, "example_{:04d}_*.tiff".format(label)))[0]
+        filename = glob.glob(os.path.join(directory, "example_{}.tiff".format(label)))[0]
 
         numpy.testing.assert_array_equal(skimage.io.imread(filename), mask)
 
@@ -95,7 +95,7 @@ def test_create_subfolders(image, module, image_set, workspace, object_set, tmpd
 
         mask = skimage.img_as_ubyte(mask)
 
-        filename = glob.glob(os.path.join(directory, "subdirectory", "example_{:04d}_*.tiff".format(label)))[0]
+        filename = glob.glob(os.path.join(directory, "subdirectory", "example_{}.tiff".format(label)))[0]
 
         numpy.testing.assert_array_equal(skimage.io.imread(filename), mask)
 
@@ -147,6 +147,6 @@ def test_create_subfolders_from_metadata(image, module, image_set, workspace, ob
 
         mask = skimage.img_as_ubyte(mask)
 
-        filename = glob.glob(os.path.join(directory, "002", "D", "example_{:04d}_*.tiff".format(label)))[0]
+        filename = glob.glob(os.path.join(directory, "002", "D", "example_{}.tiff".format(label)))[0]
 
         numpy.testing.assert_array_equal(skimage.io.imread(filename), mask)


### PR DESCRIPTION
Re: #3544 It seems like saving masks as 8-bit PNG instead of 8-bit TIFF reduces the space required a satisfactory amount; it is a one-line fix. FWIW, I did not see a way to save a binary image with skimage, but did find an issue that alludes to this https://github.com/scikit-image/scikit-image/issues/1623.

I've been converting the TIFF images into PNG images after CellProfiler creates the crops/masks, so this would also save a step from a practical perspective.