### PR TITLE
Demote the update exception from warning to debug

### DIFF
--- a/cellprofiler/utilities/check_for_updates.py
+++ b/cellprofiler/utilities/check_for_updates.py
@@ -31,7 +31,7 @@ class VersionChecker(threading.Thread):
             if new_version > self.current_version:
                 self.callback(new_version, info)
         except Exception, e:
-            logger.warning("Exception fetching new version information from %s: %s"%(self.url, e))
+            logger.debug("NON-CRITICAL: Exception fetching new version information from %s: %s"%(self.url, e))
             pass # no worries
 
 def check_for_updates(url, current_version, callback, user_agent='CellProfiler_cfu'):

--- a/cellprofiler/utilities/check_for_updates.py
+++ b/cellprofiler/utilities/check_for_updates.py
@@ -31,8 +31,7 @@ class VersionChecker(threading.Thread):
             if new_version > self.current_version:
                 self.callback(new_version, info)
         except Exception, e:
-            logger.debug("NON-CRITICAL: cannot fetch new version information from %s: %s"%(self.url, e))
-            pass # no worries
+            pass # This site is no longer maintained
 
 def check_for_updates(url, current_version, callback, user_agent='CellProfiler_cfu'):
     vc = VersionChecker(url, current_version, callback, user_agent)

--- a/cellprofiler/utilities/check_for_updates.py
+++ b/cellprofiler/utilities/check_for_updates.py
@@ -31,7 +31,7 @@ class VersionChecker(threading.Thread):
             if new_version > self.current_version:
                 self.callback(new_version, info)
         except Exception, e:
-            logger.debug("NON-CRITICAL: Exception fetching new version information from %s: %s"%(self.url, e))
+            logger.debug("NON-CRITICAL: cannot fetch new version information from %s: %s"%(self.url, e))
             pass # no worries
 
 def check_for_updates(url, current_version, callback, user_agent='CellProfiler_cfu'):


### PR DESCRIPTION
This message is often part of peoples' error messages on
GitHub/the forum, and it's a bit misleading. Since this site
is no longer maintained, we shouldn't let users know about this
error anyway.