### PR TITLE
Actually display Z-index on gridview

### DIFF
--- a/cellprofiler/gui/figure.py
+++ b/cellprofiler/gui/figure.py
@@ -1263,7 +1263,7 @@ class Figure(wx.Frame):
                 norm=norm
             )
 
-            ax.set_label("{:d}".format(position * (z - 1) / 8))
+            ax.set_xlabel("Z: {:d}".format(position * (z - 1) / 8))
 
             self.figure.add_subplot(ax)
 


### PR DESCRIPTION
The `set_label` call wasn't actually displaying anything useful on the gridview. I've changed this to `set_xlabel` (with a little more clarity) so the z-index is actually displayed. 

Here's before: 
![screenshot_2018-09-07_13-29-50](https://user-images.githubusercontent.com/10214785/45241730-5f699080-b2a2-11e8-97a1-ac39925dab9a.png)

And after:
![screenshot_2018-09-07_13-28-48](https://user-images.githubusercontent.com/10214785/45241738-62fd1780-b2a2-11e8-8f54-5950e73cd9ea.png)
