### PR TITLE
Issue/3598

### DIFF
--- a/cellprofiler/modules/colortogray.py
+++ b/cellprofiler/modules/colortogray.py
@@ -528,14 +528,14 @@ Select the name of the output grayscale image."""))
                               setting_values[13:])
             variable_revision_number = 3
 
-        #
-        # Standardize the channel choices
-        #
-        setting_values = list(setting_values)
-        nchannels = int(setting_values[SLOT_CHANNEL_COUNT])
-        for i in range(nchannels):
-            idx = SLOT_FIXED_COUNT + SLOT_CHANNEL_CHOICE + i * SLOTS_PER_CHANNEL
-            channel_idx = self.get_channel_idx_from_choice(setting_values[idx])
-            setting_values[idx] = channel_idx+1
-
+        if variable_revision_number < 4:
+            #
+            # Standardize the channel choices
+            #
+            setting_values = list(setting_values)
+            nchannels = int(setting_values[SLOT_CHANNEL_COUNT])
+            for i in range(nchannels):
+                idx = SLOT_FIXED_COUNT + SLOT_CHANNEL_CHOICE + i * SLOTS_PER_CHANNEL
+                channel_idx = self.get_channel_idx_from_choice(setting_values[idx])
+                setting_values[idx] = channel_idx+1
         return setting_values, variable_revision_number, from_matlab

--- a/cellprofiler/modules/colortogray.py
+++ b/cellprofiler/modules/colortogray.py
@@ -219,11 +219,11 @@ Enter a name for the resulting grayscale image coming from the value.""")
             doc="""\
 *(Used only when splitting images)*
 
-This setting chooses a channel to be processed. For example, *Red: 1*
+This setting chooses a channel to be processed. For example, *1*
 is the first
 channel in a .TIF or the red channel in a traditional image file.
-*Green: 2* and *Blue: 3* are the second and third channels of a TIF or
-the green and blue channels in other formats. *Alpha: 4* is the
+*2* and *3* are the second and third channels of a TIF or
+the green and blue channels in other formats. *4* is the
 transparency channel for image formats that support transparency and is
 channel # 4 for a .TIF file. **ColorToGray** will fail to process an
 image if you select a channel that is not supported by that image, for

--- a/cellprofiler/modules/colortogray.py
+++ b/cellprofiler/modules/colortogray.py
@@ -56,6 +56,7 @@ class ColorToGray(cpm.Module):
     module_name = "ColorToGray"
     variable_revision_number = 4
     category = "Image Processing"
+    channel_names = ["Red: 1", "Green: 2", "Blue: 3", "Alpha: 4"]
 
     def create_settings(self):
         self.image_name = cps.ImageNameSubscriber(
@@ -206,7 +207,6 @@ Enter a name for the resulting grayscale image coming from the value.""")
 
         self.channel_count = cps.HiddenCount(self.channels, "Channel count")
 
-    channel_names = ["Red: 1", "Green: 2", "Blue: 3", "Alpha: 4"]
 
     def add_channel(self, can_remove=True):
         '''Add another channel to the channels list'''
@@ -214,7 +214,7 @@ Enter a name for the resulting grayscale image coming from the value.""")
         group.can_remove = can_remove
         group.append("channel_choice", cps.Integer(
             text="Channel number",
-            value=len(self.channels)+1,
+            value=len(self.channels) + 1,
             minval=1,
             doc="""\
 *(Used only when splitting images)*
@@ -349,9 +349,9 @@ Select the name of the output grayscale image."""))
         returns the zero-based index of the channel.
         '''
         if type(choice) == int:
-            return choice-1
+            return choice - 1
         else:
-            return int(re.search("[0-9]+$", choice).group())-1
+            return int(re.search("[0-9]+$", choice).group()) - 1
 
     def channels_and_image_names(self):
         """Return tuples of channel indexes and the image names for output"""
@@ -376,7 +376,7 @@ Select the name of the output grayscale image."""))
             if channel_idx < len(self.channel_names):
                 channel_name = self.channel_names[channel_idx]
             else:
