### PR TITLE
Add "c" and "cmap" as options for subplot_scatter

### DIFF
--- a/cellprofiler/gui/figure.py
+++ b/cellprofiler/gui/figure.py
@@ -1921,6 +1921,8 @@ class Figure(wx.Frame):
                         xlabel='', ylabel='',
                         xscale='linear', yscale='linear',
                         title='',
+                        color='b',
+                        cmap=None,
                         clear=True):
         """Put a scatterplot into a subplot
 
@@ -1931,6 +1933,8 @@ class Figure(wx.Frame):
         xscale - scaling of the x axis (e.g., 'log' or 'linear')
         yscale - scaling of the y axis (e.g., 'log' or 'linear')
         title  - string title for the plot
+        color  - color, sequence, or sequence of color for the plotted points
+        cmap   - matplotlib Colormap
         """
         xvals = numpy.array(xvals).flatten()
         yvals = numpy.array(yvals).flatten()
@@ -1956,6 +1960,8 @@ class Figure(wx.Frame):
         plot = axes.scatter(xvals, yvals,
                             facecolor=(0.0, 0.62, 1.0),
                             edgecolor='none',
+                            c=color,
+                            cmap=cmap,
                             alpha=0.75)
         axes.set_title(title)
         axes.set_xlabel(xlabel)


### PR DESCRIPTION
Options taken from here: https://matplotlib.org/api/_as_gen/matplotlib.pyplot.scatter.html

This allows scatter plots to have customizable color maps and displays. For example, we have a custom module that finds two peaks within a 3D image. The previous histogram only allowed us to show the points in a single color:
![screenshot_2018-09-07_12-51-48](https://user-images.githubusercontent.com/10214785/45240372-47dbd900-b29d-11e8-9177-0090e42306ec.png)

With this change, we can now customize the color map to show the "chosen" points:
![screenshot_2018-09-07_11-31-27](https://user-images.githubusercontent.com/10214785/45240382-51654100-b29d-11e8-9f0f-2a09f1592246.png)
