### PR TITLE
h5py 2.8 fixes

### DIFF
--- a/cellprofiler/modules/filterobjects.py
+++ b/cellprofiler/modules/filterobjects.py
@@ -63,7 +63,6 @@ import numpy
 import scipy
 import scipy.ndimage
 import scipy.sparse
-import skimage.morphology
 import skimage.segmentation
 
 import cellprofiler.gui.help
@@ -881,7 +880,7 @@ value will be retained.""".format(**{
         '''
         labels = src_objects.segmented
 
-        interior_pixels = skimage.morphology.binary_erosion(numpy.ones_like(labels))
+        interior_pixels = scipy.ndimage.binary_erosion(numpy.ones_like(labels))
 
         border_pixels = numpy.logical_not(interior_pixels)
 
@@ -897,7 +896,7 @@ value will be retained.""".format(**{
             # is the border + formerly masked-out pixels.
             mask = src_objects.parent_image.mask
 
-            interior_pixels = skimage.morphology.binary_erosion(mask)
+            interior_pixels = scipy.ndimage.binary_erosion(mask)
 
             border_pixels = numpy.logical_not(interior_pixels)
 

--- a/cellprofiler/modules/measureimageareaoccupied.py
+++ b/cellprofiler/modules/measureimageareaoccupied.py
@@ -490,7 +490,7 @@ def surface_area(label_image, spacing=None, index=None):
         spacing = (1.0,) * label_image.ndim
 
     if index is None:
-        verts, faces, _, _ = skimage.measure.marching_cubes(label_image, spacing=spacing, level=0)
+        verts, faces = skimage.measure.marching_cubes_classic(label_image, spacing=spacing, level=0)
 
         return skimage.measure.mesh_surface_area(verts, faces)
 
@@ -498,6 +498,6 @@ def surface_area(label_image, spacing=None, index=None):
 
 
 def _label_surface_area(label_image, label, spacing):
-    verts, faces, _, _ = skimage.measure.marching_cubes(label_image == label, spacing=spacing, level=0)
+    verts, faces = skimage.measure.marching_cubes_classic(label_image == label, spacing=spacing, level=0)
 
     return skimage.measure.mesh_surface_area(verts, faces)

--- a/cellprofiler/modules/measureobjectsizeshape.py
+++ b/cellprofiler/modules/measureobjectsizeshape.py
@@ -485,7 +485,7 @@ module.""".format(**{
 
                 volume[labels == label] = True
 
-                verts, faces, _, _ = skimage.measure.marching_cubes(
+                verts, faces = skimage.measure.marching_cubes_classic(
                     volume,
                     spacing=objects.parent_image.spacing if objects.has_parent_image else (1.0,) * labels.ndim,
                     level=0

--- a/cellprofiler/utilities/hdf5_dict.py
+++ b/cellprofiler/utilities/hdf5_dict.py
@@ -1916,7 +1916,7 @@ class HDF5Lock:
             h5py.phil.acquire()
 
     def __exit__(self, t, v, tb):
-        if hasattr(h5py "phil"):
+        if hasattr(h5py, "phil"):
             h5py.phil.release()
         self.lock.release()
 

--- a/cellprofiler/utilities/hdf5_dict.py
+++ b/cellprofiler/utilities/hdf5_dict.py
@@ -1912,12 +1912,12 @@ class HDF5Lock:
 
     def __enter__(self):
         self.lock.acquire()
-        if hasattr(h5py.highlevel, "phil"):
-            h5py.highlevel.phil.acquire()
+        if hasattr(h5py, "phil"):
+            h5py.phil.acquire()
 
     def __exit__(self, t, v, tb):
-        if hasattr(h5py.highlevel, "phil"):
-            h5py.highlevel.phil.release()
+        if hasattr(h5py "phil"):
+            h5py.phil.release()
         self.lock.release()
 
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setuptools.setup(
         "boto3",
         "centrosome",
         "docutils",
-        "h5py",
+        "h5py<2.8.0",
         "inflect",
         "javabridge",
         "joblib",


### PR DESCRIPTION
`h5py.highlevel` will be gone by 2.9, even if it returns in 2.8, so best to yank it out.