### PR TITLE
Travis CI: Add flake8 to find syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,18 @@ notifications:
     secure: kDWVy90sDY+o3g0/ZTGX2D+PTbzhtd74Whe1AJHhcUDobTUzkch8GtY9eZxybZk4nga9lQxL6YeJ72SfBBEPaLzXcUMe0YcNaBydkQHcipKZn+Vcb8kf2FiZC6YwsUYfTvvH9MPLbkZOZvsNyd0h85z+hYMB8jHsq6Yn5gf79BA=
     on_failure: always
     on_success: change
-python: 2.7.12
+python:
+  - 2.7
+  - 3.6
+matrix:
+  allow_failures:
+    - python: 3.6
+before_script:
+  - pip install flake8
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script: pytest
 services: mysql
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
 matrix:
   allow_failures:
     - env: REQUIREMENTS_FILE="unpinned_requirements.txt"
+    - python: 3.6
 install:
   - pip install -r $REQUIREMENTS_FILE
   - pip install .[test]
@@ -30,10 +31,7 @@ notifications:
     on_success: change
 python:
   - 2.7
-  - 3.6
-matrix:
-  allow_failures:
-    - python: 3.6
+  - 3.6    
 before_script:
   - pip install flake8
   # stop the build if there are Python syntax errors or undefined names

--- a/cellprofiler/gui/imagesetctrl.py
+++ b/cellprofiler/gui/imagesetctrl.py
@@ -8,6 +8,7 @@ import cellprofiler.measurement
 import cellprofiler.modules.images
 import cellprofiler.preferences
 import cellprofiler.setting
+import cellprofiler.pipeline
 import numpy
 import re
 import urllib