-                channel_name = 'Channel: '+str(choice)
+                channel_name = 'Channel: ' + str(choice)
             result.append((channel_idx, channel.image_name.value,
                            channel_name))
         return result
@@ -459,14 +459,14 @@ Select the name of the output grayscale image."""))
         input_image = workspace.display_data.input_image
         disp_collection = workspace.display_data.disp_collection
         ndisp = len(disp_collection)
-        ncols = int(np.ceil((ndisp+1)**0.5))
-        subplots = (ncols, (ndisp/ncols)+1)
+        ncols = int(np.ceil((ndisp + 1) ** 0.5))
+        subplots = (ncols, (ndisp / ncols) + 1)
         figure.set_subplots(subplots)
         figure.subplot_imshow_color(0, 0, input_image, title="Original image")
 
         for eachplot in range(ndisp):
-             placenum = eachplot +1
-             figure.subplot_imshow(placenum%ncols, placenum/ncols, disp_collection[eachplot][0],
+             placenum = eachplot + 1
+             figure.subplot_imshow(placenum%ncols, placenum / ncols, disp_collection[eachplot][0],
                                    title="%s" % (disp_collection[eachplot][1]),
                                    colormap=matplotlib.cm.Greys_r,
                                    sharexy=figure.subplot(0, 0))
@@ -537,5 +537,5 @@ Select the name of the output grayscale image."""))
             for i in range(nchannels):
                 idx = SLOT_FIXED_COUNT + SLOT_CHANNEL_CHOICE + i * SLOTS_PER_CHANNEL
                 channel_idx = self.get_channel_idx_from_choice(setting_values[idx])
-                setting_values[idx] = channel_idx+1
+                setting_values[idx] = channel_idx + 1
         return setting_values, variable_revision_number, from_matlab

