### PR TITLE
Bubble exit code up from headless run for proper system reporting

### DIFF
--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -57,7 +57,7 @@ def main(args=None):
         cellprofiler.preferences.set_headless()
         cellprofiler.worker.aw_parse_args()
         cellprofiler.worker.main()
-        sys.exit(exit_code)
+        return exit_code
 
     options, args = parse_args(args)
 
@@ -132,7 +132,6 @@ def main(args=None):
         if options.write_schema_and_exit:
             write_schema(options.pipeline_filename)
 
-        exit_code = 0
         if options.show_gui:
             matplotlib.use('WXAgg')
 
@@ -169,7 +168,7 @@ def main(args=None):
         if not options.show_gui:
             stop_cellprofiler()
 
-    sys.exit(exit_code)
+    return exit_code
 
 
 def __version__(exit_code):
@@ -775,4 +774,4 @@ def run_pipeline_headless(options, args):
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -132,6 +132,7 @@ def main(args=None):
         if options.write_schema_and_exit:
             write_schema(options.pipeline_filename)
 
+        exit_code = 0
         if options.show_gui:
             matplotlib.use('WXAgg')
 
@@ -160,13 +161,15 @@ def main(args=None):
 
             return
         elif options.run_pipeline:
-            run_pipeline_headless(options, args)
+            exit_code = run_pipeline_headless(options, args)
 
     finally:
         # If anything goes wrong during the startup sequence headlessly, the JVM needs
         # to be explicitly closed
         if not options.show_gui:
             stop_cellprofiler()
+
+    sys.exit(exit_code)
 
 
 def __version__(exit_code):
@@ -759,6 +762,9 @@ def run_pipeline_headless(options, args):
         fd = open(options.done_file, "wt")
         fd.write("%s\n" % done_text)
         fd.close()
+    elif not measurements.has_feature(cellprofiler.measurement.EXPERIMENT, cellprofiler.pipeline.EXIT_STATUS):
+        # The pipeline probably failed
+        exit_code = 1
     else:
         exit_code = 0
 


### PR DESCRIPTION
The error code that was returned from run_pipeline_headless was not being captured by the calling process. Additionally, an exception raised in a pipeline wasn't being caught as a failure inside the run_pipeline_headless block.

This was preventing us from capturing the exit code appropriately when cellprofiler failed on a run, since it would just emit a `0`. 