@@ -296,7 +297,7 @@ class ImageSetCtrl(wx.grid.Grid, cellprofiler.gui.cornerbuttonmixin.CornerButton
             """Get the URL for a cell"""
             image_set = self.image_numbers[row]
             column = self.columns[col]
-            if column.channel_type == cpp.Pipeline.ImageSetChannelDescriptor.CT_OBJECTS:
+            if column.channel_type == cellprofiler.pipeline.Pipeline.ImageSetChannelDescriptor.CT_OBJECTS:
                 feature = cellprofiler.measurement.C_OBJECTS_URL + "_" + column.channel
             else:
                 feature = cellprofiler.measurement.C_URL + "_" + column.channel
@@ -632,19 +633,19 @@ class ImageSetCtrl(wx.grid.Grid, cellprofiler.gui.cornerbuttonmixin.CornerButton
             dlg.Title = "Change image type for %s" % (self.Table.GetColLabelValue(col))
             dlg.Sizer = wx.BoxSizer(wx.VERTICAL)
             choices = [
-                (cpp.Pipeline.ImageSetChannelDescriptor.CT_GRAYSCALE,
+                (cellprofiler.pipeline.Pipeline.ImageSetChannelDescriptor.CT_GRAYSCALE,
                  self.monochrome_channel_image,
                  "Treat the image as monochrome, averaging colors if needed"),
-                (cpp.Pipeline.ImageSetChannelDescriptor.CT_COLOR,
+                (cellprofiler.pipeline.Pipeline.ImageSetChannelDescriptor.CT_COLOR,
                  self.color_channel_image,
                  "Treat the image as color. Use ColorToGray to get individual colors"),
-                (cpp.Pipeline.ImageSetChannelDescriptor.CT_MASK,
+                (cellprofiler.pipeline.Pipeline.ImageSetChannelDescriptor.CT_MASK,
                  self.mask_image,
                  "Treat the image as a binary mask"),
-                (cpp.Pipeline.ImageSetChannelDescriptor.CT_OBJECTS,
+                (cellprofiler.pipeline.Pipeline.ImageSetChannelDescriptor.CT_OBJECTS,
                  self.objects_image,
                  "Treat the image as objects"),
-                (cpp.Pipeline.ImageSetChannelDescriptor.CT_FUNCTION,
+                (cellprofiler.pipeline.Pipeline.ImageSetChannelDescriptor.CT_FUNCTION,
                  self.illumination_function_image,
                  "Use the image for illumination correction")]
             sub_sizer = wx.BoxSizer(wx.HORIZONTAL)

--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -977,7 +977,7 @@ class PipelineController(object):
                               os.path.split(pathname)[1]
                     sizer.Add(wx.StaticText(dlg, label=message), 0, wx.EXPAND)
                     sizer.AddSpacer(4)
-                    gb_sizer = wx.BoxSizer(groupbox, wx.VERTICAL)
+                    gb_sizer = wx.BoxSizer(wx.VERTICAL)
                     sizer.Add(gb_sizer, 1, wx.EXPAND)
                     rb_primary = wx.RadioButton(dlg, label="&Primary pipeline")
                     gb_sizer.Add(rb_primary, 0, wx.ALIGN_LEFT)

--- a/cellprofiler/modules/editobjectsmanually.py
+++ b/cellprofiler/modules/editobjectsmanually.py
@@ -392,6 +392,7 @@ supplied by a previous module.
 
     def save_into_ilp(self, project_name, labels, guidename):
         import h5py
+        import wx
         with h5py.File(project_name) as f:
             g = f["DataSets"]
             for k in g:
@@ -400,7 +401,7 @@ supplied by a previous module.
                     break
             else:
                 wx.MessageBox("Sorry, could not find the file, %s, in the project, %s" %
-                              (guidname, project_name))
+                              (guidename, project_name))
             project_labels = data_item["labels"]["data"]
             mask = np.ones(project_labels.shape[2:4], project_labels.dtype)
             for label in labels:

--- a/cellprofiler/modules/filterobjects.py
+++ b/cellprofiler/modules/filterobjects.py
@@ -1024,7 +1024,11 @@ value will be retained.""".format(**{
             # Added CPA rules
             #
             setting_values = (setting_values[:11] +
-                              [MODE_MEASUREMENTS, dir_default_input, "."] +
+                              [
+                                  MODE_MEASUREMENTS, 
+                                  cellprofiler.preferences.DEFAULT_INPUT_FOLDER_NAME, 
+                                  "."
+                              ] +
                               setting_values[11:])
             variable_revision_number = 2
         if (not from_matlab) and variable_revision_number == 2:
@@ -1062,11 +1066,11 @@ value will be retained.""".format(**{
             rules_directory_choice = setting_values[7]
             rules_path_name = setting_values[8]
             if rules_directory_choice == DIR_CUSTOM:
-                rules_directory_choice == cellprofiler.preferences.ABSOLUTE_FOLDER_NAME
+                rules_directory_choice = cellprofiler.preferences.ABSOLUTE_FOLDER_NAME
                 if rules_path_name.startswith('.'):
-                    rules_directory_choice = cellprofiler.setting.DEFAULT_INPUT_SUBFOLDER_NAME
+                    rules_directory_choice = cellprofiler.preferences.DEFAULT_INPUT_SUBFOLDER_NAME
                 elif rules_path_name.startswith('&'):
-                    rules_directory_choice = cellprofiler.setting.DEFAULT_OUTPUT_SUBFOLDER_NAME
+                    rules_directory_choice = cellprofiler.preferences.DEFAULT_OUTPUT_SUBFOLDER_NAME
                     rules_path_name = "." + rules_path_name[1:]
 
             rules_directory = cellprofiler.setting.DirectoryPath.static_join_string(

--- a/cellprofiler/modules/loaddata.py
+++ b/cellprofiler/modules/loaddata.py
@@ -856,7 +856,7 @@ safe to press it.""")
                        for s in row]
                 if len(row) != len(header):
                     raise ValueError("Row # %d has the wrong number of elements: %d. Expected %d" %
-                                     (i, len(row), len(header)))
+                                     (idx, len(row), len(header)))
                 rows.append(row)
         else:
             rows = [[unicode(s, 'utf8') if isinstance(s, str) else s

--- a/cellprofiler/pipeline.py
+++ b/cellprofiler/pipeline.py
@@ -2177,7 +2177,7 @@ class Pipeline(object):
         if len(args) == 3:
             measurements, image_set_list, frame = args
             workspace = cpw.Workspace(self,
-                                      module,
+                                      None,
                                       None,
                                       None,
                                       measurements,
@@ -3083,7 +3083,6 @@ class Pipeline(object):
                 ipd = self.find_image_plane_details(exemplar)
             if ipd is not None:
                 ipd.metadata.update(m)
-                self.notify_listeners(ImagePlaneDetailsMetadataEvent(ipd))
 
         #
         # If there are planes, we create image plane descriptors for them
@@ -3119,7 +3118,6 @@ class Pipeline(object):
                         to_add.append(exemplar)
                     else:
                         ipd.metadata.update(m)
-                        self.notify_listeners(ImagePlaneDetailsMetadataEvent(ipd))
 
             elif pixels.SizeZ > 1 or pixels.SizeT > 1:
                 #
@@ -3174,7 +3172,6 @@ class Pipeline(object):
                         to_add.append(exemplar)
                     else:
                         ipd.metadata.update(metadata)
-                        self.notify_listeners(ImagePlaneDetailsMetadataEvent(ipd))
         if len(to_add) > 0:
             self.add_image_plane_details(to_add, False)
 

--- a/cellprofiler/setting.py
+++ b/cellprofiler/setting.py
@@ -750,7 +750,7 @@ class Number(Text):
         '''Programatically set the minimum value allowed'''
         self.__minval = minval
 
-    def set_max_value(self, minval):
+    def set_max_value(self, maxval):
         '''Programatically set the maximum value allowed'''
         self.__maxval = maxval
 

--- a/cellprofiler/utilities/hdf5_dict.py
+++ b/cellprofiler/utilities/hdf5_dict.py
@@ -2533,7 +2533,7 @@ class StringReferencer(object):
         j_data = self.data[i, j_data_idx:(j_data_idx + j_data_len)]
         if i0 == self.SR_NULL:
             # Splitting the root. We need to promote.
-            i0 = self.sr_alloc_block(self.blockdesc, ol, data)
+            i0 = self.sr_alloc_block()
             j0 = 0
             self.blockdesc[i0, self.SR_BLOCKDESC_LEFTMOST_CHILD] = i
         elif self.blockdesc[i0, self.SR_BLOCKDESC_IDX_LEN] == self.blocksize:

--- a/cellprofiler/utilities/zmqrequest.py
+++ b/cellprofiler/utilities/zmqrequest.py
@@ -900,20 +900,8 @@ def lock_file(path, timeout=3):
         #
         # Fall through if we believe that the other end is dead
         #
-        if sys.platform == "win32":
-            # I'm not a patient person. Python open apparently can't
-            # open hidden files - are you kidding? It's some screwed up
-            # who's on first scenario between Windows and Python "it's hidden
-            # so when I go to see if it's there, it's not but when I open it
-            # it is there!". Another 15 minutes of my life down the drain.
-            #
-            attrs = get_file_attributes(lock_path)
-            set_file_attributes(lock_path, attrs & ~ FILE_ATTRIBUTE_HIDDEN)
         with open(lock_path, "w") as f:
             f.write(the_boundary.request_address + "\n" + uid)
-        if sys.platform == "win32":
-            attrs = get_file_attributes(lock_path)
-            set_file_attributes(lock_path, attrs | FILE_ATTRIBUTE_HIDDEN)
     #
     # The coast is clear to lock
     #


### PR DESCRIPTION
Add [flake8](http://flake8.pycqa.org) tests to find Python syntax errors and undefined names.

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree