### PR TITLE
WIP: DO NOT MERGE -- flake8 across ALL repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,42 @@
-addons:
-  apt:
-    packages:
-      - libhdf5-serial-dev
-      - python-mysqldb
-      - python-pip
-cache:
-  apt: true
-  directories: $HOME/.cache/pip
-dist: trusty
-env:
-  global:
-    - LC_ALL="en_US.UTF-8" CP_MYSQL_TEST_HOST="127.0.0.1" CP_MYSQL_TEST_USER="root" CP_MYSQL_TEST_PASSWORD=""
-  matrix:
-    - REQUIREMENTS_FILE="unpinned_requirements.txt"
-    - REQUIREMENTS_FILE="requirements.txt"
+group: travis_latest
+language: python
+cache: pip
+python:
+  - 2.7
+  - 3.6
 matrix:
   allow_failures:
-    - env: REQUIREMENTS_FILE="unpinned_requirements.txt"
+    - python: 3.6
+env:
+  - REPO=CellProfiler/BatchProfiler
+  - REPO=CellProfiler/CPCharm
+  - REPO=CellProfiler/CellProfiler  # has .travis.yml file
+  - REPO=CellProfiler/CellProfiler-Analyst
+  - REPO=CellProfiler/CellProfiler-build
+  - REPO=CellProfiler/CellProfiler-plugins  # has .travis.yml file
+  - REPO=CellProfiler/Distributed-CellProfiler
+  - REPO=CellProfiler/centrosome  # has .travis.yml file
+  - REPO=CellProfiler/distribution  # has .travis.yml file
+  - REPO=CellProfiler/meoir
+  - REPO=CellProfiler/python-bioformats  # has .travis.yml file
+  - REPO=CellProfiler/stitching
+  - REPO=CellProfiler/tutorial
+    
 install:
-  - pip install -r $REQUIREMENTS_FILE
-  - pip install .[test]
-  - pip freeze
-language: python
+  #- pip install -r requirements.txt
+  - pip install flake8  # pytest  # add other testing frameworks later
+before_script:
+  - URL=https://github.com/${REPO}
+  - echo ; echo -n "flake8 testing of ${URL} on " ; python -V
+  - git clone --depth=50 ${URL} ~/${REPO}  # --branch=master
+  - cd ~/${REPO}
+script:
+  - echo stop the build if there are Python syntax errors or undefined names
+  - echo ; echo -n "flake8 testing of ${URL} on " ; python -V
+  - time flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  - echo exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - time flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  #- true  # pytest --capture=sys
 notifications:
-  email: false
-  slack:
-    secure: kDWVy90sDY+o3g0/ZTGX2D+PTbzhtd74Whe1AJHhcUDobTUzkch8GtY9eZxybZk4nga9lQxL6YeJ72SfBBEPaLzXcUMe0YcNaBydkQHcipKZn+Vcb8kf2FiZC6YwsUYfTvvH9MPLbkZOZvsNyd0h85z+hYMB8jHsq6Yn5gf79BA=
-    on_failure: always
-    on_success: change
-python: 2.7.12
-script: pytest
-services: mysql
-sudo: required
+  on_success: change
+  on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
@AetherUnbound The flake8 tests can help in the port to Python 3 but it is useful to make sure they run cleanly on Python 2 as well as Python 3.  This script runs common tests across all __CellProfiler__ Python repos.

<sub>https://travis-ci.org/CellProfiler/CellProfiler/builds/428840598?utm_source=github_status&utm_medium=notification</sub>

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree