### PR TITLE
Issues/3531

### DIFF
--- a/cellprofiler/modules/resize.py
+++ b/cellprofiler/modules/resize.py
@@ -317,20 +317,24 @@ resized with the same settings as the first image."""))
         new_shape = self.resized_shape(image, workspace)
 
         order = self.spline_order()
+        # Pixel values need to be between -1, 1 in order to use  skimage resize
+        # Thus determine a factor to scale by
+        img_scale_fac = numpy.abs(image_pixels).max()
 
         if image.volumetric and image.multichannel:
             output_pixels = numpy.zeros(new_shape.astype(int), dtype=image_pixels.dtype)
 
+
             for idx in range(int(new_shape[-1])):
                 output_pixels[:, :, :, idx] = skimage.transform.resize(
-                    image_pixels[:, :, :, idx],
+                    image_pixels[:, :, :, idx]/img_scale_fac,
                     new_shape[:-1],
                     order=order,
                     mode="symmetric"
                 )
         else:
             output_pixels = skimage.transform.resize(
-                image_pixels,
+                image_pixels/img_scale_fac,
                 new_shape,
                 order=order,
                 mode="symmetric"
@@ -338,6 +342,11 @@ resized with the same settings as the first image."""))
 
         if image.multichannel and len(new_shape) > image.dimensions:
             new_shape = new_shape[:-1]
+
+        if img_scale_fac != 1:
+            # if the image intensities were scaled,
+            # scale them back in the output
+            output_pixels = output_pixels*img_scale_fac
 
         mask = skimage.transform.resize(
             image.mask,

--- a/tests/modules/test_resize.py
+++ b/tests/modules/test_resize.py
@@ -1009,3 +1009,20 @@ Resize:[module_num:2|svn_version:\'10104\'|variable_revision_number:3|show_windo
         module.run(workspace)
 
         assert workspace.image_set.get_image(OUTPUT_IMAGE_NAME).pixel_data.shape == (25, 25)
+
+    # https://github.com/CellProfiler/CellProfiler/issues/3531
+    def test_resize_float(self):
+        data = numpy.ones((10,10), dtype=numpy.float32)*2
+        out_data = numpy.ones((5,5), dtype=numpy.float32)*2
+        workspace, module = self.make_workspace(
+            data,
+            cellprofiler.modules.resize.R_BY_FACTOR,
+            cellprofiler.modules.resize.I_NEAREST_NEIGHBOR
+        )
+
+        module.resizing_factor.value = 0.5
+
+        module.run(workspace)
+
+        out_pixels = workspace.image_set.get_image(OUTPUT_IMAGE_NAME).pixel_data
+        assert numpy.all(out_pixels == out_data)

--- a/tests/modules/test_resize.py
+++ b/tests/modules/test_resize.py
@@ -1013,7 +1013,7 @@ Resize:[module_num:2|svn_version:\'10104\'|variable_revision_number:3|show_windo
     # https://github.com/CellProfiler/CellProfiler/issues/3531
     def test_resize_float(self):
         data = numpy.ones((10,10), dtype=numpy.float32)*2
-        out_data = numpy.ones((5,5), dtype=numpy.float32)*2
+        expected = numpy.ones((5,5), dtype=numpy.float32)*2
         workspace, module = self.make_workspace(
             data,
             cellprofiler.modules.resize.R_BY_FACTOR,
@@ -1024,5 +1024,5 @@ Resize:[module_num:2|svn_version:\'10104\'|variable_revision_number:3|show_windo
 
         module.run(workspace)
 
-        out_pixels = workspace.image_set.get_image(OUTPUT_IMAGE_NAME).pixel_data
-        assert numpy.all(out_pixels == out_data)
+        result = workspace.image_set.get_image(OUTPUT_IMAGE_NAME).pixel_data
+        numpy.testing.assert_allclose(result, expected)


### PR DESCRIPTION
This fixes the issue #3531 
It is addressed by rescaling the intensities to -1/1 during the function call to skimage.transform.resize, by dividing by the maximum absolute value of the image. The result is scaled back to the original values by multiplying by the same value.

A test has been added to test for this potential issue.