--- a/cellprofiler/modules/colortogray.py
+++ b/cellprofiler/modules/colortogray.py
@@ -538,4 +538,6 @@ Select the name of the output grayscale image."""))
                 idx = SLOT_FIXED_COUNT + SLOT_CHANNEL_CHOICE + i * SLOTS_PER_CHANNEL
                 channel_idx = self.get_channel_idx_from_choice(setting_values[idx])
                 setting_values[idx] = channel_idx + 1
+            variable_revision_number = 4
+
         return setting_values, variable_revision_number, from_matlab

--- a/cellprofiler/modules/colortogray.py
+++ b/cellprofiler/modules/colortogray.py
@@ -54,7 +54,7 @@ SLOT_CHANNEL_CHOICE = 0
 
 class ColorToGray(cpm.Module):
     module_name = "ColorToGray"
-    variable_revision_number = 3
+    variable_revision_number = 4
     category = "Image Processing"
 
     def create_settings(self):

--- a/tests/modules/test_colortogray.py
+++ b/tests/modules/test_colortogray.py
@@ -145,7 +145,7 @@ def test_01_03_combine_channels():
     divisor = numpy.sum(factors)
     expected = numpy.zeros((20, 10))
     for i, channel_index in enumerate(channel_indexes):
-        module.channels[i].channel_choice.value = module.channel_names[channel_index]
+        module.channels[i].channel_choice.value = channel_index+1
         module.channels[i].contribution.value_text = "%.10f" % factors[i]
         expected += image[:, :, channel_index] * factors[i] / divisor
 
@@ -184,7 +184,7 @@ def test_01_04_split_channels():
 
     channel_indexes = numpy.array([1, 4, 2])
     for i, channel_index in enumerate(channel_indexes):
-        module.channels[i].channel_choice.value = module.channel_names[channel_index]
+        module.channels[i].channel_choice.value = channel_index+1
         module.channels[i].image_name.value = OUTPUT_IMAGE_F % i
 
     pipeline = cellprofiler.pipeline.Pipeline()
@@ -310,9 +310,9 @@ Image name\x3A:BlueChannel3
     assert module.green_name == "OrigGreeny"
     assert module.blue_name == "OrigBluez"
     assert module.channel_count.value == 3
-    assert module.channels[0].channel_choice == module.channel_names[0]
-    assert module.channels[1].channel_choice == module.channel_names[2]
-    assert module.channels[2].channel_choice == module.channel_names[1]
+    assert module.channels[0].channel_choice.value == 1
+    assert module.channels[1].channel_choice.value == 3
+    assert module.channels[2].channel_choice.value == 2
     assert module.channels[0].contribution == 1
     assert module.channels[1].contribution == 2
     assert module.channels[2].contribution == 3

--- a/tests/modules/test_colortogray.py
+++ b/tests/modules/test_colortogray.py
@@ -319,3 +319,84 @@ Image name\x3A:BlueChannel3
     assert module.channels[0].image_name == "RedChannel1"
     assert module.channels[1].image_name == "GreenChannel2"
     assert module.channels[2].image_name == "BlueChannel3"
+
+def test_2_6_load_v3():
+    """
+    Tests a pipeline that was produced with module revision 3.
+    The channel names are named according to the schema:
+    Channel(#new_imagenumber)_(#channel_number),
+    e.g. Channel3_2 would be the image number 3 that contains channel
+    number 2.
+    Thus it can be easily checked via the new image name, if the channel
+    number is correctly parsed.
+    """
+
+    data = r"""CellProfiler Pipeline: http://www.cellprofiler.org
+Version:4
+DateRevision:315
+GitHash:
+ModuleCount:5
+HasImagePlaneDetails:False
+
+ColorToGray:[module_num:5|svn_version:\'Unknown\'|variable_revision_number:3|show_window:True|notes:\x5B\x5D|batch_state:array(\x5B\x5D, dtype=uint8)|enabled:True|wants_pause:False]
+    Select the input image:\xff\xfeD\x00N\x00A\x00
+    Conversion method:\xff\xfeS\x00p\x00l\x00i\x00t\x00
+    Image type:\xff\xfeC\x00h\x00a\x00n\x00n\x00e\x00l\x00s\x00
+    Name the output image:\xff\xfeO\x00r\x00i\x00g\x00G\x00r\x00a\x00y\x00
+    Relative weight of the red channel:\xff\xfe1\x00.\x000\x00
+    Relative weight of the green channel:\xff\xfe1\x00.\x000\x00
+    Relative weight of the blue channel:\xff\xfe1\x00.\x000\x00
+    Convert red to gray?:\xff\xfeY\x00e\x00s\x00
+    Name the output image:\xff\xfeO\x00r\x00i\x00g\x00R\x00e\x00d\x00
+    Convert green to gray?:\xff\xfeY\x00e\x00s\x00
+    Name the output image:\xff\xfeO\x00r\x00i\x00g\x00G\x00r\x00e\x00e\x00n\x00
+    Convert blue to gray?:\xff\xfeY\x00e\x00s\x00
+    Name the output image:\xff\xfeO\x00r\x00i\x00g\x00B\x00l\x00u\x00e\x00
+    Convert hue to gray?:\xff\xfeY\x00e\x00s\x00
+    Name the output image:\xff\xfeO\x00r\x00i\x00g\x00H\x00u\x00e\x00
+    Convert saturation to gray?:\xff\xfeY\x00e\x00s\x00
+    Name the output image:\xff\xfeO\x00r\x00i\x00g\x00S\x00a\x00t\x00u\x00r\x00a\x00t\x00i\x00o\x00n\x00
+    Convert value to gray?:\xff\xfeY\x00e\x00s\x00
+    Name the output image:\xff\xfeO\x00r\x00i\x00g\x00V\x00a\x00l\x00u\x00e\x00
+    Channel count:\xff\xfe8\x00
+    Channel number:\xff\xfeG\x00r\x00e\x00e\x00n\x00\x3A\x00 \x002\x00
+    Relative weight of the channel:\xff\xfe1\x00.\x000\x00
+    Image name:\xff\xfeC\x00h\x00a\x00n\x00n\x00e\x00l\x001\x00_\x002\x00
+    Channel number:\xff\xfeR\x00e\x00d\x00\x3A\x00 \x001\x00
+    Relative weight of the channel:\xff\xfe1\x00.\x000\x00
+    Image name:\xff\xfeC\x00h\x00a\x00n\x00n\x00e\x00l\x002\x00_\x001\x00
+    Channel number:\xff\xfeB\x00l\x00u\x00e\x00\x3A\x00 \x003\x00
+    Relative weight of the channel:\xff\xfe1\x00.\x000\x00
+    Image name:\xff\xfeC\x00h\x00a\x00n\x00n\x00e\x00l\x003\x00_\x003\x00
+    Channel number:\xff\xfeA\x00l\x00p\x00h\x00a\x00\x3A\x00 \x004\x00
+    Relative weight of the channel:\xff\xfe1\x00.\x000\x00
+    Image name:\xff\xfeC\x00h\x00a\x00n\x00n\x00e\x00l\x004\x00_\x004\x00
+    Channel number:\xff\xfe5\x00
+    Relative weight of the channel:\xff\xfe1\x00.\x000\x00
+    Image name:\xff\xfeC\x00h\x00a\x00n\x00n\x00e\x00l\x005\x00_\x005\x00
+    Channel number:\xff\xfe7\x00
+    Relative weight of the channel:\xff\xfe1\x00.\x000\x00
+    Image name:\xff\xfeC\x00h\x00a\x00n\x00n\x00e\x00l\x006\x00_\x007\x00
+    Channel number:\xff\xfe7\x00
+    Relative weight of the channel:\xff\xfe1\x00.\x000\x00
+    Image name:\xff\xfeC\x00h\x00a\x00n\x00n\x00e\x00l\x007\x00_\x007\x00
+    Channel number:\xff\xfe6\x00
+    Relative weight of the channel:\xff\xfe1\x00.\x000\x00
+    Image name:\xff\xfeC\x00h\x00a\x00n\x00n\x00e\x00l\x008\x00_\x006\x00
+"""
+    pipeline = cellprofiler.pipeline.Pipeline()
+
+    def callback(caller, event):
+        assert not isinstance(event, cellprofiler.pipeline.LoadExceptionEvent)
+
+    pipeline.add_listener(callback)
+    pipeline.load(StringIO(data))
+    assert len(pipeline.modules()) == 1
+    module = pipeline.modules()[0]
+    assert isinstance(module, cellprofiler.modules.colortogray.ColorToGray)
+    assert module.image_name == "DNA"
+    assert module.channel_count.value == 8
+    for i in range(module.channel_count.value):
+        c = module.channels[i].image_name.value.split('_')[1]
+        assert module.channels[i].channel_choice.value == int(c)
+    assert module.channels[6].image_name.value == 'Channel7_7'


### PR DESCRIPTION
We are dealing routinely with 30+ channel images. As discussed in the issue #3598 , it thus would sometimes be convenient to easily extract single planes to grayscale using `colortogray`. The previous solution for this solution was elegant and supported that many channels. Unfortunately in practice it is very tedious, as e.g. selecting a channel with index 20 would require the addition of 20 channels.

I thus propose to change the channel_choice widget to a `cps.Integer`. This is a little bit less verbose, the user will put in just a channel number. The hint that Channel1 often is 'Red' is thus a bit less obvious as before, when the user selected 'Red: 1'. However I would argue a user that needs to split using the 'Channel' and not the 'RGB' option, anyway often should be aware what channel number corresponds to what color. Additionally the hint that channel 1 is red would still be available in the help. Thus I find the solution of using an Integer to indicate a channel number a veritable alternative, that is more convenient if higher plane numbers should be selected.