### PR TITLE
Compress volumetric tiffs by default

### DIFF
--- a/cellprofiler/modules/saveimages.py
+++ b/cellprofiler/modules/saveimages.py
@@ -639,7 +639,12 @@ store images in the subfolder, "*date*\/*plate-name*".""")
             if not image.volumetric and len(pixels.shape) > 2 and  pixels.shape[2] > 4:
                 pixels = numpy.transpose(pixels, (2, 0, 1))
 
-            skimage.io.imsave(filename, pixels)
+            save_kwargs = {}
+
+            if image.volumetric and self.file_format.value == FF_TIFF:
+                save_kwargs.update({'compress': 6})
+
+            skimage.io.imsave(filename, pixels, **save_kwargs)
 
         if self.show_window:
             workspace.display_data.wrote_image = True


### PR DESCRIPTION
Special thanks to @derekthirstrup for mentioning this - currently CellProfiler doesn't compress volumetric images when it saves them as tiffs, which means that an image that might be less than 1MB ends up taking 75MB or so. Based on some work that @karhohs did, I think it's reasonable for us to move over to compressing tiffs by default on the reg. 