### PR TITLE
Python 3 fixes for basestring, cmp(), reload(), unicode(), xrange()

### DIFF
--- a/cellprofiler/analysis.py
+++ b/cellprofiler/analysis.py
@@ -17,7 +17,7 @@ import uuid
 import h5py
 import numpy as np
 import zmq
-from six import string_types, text_type
+import six
 
 import cellprofiler
 import cellprofiler.image as cpimage
@@ -816,7 +816,7 @@ def find_worker_env(idx):
     if hasattr(sys, 'frozen'):
         if sys.platform == "darwin":
             # http://mail.python.org/pipermail/pythonmac-sig/2005-April/013852.html
-            added_paths += [p for p in sys.path if isinstance(p, string_types)]
+            added_paths += [p for p in sys.path if isinstance(p, six.string_types)]
     if 'PYTHONPATH' in newenv:
         added_paths.insert(0, newenv['PYTHONPATH'])
     newenv['PYTHONPATH'] = os.pathsep.join(
@@ -828,7 +828,7 @@ def find_worker_env(idx):
         newenv["CP_JDWP_PORT"] = port
         del newenv["AW_JDWP_PORT"]
     for key in newenv:
-        if isinstance(newenv[key], text_type):
+        if isinstance(newenv[key], six.text_type):
             newenv[key] = newenv[key].encode('utf-8')
     return newenv
 

--- a/cellprofiler/analysis.py
+++ b/cellprofiler/analysis.py
@@ -17,6 +17,7 @@ import uuid
 import h5py
 import numpy as np
 import zmq
+from six import string_types, text_type
 
 import cellprofiler
 import cellprofiler.image as cpimage
@@ -815,7 +816,7 @@ def find_worker_env(idx):
     if hasattr(sys, 'frozen'):
         if sys.platform == "darwin":
             # http://mail.python.org/pipermail/pythonmac-sig/2005-April/013852.html
-            added_paths += [p for p in sys.path if isinstance(p, basestring)]
+            added_paths += [p for p in sys.path if isinstance(p, string_types)]
     if 'PYTHONPATH' in newenv:
         added_paths.insert(0, newenv['PYTHONPATH'])
     newenv['PYTHONPATH'] = os.pathsep.join(
@@ -827,7 +828,7 @@ def find_worker_env(idx):
         newenv["CP_JDWP_PORT"] = port
         del newenv["AW_JDWP_PORT"]
     for key in newenv:
-        if isinstance(newenv[key], unicode):
+        if isinstance(newenv[key], text_type):
             newenv[key] = newenv[key].encode('utf-8')
     return newenv
 

--- a/cellprofiler/gui/editobjectsdlg.py
+++ b/cellprofiler/gui/editobjectsdlg.py
@@ -1802,8 +1802,8 @@ class EditObjectsDialog(wx.Dialog):
             (xmin, xmax), (ymin, ymax) = [
                 [fn(a, b) for fn in (min, max)]
                 for a, b in
-                (self.delete_mode_start[0], event.xdata),
-                (self.delete_mode_start[1], event.ydata)]
+                ((self.delete_mode_start[0], event.xdata),
+                 (self.delete_mode_start[1], event.ydata))]
             self.delete_mode_rect_artist.set_data([
                 [xmin, xmin, xmax, xmax, xmin],
                 [ymin, ymax, ymax, ymin, ymin]])

--- a/cellprofiler/gui/figure.py
+++ b/cellprofiler/gui/figure.py
@@ -33,6 +33,7 @@ import scipy.sparse
 import skimage.exposure
 import wx
 import wx.grid
+from six import string_types, text_type
 
 import cellprofiler.gui
 import cellprofiler.gui.artist
@@ -1446,7 +1447,7 @@ class Figure(wx.Frame):
             else:
                 tick_vmax = image.max()
 
-            if isinstance(colormap, basestring):
+            if isinstance(colormap, string_types):
                 colormap = matplotlib.cm.ScalarMappable(cmap=colormap)
 
             # NOTE: We bind this event each time imshow is called to a new closure
@@ -1880,7 +1881,7 @@ class Figure(wx.Frame):
         ctrl.CreateGrid(nrows, ncols)
         if col_labels is not None:
             for i, value in enumerate(col_labels):
-                ctrl.SetColLabelValue(i, unicode(value))
+                ctrl.SetColLabelValue(i, text_type(value))
         else:
             ctrl.SetColLabelSize(0)
         if row_labels is not None:
@@ -1888,7 +1889,7 @@ class Figure(wx.Frame):
             ctrl.SetRowLabelAlignment(wx.ALIGN_LEFT, wx.ALIGN_CENTER)
             max_width = 0
             for i, value in enumerate(row_labels):
-                value = unicode(value)
+                value = text_type(value)
                 ctrl.SetRowLabelValue(i, value)
                 max_width = max(
                         max_width,
@@ -1899,7 +1900,7 @@ class Figure(wx.Frame):
 
         for i, row in enumerate(statistics):
             for j, value in enumerate(row):
-                ctrl.SetCellValue(i, j, unicode(value))
+                ctrl.SetCellValue(i, j, text_type(value))
                 ctrl.SetReadOnly(i, j, True)
         ctrl.AutoSize()
         ctrl.Show()

--- a/cellprofiler/gui/figure.py
+++ b/cellprofiler/gui/figure.py
@@ -33,7 +33,7 @@ import scipy.sparse
 import skimage.exposure
 import wx
 import wx.grid
-from six import string_types, text_type
+import six
 
 import cellprofiler.gui
 import cellprofiler.gui.artist
@@ -1447,7 +1447,7 @@ class Figure(wx.Frame):
             else:
                 tick_vmax = image.max()
 
-            if isinstance(colormap, string_types):
+            if isinstance(colormap, six.string_types):
                 colormap = matplotlib.cm.ScalarMappable(cmap=colormap)
 
             # NOTE: We bind this event each time imshow is called to a new closure
@@ -1881,7 +1881,7 @@ class Figure(wx.Frame):
         ctrl.CreateGrid(nrows, ncols)
         if col_labels is not None:
             for i, value in enumerate(col_labels):
-                ctrl.SetColLabelValue(i, text_type(value))
+                ctrl.SetColLabelValue(i, six.text_type(value))
         else:
             ctrl.SetColLabelSize(0)
         if row_labels is not None:
@@ -1889,7 +1889,7 @@ class Figure(wx.Frame):
             ctrl.SetRowLabelAlignment(wx.ALIGN_LEFT, wx.ALIGN_CENTER)
             max_width = 0
             for i, value in enumerate(row_labels):
-                value = text_type(value)
+                value = six.text_type(value)
                 ctrl.SetRowLabelValue(i, value)
                 max_width = max(
                         max_width,
@@ -1900,7 +1900,7 @@ class Figure(wx.Frame):
 
         for i, row in enumerate(statistics):
             for j, value in enumerate(row):
-                ctrl.SetCellValue(i, j, text_type(value))
+                ctrl.SetCellValue(i, j, six.text_type(value))
                 ctrl.SetReadOnly(i, j, True)
         ctrl.AutoSize()
         ctrl.Show()

--- a/cellprofiler/gui/help/__init__.py
+++ b/cellprofiler/gui/help/__init__.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+from six import string_types
 
 
 def make_help_menu(h, window, menu=None):
@@ -8,7 +9,7 @@ def make_help_menu(h, window, menu=None):
         menu = wx.Menu()
     for key, value in h:
         my_id = wx.NewId()
-        if hasattr(value, "__iter__") and not isinstance(value, (str, unicode)):
+        if hasattr(value, "__iter__") and not isinstance(value, string_types):
             menu.AppendMenu(my_id, key, make_help_menu(value, window))
         else:
             def show_dialog(event, key=key, value=value):

--- a/cellprofiler/gui/help/__init__.py
+++ b/cellprofiler/gui/help/__init__.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from six import string_types
+import six
 
 
 def make_help_menu(h, window, menu=None):
@@ -9,7 +9,7 @@ def make_help_menu(h, window, menu=None):
         menu = wx.Menu()
     for key, value in h:
         my_id = wx.NewId()
-        if hasattr(value, "__iter__") and not isinstance(value, string_types):
+        if hasattr(value, "__iter__") and not isinstance(value, six.string_types):
             menu.AppendMenu(my_id, key, make_help_menu(value, window))
         else:
             def show_dialog(event, key=key, value=value):

--- a/cellprofiler/gui/imagesetctrl.py
+++ b/cellprofiler/gui/imagesetctrl.py
@@ -11,6 +11,7 @@ import cellprofiler.pipeline as cpp
 import cellprofiler.preferences
 import cellprofiler.setting
 import cellprofiler.pipeline
+import cellprofiler.utilities.legacy
 import numpy
 import re
 import urllib
@@ -20,11 +21,6 @@ import wx.grid
 import wx.lib.mixins.gridlabelrenderer
 from six import string_types, text_type
 
-try:
-    cmp             # Python 2
-except NameError:
-    def cmp(a, b):  # Python 3
-        return (a > b) - (a < b)
 
 '''Table column displays metadata'''
 COL_METADATA = "Metadata"
@@ -243,7 +239,7 @@ class ImageSetCtrl(wx.grid.Grid, cellprofiler.gui.cornerbuttonmixin.CornerButton
                 #
                 if a.is_key:
                     if b.is_key:
-                        return cmp(a.name, b.name)
+                        return cellprofiler.utilities.legacy.cmp(a.name, b.name)
                     return -1
                 elif b.is_key:
                     return 1
@@ -252,7 +248,7 @@ class ImageSetCtrl(wx.grid.Grid, cellprofiler.gui.cornerbuttonmixin.CornerButton
                 #
                 if a.column_type == COL_METADATA:
                     if b.column_type == COL_METADATA:
-                        return cmp(a.name, b.name)
+                        return cellprofiler.utilities.legacy.cmp(a.name, b.name)
                     return 1
                 elif b.column_type == COL_METADATA:
                     return -1
@@ -260,12 +256,12 @@ class ImageSetCtrl(wx.grid.Grid, cellprofiler.gui.cornerbuttonmixin.CornerButton
                 # If different channels, order by channel
                 #
                 if a.channel != b.channel:
-                    return cmp(a.channel, b.channel)
+                    return cellprofiler.utilities.legacy.cmp(a.channel, b.channel)
                 #
                 # Otherwise, the order is given by COL_ORDER
                 #
-                return cmp(COL_ORDER.index(a.column_type),
-                           COL_ORDER.index(b.column_type))
+                return cellprofiler.utilities.legacy.cmp(COL_ORDER.index(a.column_type),
+                                                         COL_ORDER.index(b.column_type))
 
             columns.sort(cmp=ordering_fn)
 

--- a/cellprofiler/gui/imagesetctrl.py
+++ b/cellprofiler/gui/imagesetctrl.py
@@ -19,7 +19,7 @@ import wx
 import wx.combo
 import wx.grid
 import wx.lib.mixins.gridlabelrenderer
-from six import string_types, text_type
+import six
 
 
 '''Table column displays metadata'''
@@ -316,7 +316,7 @@ class ImageSetCtrl(wx.grid.Grid, cellprofiler.gui.cornerbuttonmixin.CornerButton
             image_number = self.image_numbers[row]
             metadata_tags = self.metadata_tags
             if len(metadata_tags) > 0:
-                key = [text_type(self.cache[tag, image_number])
+                key = [six.text_type(self.cache[tag, image_number])
                        for tag in metadata_tags]
                 return " : ".join(key)
 
@@ -983,7 +983,7 @@ class ImageSetCtrl(wx.grid.Grid, cellprofiler.gui.cornerbuttonmixin.CornerButton
             if need_column_layout:
                 if self.Table.GetNumberRows() > 0:
                     first_width, _ = self.GridWindow.GetTextExtent(
-                            text_type(self.Table.GetValue(0, i)))
+                            six.text_type(self.Table.GetValue(0, i)))
                     first_width += self.cell_renderer.padding * 4
                     width = max(first_width, min_width)
                 else:
@@ -1006,7 +1006,7 @@ class EllipsisGridCellRenderer(wx.grid.PyGridCellRenderer):
         assert isinstance(attr, wx.grid.GridCellAttr)
         assert isinstance(rect, wx.Rect)
         assert isinstance(grid, ImageSetCtrl)
-        s = text_type(grid.Table.GetValue(row, col))
+        s = six.text_type(grid.Table.GetValue(row, col))
         old_font = dc.GetFont()
         old_brush = dc.GetBrush()
         old_pen = dc.GetPen()
@@ -1096,7 +1096,7 @@ class EllipsisGridCellRenderer(wx.grid.PyGridCellRenderer):
     def GetBestSize(self, grid, attr, dc, row, col):
         assert isinstance(dc, wx.DC)
         assert isinstance(grid, wx.grid.Grid)
-        s = text_type(grid.Table.GetValue(row, col))
+        s = six.text_type(grid.Table.GetValue(row, col))
         width, height = grid.GetGridWindow().GetTextExtent(s)
         return wx.Size(width + 2 * self.padding, height)
 
@@ -1258,7 +1258,7 @@ class ColLabelRenderer(wx.lib.mixins.gridlabelrenderer.GridLabelRenderer):
         self.renderer.DrawPushButton(window, dc, rect, flags)
         if isinstance(bitmap, wx.Bitmap):
             dc.DrawBitmap(bitmap, x, y, useMask=True)
-        elif isinstance(bitmap, string_types):
+        elif isinstance(bitmap, six.string_types):
             dc.Font = window.Font
             dc.BackgroundMode = wx.TRANSPARENT
             width, height = dc.GetTextExtent(bitmap)

--- a/cellprofiler/gui/imagesetctrl.py
+++ b/cellprofiler/gui/imagesetctrl.py
@@ -18,6 +18,13 @@ import wx
 import wx.combo
 import wx.grid
 import wx.lib.mixins.gridlabelrenderer
+from six import string_types, text_type
+
+try:
+    cmp             # Python 2
+except NameError:
+    def cmp(a, b):  # Python 3
+        return (a > b) - (a < b)
 
 '''Table column displays metadata'''
 COL_METADATA = "Metadata"
@@ -313,7 +320,7 @@ class ImageSetCtrl(wx.grid.Grid, cellprofiler.gui.cornerbuttonmixin.CornerButton
             image_number = self.image_numbers[row]
             metadata_tags = self.metadata_tags
             if len(metadata_tags) > 0:
-                key = [unicode(self.cache[tag, image_number])
+                key = [text_type(self.cache[tag, image_number])
                        for tag in metadata_tags]
                 return " : ".join(key)
 
@@ -980,7 +987,7 @@ class ImageSetCtrl(wx.grid.Grid, cellprofiler.gui.cornerbuttonmixin.CornerButton
             if need_column_layout:
                 if self.Table.GetNumberRows() > 0:
                     first_width, _ = self.GridWindow.GetTextExtent(
-                            unicode(self.Table.GetValue(0, i)))
+                            text_type(self.Table.GetValue(0, i)))
                     first_width += self.cell_renderer.padding * 4
                     width = max(first_width, min_width)
                 else:
@@ -1003,7 +1010,7 @@ class EllipsisGridCellRenderer(wx.grid.PyGridCellRenderer):
         assert isinstance(attr, wx.grid.GridCellAttr)
         assert isinstance(rect, wx.Rect)
         assert isinstance(grid, ImageSetCtrl)
-        s = unicode(grid.Table.GetValue(row, col))
+        s = text_type(grid.Table.GetValue(row, col))
         old_font = dc.GetFont()
         old_brush = dc.GetBrush()
         old_pen = dc.GetPen()
@@ -1093,7 +1100,7 @@ class EllipsisGridCellRenderer(wx.grid.PyGridCellRenderer):
     def GetBestSize(self, grid, attr, dc, row, col):
         assert isinstance(dc, wx.DC)
         assert isinstance(grid, wx.grid.Grid)
-        s = unicode(grid.Table.GetValue(row, col))
+        s = text_type(grid.Table.GetValue(row, col))
         width, height = grid.GetGridWindow().GetTextExtent(s)
         return wx.Size(width + 2 * self.padding, height)
 
@@ -1255,7 +1262,7 @@ class ColLabelRenderer(wx.lib.mixins.gridlabelrenderer.GridLabelRenderer):
         self.renderer.DrawPushButton(window, dc, rect, flags)
         if isinstance(bitmap, wx.Bitmap):
             dc.DrawBitmap(bitmap, x, y, useMask=True)
-        elif isinstance(bitmap, basestring):
+        elif isinstance(bitmap, string_types):
             dc.Font = window.Font
             dc.BackgroundMode = wx.TRANSPARENT
             width, height = dc.GetTextExtent(bitmap)

--- a/cellprofiler/gui/metadatactrl.py
+++ b/cellprofiler/gui/metadatactrl.py
@@ -7,7 +7,7 @@ import cellprofiler.preferences
 import wx
 import wx.lib.masked
 
-from six import text_type, unichr
+import six
 
 __choice_ids = []
 
@@ -128,7 +128,7 @@ class MetadataControl(wx.PyControl):
                 if value[index] in ('g', '?'):
                     state = STATE_PRE
                 else:
-                    self.__tokens.append(text_type(value[index]))
+                    self.__tokens.append(six.text_type(value[index]))
                     state = STATE_INITIAL
             elif state == STATE_PRE:
                 if value[index] != '<':
@@ -386,7 +386,7 @@ class MetadataControl(wx.PyControl):
 
     def on_char(self, event):
         self.delete_selection()
-        c = unichr(event.GetUnicodeKey())
+        c = six.unichr(event.GetUnicodeKey())
         self.__tokens.insert(self.__cursor_pos, c)
         self.move_cursor_pos(self.__cursor_pos + 1)
         self.on_token_change()

--- a/cellprofiler/gui/metadatactrl.py
+++ b/cellprofiler/gui/metadatactrl.py
@@ -7,6 +7,8 @@ import cellprofiler.preferences
 import wx
 import wx.lib.masked
 
+from six import text_type, unichr
+
 __choice_ids = []
 
 
@@ -126,7 +128,7 @@ class MetadataControl(wx.PyControl):
                 if value[index] in ('g', '?'):
                     state = STATE_PRE
                 else:
-                    self.__tokens.append(unicode(value[index]))
+                    self.__tokens.append(text_type(value[index]))
                     state = STATE_INITIAL
             elif state == STATE_PRE:
                 if value[index] != '<':

--- a/cellprofiler/gui/moduleview.py
+++ b/cellprofiler/gui/moduleview.py
@@ -13,6 +13,7 @@ import time
 import uuid
 
 import numpy
+from six import string_types, text_type
 
 import cellprofiler.gui.html.utils
 import cellprofiler.gui.htmldialog
@@ -1652,7 +1653,7 @@ class ModuleView(object):
             else:
                 style = 0
                 text = v.get_value_text()
-                if not isinstance(text, (unicode, str)):
+                if not isinstance(text, string_types):
                     text = str(text)
                 if getattr(v, "multiline_display", False):
                     style = wx.TE_MULTILINE | wx.TE_PROCESS_ENTER
@@ -1672,7 +1673,7 @@ class ModuleView(object):
             self.__module_panel.Bind(wx.EVT_TEXT, on_cell_change, control)
         elif not (v.get_value_text() == control.Value):
             text = v.get_value_text()
-            if not isinstance(text, (unicode, str)):
+            if not isinstance(text, string_types):
                 text = str(text)
             control.Value = text
         if text is not None:
@@ -2135,7 +2136,7 @@ class ModuleView(object):
     def __on_cell_change(self, event, setting, control):
         if not self.__handle_change:
             return
-        proposed_value = unicode(control.GetValue())
+        proposed_value = text_type(control.GetValue())
         self.on_value_change(setting, control, proposed_value, event,
                              EDIT_TIMEOUT_SEC * 1000)
 
@@ -2593,7 +2594,7 @@ class FilterPanelController(object):
         # Make sure following predicates are legal
         #
         for index in range(index + 1, len(sequence)):
-            if isinstance(sequence[index], basestring):
+            if isinstance(sequence[index], string_types):
                 is_good = cellprofiler.setting.Filter.LITERAL_PREDICATE in predicates
             else:
                 matches = [p for p in predicates
@@ -2748,7 +2749,7 @@ class FilterPanelController(object):
                 sizer = self.get_sizer(subaddress)
                 predicates = self.v.predicates
                 for i, token in enumerate(substructure):
-                    if isinstance(token, basestring):
+                    if isinstance(token, string_types):
                         literal_ctrl = self.make_literal(
                                 token, i, subaddress, sizer)
                         predicates = []
@@ -3243,7 +3244,7 @@ class FileCollectionDisplayController(object):
                 file_tree = self.v.file_tree
             is_filtered = False
             while True:
-                if isinstance(mp, basestring) or isinstance(mp, tuple) and len(mp) == 3:
+                if isinstance(mp, string_types) or isinstance(mp, tuple) and len(mp) == 3:
                     path.append(mp)
                     if hint != cellprofiler.setting.FileCollectionDisplay.REMOVE:
                         is_filtered = not file_tree[mp]
@@ -3259,7 +3260,7 @@ class FileCollectionDisplayController(object):
                 mp = mp_list[0]
             if hint != cellprofiler.setting.FileCollectionDisplay.REMOVE:
                 self.status_text.Label = \
-                    ("Processing " + path[-1] if isinstance(path[-1], basestring)
+                    ("Processing " + path[-1] if isinstance(path[-1], string_types)
                      else path[-2])
             self.status_text.Update()
             if not any_others:
@@ -4153,7 +4154,7 @@ class TableController(wx.grid.PyGridTableBase):
             s = self.v.data[row][col]
             if s is None:
                 s = ''
-            elif not isinstance(s, basestring):
+            elif not isinstance(s, string_types):
                 s = str(s)
             self.grid.GetGridWindow().SetToolTipString(s)
         event.Skip()
@@ -4196,7 +4197,7 @@ class TableController(wx.grid.PyGridTableBase):
     def GetValue(self, row, col):
         if self.IsEmptyCell(row, col):
             return None
-        s = unicode(self.v.data[row][col])
+        s = text_type(self.v.data[row][col])
         if len(self.column_size) <= col:
             self.column_size += [self.v.max_field_size] * (col - len(self.column_size) + 1)
         field_size = self.column_size[col]

--- a/cellprofiler/gui/moduleview.py
+++ b/cellprofiler/gui/moduleview.py
@@ -13,7 +13,7 @@ import time
 import uuid
 
 import numpy
-from six import string_types, text_type
+import six
 
 import cellprofiler.gui.html.utils
 import cellprofiler.gui.htmldialog
@@ -1653,7 +1653,7 @@ class ModuleView(object):
             else:
                 style = 0
                 text = v.get_value_text()
-                if not isinstance(text, string_types):
+                if not isinstance(text, six.string_types):
                     text = str(text)
                 if getattr(v, "multiline_display", False):
                     style = wx.TE_MULTILINE | wx.TE_PROCESS_ENTER
@@ -1673,7 +1673,7 @@ class ModuleView(object):
             self.__module_panel.Bind(wx.EVT_TEXT, on_cell_change, control)
         elif not (v.get_value_text() == control.Value):
             text = v.get_value_text()
-            if not isinstance(text, string_types):
+            if not isinstance(text, six.string_types):
                 text = str(text)
             control.Value = text
         if text is not None:
@@ -2136,7 +2136,7 @@ class ModuleView(object):
     def __on_cell_change(self, event, setting, control):
         if not self.__handle_change:
             return
-        proposed_value = text_type(control.GetValue())
+        proposed_value = six.text_type(control.GetValue())
         self.on_value_change(setting, control, proposed_value, event,
                              EDIT_TIMEOUT_SEC * 1000)
 
@@ -2594,7 +2594,7 @@ class FilterPanelController(object):
         # Make sure following predicates are legal
         #
         for index in range(index + 1, len(sequence)):
-            if isinstance(sequence[index], string_types):
+            if isinstance(sequence[index], six.string_types):
                 is_good = cellprofiler.setting.Filter.LITERAL_PREDICATE in predicates
             else:
                 matches = [p for p in predicates
@@ -2749,7 +2749,7 @@ class FilterPanelController(object):
                 sizer = self.get_sizer(subaddress)
                 predicates = self.v.predicates
                 for i, token in enumerate(substructure):
-                    if isinstance(token, string_types):
+                    if isinstance(token, six.string_types):
                         literal_ctrl = self.make_literal(
                                 token, i, subaddress, sizer)
                         predicates = []
@@ -3244,7 +3244,7 @@ class FileCollectionDisplayController(object):
                 file_tree = self.v.file_tree
             is_filtered = False
             while True:
-                if isinstance(mp, string_types) or isinstance(mp, tuple) and len(mp) == 3:
+                if isinstance(mp, six.string_types) or isinstance(mp, tuple) and len(mp) == 3:
                     path.append(mp)
                     if hint != cellprofiler.setting.FileCollectionDisplay.REMOVE:
                         is_filtered = not file_tree[mp]
@@ -3260,7 +3260,7 @@ class FileCollectionDisplayController(object):
                 mp = mp_list[0]
             if hint != cellprofiler.setting.FileCollectionDisplay.REMOVE:
                 self.status_text.Label = \
-                    ("Processing " + path[-1] if isinstance(path[-1], string_types)
+                    ("Processing " + path[-1] if isinstance(path[-1], six.string_types)
                      else path[-2])
             self.status_text.Update()
             if not any_others:
@@ -4154,7 +4154,7 @@ class TableController(wx.grid.PyGridTableBase):
             s = self.v.data[row][col]
             if s is None:
                 s = ''
-            elif not isinstance(s, string_types):
+            elif not isinstance(s, six.string_types):
                 s = str(s)
             self.grid.GetGridWindow().SetToolTipString(s)
         event.Skip()
@@ -4197,7 +4197,7 @@ class TableController(wx.grid.PyGridTableBase):
     def GetValue(self, row, col):
         if self.IsEmptyCell(row, col):
             return None
-        s = text_type(self.v.data[row][col])
+        s = six.text_type(self.v.data[row][col])
         if len(self.column_size) <= col:
             self.column_size += [self.v.max_field_size] * (col - len(self.column_size) + 1)
         field_size = self.column_size[col]

--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -52,7 +52,7 @@ import wx
 import wx.lib.buttons
 import wx.lib.mixins.listctrl
 from functools import reduce
-from six import string_types, text_type
+import six
 
 
 logger = logging.getLogger(__name__)
@@ -820,7 +820,7 @@ class PipelineController(object):
         """
         with open(path, mode="w") as fd:
             for url in self.__workspace.file_list.get_filelist():
-                if isinstance(url, text_type):
+                if isinstance(url, six.text_type):
                     url = url.encode()
                 fd.write(url + "\n")
 
@@ -1954,7 +1954,7 @@ class PipelineController(object):
                 if module.is_input_module():
                     continue
                 category = module.category
-                if isinstance(category, string_types):
+                if isinstance(category, six.string_types):
                     categories = [category, "All"]
                 else:
                     categories = list(category) + ["All"]
@@ -3218,7 +3218,7 @@ class PipelineController(object):
                     self.list_ctrl.InsertColumn(i + 1, name)
                     width = 0
                     for row in choices.values():
-                        w, h = self.list_ctrl.GetTextExtent(text_type(row[i]))
+                        w, h = self.list_ctrl.GetTextExtent(six.text_type(row[i]))
                         if w > width:
                             width = w
                     self.list_ctrl.SetColumnWidth(i + 1, width + 15)
@@ -3230,11 +3230,11 @@ class PipelineController(object):
                                             (k,
                                              [u"%06d" % v if isinstance(v, int) else
                                               u"%020.10f" % v if isinstance(v, float) else
-                                              text_type(v) for v in [k] + choices[k]]) for k in choices])
+                                              six.text_type(v) for v in [k] + choices[k]]) for k in choices])
 
                 for image_number in sorted(choices.keys()):
-                    row = [text_type(image_number)] + \
-                          [text_type(x) for x in choices[image_number]]
+                    row = [six.text_type(image_number)] + \
+                          [six.text_type(x) for x in choices[image_number]]
                     pos = self.list_ctrl.Append(row)
                     self.list_ctrl.SetItemData(pos, image_number)
                 wx.lib.mixins.listctrl.ColumnSorterMixin.__init__(self, self.list_ctrl.ColumnCount)

--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -51,6 +51,13 @@ import wx
 import wx.lib.buttons
 import wx.lib.mixins.listctrl
 from functools import reduce
+from six import string_types, text_type
+
+try:
+    cmp             # Python 2
+except NameError:
+    def cmp(a, b):  # Python 3
+        return (a > b) - (a < b)
 
 logger = logging.getLogger(__name__)
 RECENT_PIPELINE_FILE_MENU_ID = [wx.NewId() for i in range(cellprofiler.preferences.RECENT_FILE_COUNT)]
@@ -817,7 +824,7 @@ class PipelineController(object):
         """
         with open(path, mode="w") as fd:
             for url in self.__workspace.file_list.get_filelist():
-                if isinstance(url, unicode):
+                if isinstance(url, text_type):
                     url = url.encode()
                 fd.write(url + "\n")
 
@@ -1951,7 +1958,7 @@ class PipelineController(object):
                 if module.is_input_module():
                     continue
                 category = module.category
-                if isinstance(category, (str, unicode)):
+                if isinstance(category, string_types):
                     categories = [category, "All"]
                 else:
                     categories = list(category) + ["All"]
@@ -3215,7 +3222,7 @@ class PipelineController(object):
                     self.list_ctrl.InsertColumn(i + 1, name)
                     width = 0
                     for row in choices.values():
-                        w, h = self.list_ctrl.GetTextExtent(unicode(row[i]))
+                        w, h = self.list_ctrl.GetTextExtent(text_type(row[i]))
                         if w > width:
                             width = w
                     self.list_ctrl.SetColumnWidth(i + 1, width + 15)
@@ -3227,11 +3234,11 @@ class PipelineController(object):
                                             (k,
                                              [u"%06d" % v if isinstance(v, int) else
                                               u"%020.10f" % v if isinstance(v, float) else
-                                              unicode(v) for v in [k] + choices[k]]) for k in choices])
+                                              text_type(v) for v in [k] + choices[k]]) for k in choices])
 
                 for image_number in sorted(choices.keys()):
-                    row = [unicode(image_number)] + \
-                          [unicode(x) for x in choices[image_number]]
+                    row = [text_type(image_number)] + \
+                          [text_type(x) for x in choices[image_number]]
                     pos = self.list_ctrl.Append(row)
                     self.list_ctrl.SetItemData(pos, image_number)
                 wx.lib.mixins.listctrl.ColumnSorterMixin.__init__(self, self.list_ctrl.ColumnCount)

--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -29,6 +29,7 @@ import cellprofiler.preferences
 import cellprofiler.setting
 import cellprofiler.workspace
 import cellprofiler.gui.cpframe
+import cellprofiler.utilities.legacy
 import cStringIO
 import csv
 import datetime
@@ -53,11 +54,6 @@ import wx.lib.mixins.listctrl
 from functools import reduce
 from six import string_types, text_type
 
-try:
-    cmp             # Python 2
-except NameError:
-    def cmp(a, b):  # Python 3
-        return (a > b) - (a < b)
 
 logger = logging.getLogger(__name__)
 RECENT_PIPELINE_FILE_MENU_ID = [wx.NewId() for i in range(cellprofiler.preferences.RECENT_FILE_COUNT)]
@@ -3132,7 +3128,7 @@ class PipelineController(object):
 
         def feature_cmp(x, y):
             if "_" not in x or "_" not in y:
-                return cmp(x, y)
+                return cellprofiler.utilities.legacy.cmp(x, y)
             (cx, fx), (cy, fy) = [z.split("_", 1) for z in (x, y)]
             #
             # For image names, group image file, path and frame consecutively
@@ -3147,15 +3143,15 @@ class PipelineController(object):
                 if not cy_is_file_md:
                     return 1
                 elif fx != fy:
-                    return cmp(fx, fy)
+                    return cellprofiler.utilities.legacy.cmp(fx, fy)
                 else:
                     cx_priority, cy_priority = \
                         [file_md_order.index(cz) for cz in (cx, cy)]
-                    return cmp(cx_priority, cy_priority)
+                    return cellprofiler.utilities.legacy.cmp(cx_priority, cy_priority)
             elif cy_is_file_md:
                 return -1
             else:
-                return cmp(x, y)
+                return cellprofiler.utilities.legacy.cmp(x, y)
 
         m = self.__debug_measurements
         features = sorted(

--- a/cellprofiler/gui/preferencesdlg.py
+++ b/cellprofiler/gui/preferencesdlg.py
@@ -10,6 +10,7 @@ import matplotlib.cm
 import os
 import sys
 import wx
+from six import string_types
 
 DIRBROWSE = "Browse"
 FILEBROWSE = "FileBrowse"
@@ -133,7 +134,7 @@ class PreferencesDlg(wx.Dialog):
                     if dlg.ShowModal() == wx.ID_OK:
                         ctl.Value = dlg.Path
                         dlg.Destroy()
-            elif (isinstance(ui_info, basestring) and
+            elif (isinstance(ui_info, string_types) and
                       ui_info.startswith(FILEBROWSE)):
                 def on_press(event, ctl=ctl, parent=self, ui_info=ui_info):
                     dlg = wx.FileDialog(parent)

--- a/cellprofiler/gui/preferencesdlg.py
+++ b/cellprofiler/gui/preferencesdlg.py
@@ -10,7 +10,7 @@ import matplotlib.cm
 import os
 import sys
 import wx
-from six import string_types
+import six
 
 DIRBROWSE = "Browse"
 FILEBROWSE = "FileBrowse"
@@ -134,8 +134,8 @@ class PreferencesDlg(wx.Dialog):
                     if dlg.ShowModal() == wx.ID_OK:
                         ctl.Value = dlg.Path
                         dlg.Destroy()
-            elif (isinstance(ui_info, string_types) and
-                      ui_info.startswith(FILEBROWSE)):
+            elif (isinstance(ui_info, six.string_types) and
+                  ui_info.startswith(FILEBROWSE)):
                 def on_press(event, ctl=ctl, parent=self, ui_info=ui_info):
                     dlg = wx.FileDialog(parent)
                     dlg.Path = ctl.Value

--- a/cellprofiler/image.py
+++ b/cellprofiler/image.py
@@ -14,6 +14,8 @@ import zlib
 
 import numpy
 
+from six import text_type
+
 logger = logging.getLogger(__name__)
 
 
@@ -798,5 +800,5 @@ class ImageSetList(object):
 
 def make_dictionary_key(key):
     '''Make a dictionary into a stable key for another dictionary'''
-    return u", ".join([u":".join([unicode(y) for y in x])
+    return u", ".join([u":".join([text_type(y) for y in x])
                        for x in sorted(key.iteritems())])

--- a/cellprofiler/image.py
+++ b/cellprofiler/image.py
@@ -14,7 +14,7 @@ import zlib
 
 import numpy
 
-from six import text_type
+import six
 
 logger = logging.getLogger(__name__)
 
@@ -800,5 +800,5 @@ class ImageSetList(object):
 
 def make_dictionary_key(key):
     '''Make a dictionary into a stable key for another dictionary'''
-    return u", ".join([u":".join([text_type(y) for y in x])
+    return u", ".join([u":".join([six.text_type(y) for y in x])
                        for x in sorted(key.iteritems())])

--- a/cellprofiler/knime_bridge.py
+++ b/cellprofiler/knime_bridge.py
@@ -14,7 +14,7 @@ import javabridge
 import numpy as np
 import threading
 import uuid
-from six import text_type
+import six
 import zmq
 
 if not hasattr(zmq, "Frame"):
@@ -287,7 +287,7 @@ class KnimeBridgeServer(threading.Thread):
                         sf.append((feature, 0))
                     else:
                         s = data[0]
-                        if isinstance(s, text_type):
+                        if isinstance(s, six.text_type):
                             s = s.encode("utf-8")
                         else:
                             s = str(s)
@@ -523,7 +523,7 @@ class KnimeBridgeServer(threading.Thread):
         return pipeline, m, object_set
 
     def raise_pipeline_exception(self, session_id, message):
-        if isinstance(message, text_type):
+        if isinstance(message, six.text_type):
             message = message.encode("utf-8")
         else:
             message = str(message)
@@ -534,7 +534,7 @@ class KnimeBridgeServer(threading.Thread):
                  zmq.Frame(message)])
 
     def raise_cellprofiler_exception(self, session_id, message):
-        if isinstance(message, text_type):
+        if isinstance(message, six.text_type):
             message = message.encode("utf-8")
         else:
             message = str(message)

--- a/cellprofiler/knime_bridge.py
+++ b/cellprofiler/knime_bridge.py
@@ -14,6 +14,7 @@ import javabridge
 import numpy as np
 import threading
 import uuid
+from six import text_type
 import zmq
 
 if not hasattr(zmq, "Frame"):
@@ -286,7 +287,7 @@ class KnimeBridgeServer(threading.Thread):
                         sf.append((feature, 0))
                     else:
                         s = data[0]
-                        if isinstance(s, unicode):
+                        if isinstance(s, text_type):
                             s = s.encode("utf-8")
                         else:
                             s = str(s)
@@ -522,7 +523,7 @@ class KnimeBridgeServer(threading.Thread):
         return pipeline, m, object_set
 
     def raise_pipeline_exception(self, session_id, message):
-        if isinstance(message, unicode):
+        if isinstance(message, text_type):
             message = message.encode("utf-8")
         else:
             message = str(message)
@@ -533,7 +534,7 @@ class KnimeBridgeServer(threading.Thread):
                  zmq.Frame(message)])
 
     def raise_cellprofiler_exception(self, session_id, message):
-        if isinstance(message, unicode):
+        if isinstance(message, text_type):
             message = message.encode("utf-8")
         else:
             message = str(message)

--- a/cellprofiler/measurement.py
+++ b/cellprofiler/measurement.py
@@ -11,7 +11,7 @@ import numpy as np
 import re
 from scipy.io.matlab import loadmat
 from itertools import repeat
-from six import string_types, text_type
+import six
 import cellprofiler.preferences as cpprefs
 from cellprofiler.utilities.hdf5_dict import HDF5Dict, get_top_level_group
 from cellprofiler.utilities.hdf5_dict import VERSION, HDFCSV, VStringArray
@@ -517,8 +517,8 @@ class Measurements(object):
 
         Experiment measurements have one value per experiment
         """
-        if isinstance(data, string_types):
-            data = text_type(data).encode('unicode_escape')
+        if isinstance(data, six.string_types):
+            data = six.text_type(data).encode('unicode_escape')
         self.hdf5_dict.add_all(EXPERIMENT, feature_name, [data], [0])
 
     def get_group_number(self):
@@ -558,7 +558,7 @@ class Measurements(object):
         '''
         d = {}
         image_numbers = self.get_image_numbers()
-        values = [[text_type(x) for x in self.get_measurement(IMAGE, feature, image_numbers)]
+        values = [[six.text_type(x) for x in self.get_measurement(IMAGE, feature, image_numbers)]
                   for feature in features]
         for i, image_number in enumerate(image_numbers):
             key = tuple([(k, v[i]) for k, v in zip(features, values)])
@@ -921,7 +921,7 @@ class Measurements(object):
 
     @staticmethod
     def wrap_string(v):
-        if isinstance(v, string_types):
+        if isinstance(v, six.string_types):
             if getattr(v, "__class__") == str:
                 v = v.decode("utf-8")
             return v.encode('unicode_escape')
@@ -1217,7 +1217,7 @@ class Measurements(object):
         # more loosely matched.
         #
         def cast(x):
-            if isinstance(x, string_types) and x.isdigit():
+            if isinstance(x, six.string_types) and x.isdigit():
                 return int(x)
             return x
 
@@ -1318,7 +1318,7 @@ class Measurements(object):
 
         stop - stop loading when this line is reached.
         '''
-        if isinstance(fd_or_file, string_types):
+        if isinstance(fd_or_file, six.string_types):
             with open(fd_or_file, "r") as fd:
                 return self.load_image_sets(fd, start, stop)
         import csv
@@ -1365,7 +1365,7 @@ class Measurements(object):
                 self.hdf5_dict.add_all(IMAGE, feature, column, image_numbers)
 
     def write_image_sets(self, fd_or_file, start=None, stop=None):
-        if isinstance(fd_or_file, string_types):
+        if isinstance(fd_or_file, six.string_types):
             with open(fd_or_file, "w") as fd:
                 return self.write_image_sets(fd, start, stop)
 
@@ -1406,8 +1406,8 @@ class Measurements(object):
                 field = column[i]
                 if field is np.NaN or field is None:
                     field = ""
-                if isinstance(field, string_types):
-                    if isinstance(field, text_type):
+                if isinstance(field, six.string_types):
+                    if isinstance(field, six.text_type):
                         field = field.encode("utf-8")
                     field = "\"" + field.replace("\"", "\"\"") + "\""
                 else:
@@ -1517,7 +1517,7 @@ class Measurements(object):
                     full_name = \
                         remote_directory + full_name[len(local_directory):]
         url = "file:" + urllib.pathname2url(full_name)
-        if isinstance(url, text_type):
+        if isinstance(url, six.text_type):
             url = url.encode("utf-8")
         return url
 

--- a/cellprofiler/measurement.py
+++ b/cellprofiler/measurement.py
@@ -11,6 +11,7 @@ import numpy as np
 import re
 from scipy.io.matlab import loadmat
 from itertools import repeat
+from six import string_types, text_type
 import cellprofiler.preferences as cpprefs
 from cellprofiler.utilities.hdf5_dict import HDF5Dict, get_top_level_group
 from cellprofiler.utilities.hdf5_dict import VERSION, HDFCSV, VStringArray
@@ -516,8 +517,8 @@ class Measurements(object):
 
         Experiment measurements have one value per experiment
         """
-        if isinstance(data, basestring):
-            data = unicode(data).encode('unicode_escape')
+        if isinstance(data, string_types):
+            data = text_type(data).encode('unicode_escape')
         self.hdf5_dict.add_all(EXPERIMENT, feature_name, [data], [0])
 
     def get_group_number(self):
@@ -557,7 +558,7 @@ class Measurements(object):
         '''
         d = {}
         image_numbers = self.get_image_numbers()
-        values = [[unicode(x) for x in self.get_measurement(IMAGE, feature, image_numbers)]
+        values = [[text_type(x) for x in self.get_measurement(IMAGE, feature, image_numbers)]
                   for feature in features]
         for i, image_number in enumerate(image_numbers):
             key = tuple([(k, v[i]) for k, v in zip(features, values)])
@@ -920,7 +921,7 @@ class Measurements(object):
 
     @staticmethod
     def wrap_string(v):
-        if isinstance(v, basestring):
+        if isinstance(v, string_types):
             if getattr(v, "__class__") == str:
                 v = v.decode("utf-8")
             return v.encode('unicode_escape')
@@ -1216,7 +1217,7 @@ class Measurements(object):
         # more loosely matched.
         #
         def cast(x):
-            if isinstance(x, basestring) and x.isdigit():
+            if isinstance(x, string_types) and x.isdigit():
                 return int(x)
             return x
 
@@ -1317,7 +1318,7 @@ class Measurements(object):
 
         stop - stop loading when this line is reached.
         '''
-        if isinstance(fd_or_file, basestring):
+        if isinstance(fd_or_file, string_types):
             with open(fd_or_file, "r") as fd:
                 return self.load_image_sets(fd, start, stop)
         import csv
@@ -1364,7 +1365,7 @@ class Measurements(object):
                 self.hdf5_dict.add_all(IMAGE, feature, column, image_numbers)
 
     def write_image_sets(self, fd_or_file, start=None, stop=None):
-        if isinstance(fd_or_file, basestring):
+        if isinstance(fd_or_file, string_types):
             with open(fd_or_file, "w") as fd:
                 return self.write_image_sets(fd, start, stop)
 
@@ -1405,8 +1406,8 @@ class Measurements(object):
                 field = column[i]
                 if field is np.NaN or field is None:
                     field = ""
-                if isinstance(field, basestring):
-                    if isinstance(field, unicode):
+                if isinstance(field, string_types):
+                    if isinstance(field, text_type):
                         field = field.encode("utf-8")
                     field = "\"" + field.replace("\"", "\"\"") + "\""
                 else:
@@ -1516,7 +1517,7 @@ class Measurements(object):
                     full_name = \
                         remote_directory + full_name[len(local_directory):]
         url = "file:" + urllib.pathname2url(full_name)
-        if isinstance(url, unicode):
+        if isinstance(url, text_type):
             url = url.encode("utf-8")
         return url
 

--- a/cellprofiler/module.py
+++ b/cellprofiler/module.py
@@ -5,6 +5,8 @@ import docutils.core
 import numpy
 import skimage.color
 
+from six import text_type
+
 import cellprofiler.image
 import cellprofiler.measurement
 import cellprofiler.object
@@ -260,7 +262,7 @@ class Module(object):
     def save_to_handles(self, handles):
         module_idx = self.module_num - 1
         setting = handles[cpp.SETTINGS][0, 0]
-        setting[cpp.MODULE_NAMES][0, module_idx] = unicode(self.module_class())
+        setting[cpp.MODULE_NAMES][0, module_idx] = text_type(self.module_class())
         setting[cpp.MODULE_NOTES][0, module_idx] = numpy.ndarray(shape=(len(self.notes), 1), dtype='object')
         for i in range(0, len(self.notes)):
             setting[cpp.MODULE_NOTES][0, module_idx][i, 0] = self.notes[i]
@@ -270,9 +272,9 @@ class Module(object):
             if len(str(variable)) > 0:
                 setting[cpp.VARIABLE_VALUES][module_idx, i] = variable.get_unicode_value()
             if isinstance(variable, cps.NameProvider):
-                setting[cpp.VARIABLE_INFO_TYPES][module_idx, i] = unicode("%s indep" % variable.group)
+                setting[cpp.VARIABLE_INFO_TYPES][module_idx, i] = text_type("%s indep" % variable.group)
             elif isinstance(variable, cps.NameSubscriber):
-                setting[cpp.VARIABLE_INFO_TYPES][module_idx, i] = unicode(variable.group)
+                setting[cpp.VARIABLE_INFO_TYPES][module_idx, i] = text_type(variable.group)
         setting[cpp.VARIABLE_REVISION_NUMBERS][0, module_idx] = self.variable_revision_number
         setting[cpp.MODULE_REVISION_NUMBERS][0, module_idx] = 0
         setting[cpp.SHOW_WINDOW][0, module_idx] = 1 if self.show_window else 0

--- a/cellprofiler/module.py
+++ b/cellprofiler/module.py
@@ -5,7 +5,7 @@ import docutils.core
 import numpy
 import skimage.color
 
-from six import text_type
+import six
 
 import cellprofiler.image
 import cellprofiler.measurement
@@ -262,7 +262,7 @@ class Module(object):
     def save_to_handles(self, handles):
         module_idx = self.module_num - 1
         setting = handles[cpp.SETTINGS][0, 0]
-        setting[cpp.MODULE_NAMES][0, module_idx] = text_type(self.module_class())
+        setting[cpp.MODULE_NAMES][0, module_idx] = six.text_type(self.module_class())
         setting[cpp.MODULE_NOTES][0, module_idx] = numpy.ndarray(shape=(len(self.notes), 1), dtype='object')
         for i in range(0, len(self.notes)):
             setting[cpp.MODULE_NOTES][0, module_idx][i, 0] = self.notes[i]
@@ -272,9 +272,9 @@ class Module(object):
             if len(str(variable)) > 0:
                 setting[cpp.VARIABLE_VALUES][module_idx, i] = variable.get_unicode_value()
             if isinstance(variable, cps.NameProvider):
-                setting[cpp.VARIABLE_INFO_TYPES][module_idx, i] = text_type("%s indep" % variable.group)
+                setting[cpp.VARIABLE_INFO_TYPES][module_idx, i] = six.text_type("%s indep" % variable.group)
             elif isinstance(variable, cps.NameSubscriber):
-                setting[cpp.VARIABLE_INFO_TYPES][module_idx, i] = text_type(variable.group)
+                setting[cpp.VARIABLE_INFO_TYPES][module_idx, i] = six.text_type(variable.group)
         setting[cpp.VARIABLE_REVISION_NUMBERS][0, module_idx] = self.variable_revision_number
         setting[cpp.MODULE_REVISION_NUMBERS][0, module_idx] = 0
         setting[cpp.SHOW_WINDOW][0, module_idx] = 1 if self.show_window else 0

--- a/cellprofiler/modules/calculatemath.py
+++ b/cellprofiler/modules/calculatemath.py
@@ -58,7 +58,7 @@ import logging
 logger = logging.getLogger(__package__)
 
 import numpy as np
-from six import string_types
+import six
 
 import cellprofiler.module as cpm
 import cellprofiler.measurement as cpmeas
@@ -317,7 +317,7 @@ Enter the power by which you would like to raise the result.
                 # ensure that the data can be changed in-place by floating point ops
                 value = value.astype(np.float)
 
-            if isinstance(value, string_types):
+            if isinstance(value, six.string_types):
                 try:
                     value = float(value)
                 except ValueError:

--- a/cellprofiler/modules/calculatemath.py
+++ b/cellprofiler/modules/calculatemath.py
@@ -58,6 +58,7 @@ import logging
 logger = logging.getLogger(__package__)
 
 import numpy as np
+from six import string_types
 
 import cellprofiler.module as cpm
 import cellprofiler.measurement as cpmeas
@@ -316,7 +317,7 @@ Enter the power by which you would like to raise the result.
                 # ensure that the data can be changed in-place by floating point ops
                 value = value.astype(np.float)
 
-            if isinstance(value, str) or isinstance(value, unicode):
+            if isinstance(value, string_types):
                 try:
                     value = float(value)
                 except ValueError:

--- a/cellprofiler/modules/calculatestatistics.py
+++ b/cellprofiler/modules/calculatestatistics.py
@@ -155,6 +155,7 @@ from cellprofiler.preferences import standardize_default_folder_names, \
     DEFAULT_INPUT_FOLDER_NAME, DEFAULT_OUTPUT_FOLDER_NAME
 from cellprofiler.setting import YES, NO
 from functools import reduce
+from six import string_types
 
 '''# of settings aside from the dose measurements'''
 FIXED_SETTING_COUNT = 1
@@ -479,7 +480,7 @@ This setting lets you choose the folder for the output files. %(IO_FOLDER_CHOICE
         else:
             return False
         if np.isscalar(v):
-            return not (isinstance(v, (str, unicode)))
+            return not (isinstance(v, string_types))
         #
         # Make sure the measurement isn't a string or other oddity
         #

--- a/cellprofiler/modules/calculatestatistics.py
+++ b/cellprofiler/modules/calculatestatistics.py
@@ -155,7 +155,7 @@ from cellprofiler.preferences import standardize_default_folder_names, \
     DEFAULT_INPUT_FOLDER_NAME, DEFAULT_OUTPUT_FOLDER_NAME
 from cellprofiler.setting import YES, NO
 from functools import reduce
-from six import string_types
+import six
 
 '''# of settings aside from the dose measurements'''
 FIXED_SETTING_COUNT = 1
@@ -480,7 +480,7 @@ This setting lets you choose the folder for the output files. %(IO_FOLDER_CHOICE
         else:
             return False
         if np.isscalar(v):
-            return not (isinstance(v, string_types))
+            return not (isinstance(v, six.string_types))
         #
         # Make sure the measurement isn't a string or other oddity
         #

--- a/cellprofiler/modules/displayplatemap.py
+++ b/cellprofiler/modules/displayplatemap.py
@@ -38,7 +38,7 @@ See also other **Display** modules and data tools.
 
 import numpy as np
 
-from six import text_type
+import six
 
 import cellprofiler.image as cpi
 import cellprofiler.module as cpm
@@ -202,7 +202,7 @@ executed.
             m = workspace.get_measurements()
             # Get plates
             plates = map(
-                    text_type,
+                    six.text_type,
                     m.get_all_measurements(cpmeas.IMAGE, self.plate_name.value))
             # Get wells
             if self.well_format == WF_NAME:

--- a/cellprofiler/modules/displayplatemap.py
+++ b/cellprofiler/modules/displayplatemap.py
@@ -38,6 +38,8 @@ See also other **Display** modules and data tools.
 
 import numpy as np
 
+from six import text_type
+
 import cellprofiler.image as cpi
 import cellprofiler.module as cpm
 import cellprofiler.measurement as cpmeas
@@ -200,7 +202,7 @@ executed.
             m = workspace.get_measurements()
             # Get plates
             plates = map(
-                    unicode,
+                    text_type,
                     m.get_all_measurements(cpmeas.IMAGE, self.plate_name.value))
             # Get wells
             if self.well_format == WF_NAME:

--- a/cellprofiler/modules/exporttodatabase.py
+++ b/cellprofiler/modules/exporttodatabase.py
@@ -100,18 +100,13 @@ import cellprofiler.measurement
 import cellprofiler.icons
 import cellprofiler.pipeline
 import cellprofiler.modules.loadimages
+import cellprofiler.utilities.legacy
 from cellprofiler.modules import _help
 
 try:
     buffer         # Python 2
 except NameError:  # Python 3
     buffer = memoryview
-
-try:
-    cmp             # Python 2
-except NameError:
-    def cmp(a, b):  # Python 3
-        return (a > b) - (a < b)
 
 logger = logging.getLogger(__name__)
 try:
@@ -4215,12 +4210,12 @@ CP version : %d\n""" % int(re.sub(r"\.|rc\d{1}", "", cellprofiler.__version__))
                 elif y[0] == cellprofiler.measurement.IMAGE:
                     return 1
                 else:
-                    return cmp(x[0], y[0])
+                    return cellprofiler.utilities.legacy.cmp(x[0], y[0])
             if x[1] == M_NUMBER_OBJECT_NUMBER:
                 return -1
             if y[1] == M_NUMBER_OBJECT_NUMBER:
                 return 1
-            return cmp(x[1], y[1])
+            return cellprofiler.utilities.legacy.cmp(x[1], y[1])
 
         columns.sort(cmp=cmpfn)
         #

--- a/cellprofiler/modules/exporttodatabase.py
+++ b/cellprofiler/modules/exporttodatabase.py
@@ -91,7 +91,7 @@ import logging
 import numpy
 import os
 import re
-from six import string_types, text_type
+import six
 import cellprofiler
 import cellprofiler.module
 import cellprofiler.setting
@@ -2640,7 +2640,7 @@ INSERT INTO %s (name) values ('%s')""" % (
         properties = self.get_property_file_text(workspace)
         for p in properties:
             for k, v in p.properties.iteritems():
-                if isinstance(v, text_type):
+                if isinstance(v, six.text_type):
                     v = v.encode('utf-8')
                 statement = """
 INSERT INTO %s (experiment_id, object_name, field, value)
@@ -2676,7 +2676,7 @@ CREATE TABLE %s (
             value = workspace.measurements.get_experiment_measurement(ftr)
 
             if column[2].startswith(cellprofiler.measurement.COLTYPE_VARCHAR):
-                if isinstance(value, text_type):
+                if isinstance(value, six.text_type):
                     value = value.encode('utf-8')
                 if self.db_type != DB_SQLITE:
                     value = MySQLdb.escape_string(value)
@@ -3165,7 +3165,7 @@ OPTIONALLY ENCLOSED BY '"' ESCAPED BY '\\\\';
                 if isinstance(value, numpy.ndarray):
                     value = value[0]
                 if coltype.startswith(cellprofiler.measurement.COLTYPE_VARCHAR):
-                    if isinstance(value, string_types):
+                    if isinstance(value, six.string_types):
                         value = '"' + MySQLdb.escape_string(value) + '"'
                     elif value is None:
                         value = "NULL"

--- a/cellprofiler/modules/exporttodatabase.py
+++ b/cellprofiler/modules/exporttodatabase.py
@@ -91,6 +91,7 @@ import logging
 import numpy
 import os
 import re
+from six import string_types, text_type
 import cellprofiler
 import cellprofiler.module
 import cellprofiler.setting
@@ -101,6 +102,16 @@ import cellprofiler.pipeline
 import cellprofiler.modules.loadimages
 from cellprofiler.modules import _help
 
+try:
+    buffer         # Python 2
+except NameError:  # Python 3
+    buffer = memoryview
+
+try:
+    cmp             # Python 2
+except NameError:
+    def cmp(a, b):  # Python 3
+        return (a > b) - (a < b)
 
 logger = logging.getLogger(__name__)
 try:
@@ -109,7 +120,7 @@ try:
     import sqlite3
 
     HAS_MYSQL_DB = True
-except:
+except Exception:
     logger.warning("MySQL could not be loaded.", exc_info=True)
     HAS_MYSQL_DB = False
 
@@ -2634,7 +2645,7 @@ INSERT INTO %s (name) values ('%s')""" % (
         properties = self.get_property_file_text(workspace)
         for p in properties:
             for k, v in p.properties.iteritems():
-                if isinstance(v, unicode):
+                if isinstance(v, text_type):
                     v = v.encode('utf-8')
                 statement = """
 INSERT INTO %s (experiment_id, object_name, field, value)
@@ -2670,7 +2681,7 @@ CREATE TABLE %s (
             value = workspace.measurements.get_experiment_measurement(ftr)
 
             if column[2].startswith(cellprofiler.measurement.COLTYPE_VARCHAR):
-                if isinstance(value, unicode):
+                if isinstance(value, text_type):
                     value = value.encode('utf-8')
                 if self.db_type != DB_SQLITE:
                     value = MySQLdb.escape_string(value)
@@ -3159,7 +3170,7 @@ OPTIONALLY ENCLOSED BY '"' ESCAPED BY '\\\\';
                 if isinstance(value, numpy.ndarray):
                     value = value[0]
                 if coltype.startswith(cellprofiler.measurement.COLTYPE_VARCHAR):
-                    if isinstance(value, str) or isinstance(value, unicode):
+                    if isinstance(value, string_types):
                         value = '"' + MySQLdb.escape_string(value) + '"'
                     elif value is None:
                         value = "NULL"

--- a/cellprofiler/modules/exporttospreadsheet.py
+++ b/cellprofiler/modules/exporttospreadsheet.py
@@ -95,7 +95,7 @@ import numpy as np
 import os
 import sys
 
-from six import string_types, text_type
+import six
 
 import cellprofiler.module as cpm
 import cellprofiler.measurement as cpmeas
@@ -868,7 +868,7 @@ desired.
                                 v.dtype == np.uint8:
                     v = base64.b64encode(v.data)
                 else:
-                    text_type(v).encode('utf8')
+                    six.text_type(v).encode('utf8')
                 writer.writerow((feature_name, v))
         finally:
             fd.close()
@@ -923,9 +923,9 @@ desired.
                             value = m[IMAGE, feature_name, img_number]
                         if value is None:
                             row.append('')
-                        elif isinstance(value, text_type):
+                        elif isinstance(value, six.text_type):
                             row.append(value.encode('utf8'))
-                        elif isinstance(value, string_types):
+                        elif isinstance(value, six.string_types):
                             row.append(value)
                         elif isinstance(value, np.ndarray) and \
                                         value.dtype == np.uint8:

--- a/cellprofiler/modules/exporttospreadsheet.py
+++ b/cellprofiler/modules/exporttospreadsheet.py
@@ -95,6 +95,8 @@ import numpy as np
 import os
 import sys
 
+from six import string_types, text_type
+
 import cellprofiler.module as cpm
 import cellprofiler.measurement as cpmeas
 import cellprofiler.pipeline as cpp
@@ -866,7 +868,7 @@ desired.
                                 v.dtype == np.uint8:
                     v = base64.b64encode(v.data)
                 else:
-                    unicode(v).encode('utf8')
+                    text_type(v).encode('utf8')
                 writer.writerow((feature_name, v))
         finally:
             fd.close()
@@ -921,9 +923,9 @@ desired.
                             value = m[IMAGE, feature_name, img_number]
                         if value is None:
                             row.append('')
-                        elif isinstance(value, unicode):
+                        elif isinstance(value, text_type):
                             row.append(value.encode('utf8'))
-                        elif isinstance(value, basestring):
+                        elif isinstance(value, string_types):
                             row.append(value)
                         elif isinstance(value, np.ndarray) and \
                                         value.dtype == np.uint8:

--- a/cellprofiler/modules/groups.py
+++ b/cellprofiler/modules/groups.py
@@ -7,7 +7,7 @@ import logging
 logger = logging.getLogger(__name__)
 import numpy as np
 import os
-from six import text_type
+import six
 
 from cellprofiler.modules import _help
 
@@ -518,7 +518,7 @@ desired behavior.
             order = np.lexsort((group_indexes, group_numbers))
 
             for idx in order:
-                row = [text_type(x[idx]) for x in all_features]
+                row = [six.text_type(x[idx]) for x in all_features]
                 self.image_set_list.data.append(row)
 
     def get_groupings(self, workspace):

--- a/cellprofiler/modules/groups.py
+++ b/cellprofiler/modules/groups.py
@@ -7,6 +7,8 @@ import logging
 logger = logging.getLogger(__name__)
 import numpy as np
 import os
+from six import text_type
+
 from cellprofiler.modules import _help
 
 import cellprofiler.module as cpm
@@ -516,7 +518,7 @@ desired behavior.
             order = np.lexsort((group_indexes, group_numbers))
 
             for idx in order:
-                row = [unicode(x[idx]) for x in all_features]
+                row = [text_type(x[idx]) for x in all_features]
                 self.image_set_list.data.append(row)
 
     def get_groupings(self, workspace):

--- a/cellprofiler/modules/images.py
+++ b/cellprofiler/modules/images.py
@@ -3,6 +3,8 @@
 import os
 import urllib
 
+from six import text_type
+
 import _help
 import cellprofiler.gui.help.content
 import cellprofiler.icons
@@ -330,7 +332,7 @@ pass the current filter.
                 if url.startswith("s3:"):
                     url = url.replace(" ", "+")
 
-                if isinstance(url, unicode):
+                if isinstance(url, text_type):
                     ourl = env.new_string(url)
                 else:
                     ourl = env.new_string_utf(url)

--- a/cellprofiler/modules/images.py
+++ b/cellprofiler/modules/images.py
@@ -3,7 +3,7 @@
 import os
 import urllib
 
-from six import text_type
+import six
 
 import _help
 import cellprofiler.gui.help.content
@@ -332,7 +332,7 @@ pass the current filter.
                 if url.startswith("s3:"):
                     url = url.replace(" ", "+")
 
-                if isinstance(url, text_type):
+                if isinstance(url, six.text_type):
                     ourl = env.new_string(url)
                 else:
                     ourl = env.new_string_utf(url)

--- a/cellprofiler/modules/loaddata.py
+++ b/cellprofiler/modules/loaddata.py
@@ -18,6 +18,7 @@ import cellprofiler.preferences
 import cellprofiler.setting
 from cellprofiler.modules import identify, loadimages
 from functools import reduce
+from six import string_types, text_type
 
 logger = logging.getLogger(__name__)
 try:
@@ -643,7 +644,7 @@ safe to press it.""")
             output = []
             for h in header:
                 if not h.startswith('file_'):
-                    if isinstance(h, unicode):
+                    if isinstance(h, text_type):
                         output.append(h.encode("utf-8"))
                     else:
                         output.append(h)
@@ -1519,7 +1520,7 @@ def best_cast(sequence, coltype=None):
     Try casting all elements to integer and float, returning a numpy
     array of values. If all fail, return a numpy array of strings.
     '''
-    if (isinstance(coltype, (str, unicode)) and
+    if (isinstance(coltype, string_types) and
             coltype.startswith(cellprofiler.measurement.COLTYPE_VARCHAR)):
         # Cast columns already defined as strings as same
         return numpy.array(sequence)

--- a/cellprofiler/modules/loaddata.py
+++ b/cellprofiler/modules/loaddata.py
@@ -18,7 +18,7 @@ import cellprofiler.preferences
 import cellprofiler.setting
 from cellprofiler.modules import identify, loadimages
 from functools import reduce
-from six import string_types, text_type
+import six
 
 logger = logging.getLogger(__name__)
 try:
@@ -644,7 +644,7 @@ safe to press it.""")
             output = []
             for h in header:
                 if not h.startswith('file_'):
-                    if isinstance(h, text_type):
+                    if isinstance(h, six.text_type):
                         output.append(h.encode("utf-8"))
                     else:
                         output.append(h)
@@ -1520,7 +1520,7 @@ def best_cast(sequence, coltype=None):
     Try casting all elements to integer and float, returning a numpy
     array of values. If all fail, return a numpy array of strings.
     '''
-    if (isinstance(coltype, string_types) and
+    if (isinstance(coltype, six.string_types) and
             coltype.startswith(cellprofiler.measurement.COLTYPE_VARCHAR)):
         # Cast columns already defined as strings as same
         return numpy.array(sequence)

--- a/cellprofiler/modules/loaddata.py
+++ b/cellprofiler/modules/loaddata.py
@@ -759,7 +759,7 @@ safe to press it.""")
         for i, field in enumerate(header):
             list_ctl.InsertColumn(i, field)
         for line in reader:
-            list_ctl.Append([unicode(s, 'utf8') if isinstance(s, str) else s
+            list_ctl.Append([s.encode('utf8') if isinstance(s, str) else s
                              for s in line[:len(header)]])
         frame.SetMinSize((640, 480))
         frame.SetIcon(get_cp_icon())
@@ -854,14 +854,14 @@ safe to press it.""")
                     break
                 if len(row) == 0:
                     continue
-                row = [unicode(s, 'utf8') if isinstance(s, str) else s
+                row = [s.encode('utf8') if isinstance(s, str) else s
                        for s in row]
                 if len(row) != len(header):
                     raise ValueError("Row # %d has the wrong number of elements: %d. Expected %d" %
                                      (idx, len(row), len(header)))
                 rows.append(row)
         else:
-            rows = [[unicode(s, 'utf8') if isinstance(s, str) else s
+            rows = [[s.encode('utf8') if isinstance(s, str) else s
                      for s in row] for row in reader
                     if len(row) > 0]
         fd.close()
@@ -1100,7 +1100,7 @@ safe to press it.""")
                             fullname = loadimages.url2pathname(url)
                             fullname = fn_alter_path(fullname)
                             path, filename = os.path.split(fullname)
-                            url = unicode(loadimages.pathname2url(fullname), "utf-8")
+                            url = str(loadimages.pathname2url(fullname)).encode("utf-8")
                             m.add_measurement(cellprofiler.measurement.IMAGE, url_feature, url,
                                               image_set_number=image_number)
                             if file_feature is not None:

--- a/cellprofiler/modules/loadimages.py
+++ b/cellprofiler/modules/loadimages.py
@@ -77,6 +77,8 @@ import urllib
 import urlparse
 import shutil
 
+from six import text_type
+
 from cellprofiler.modules import _help
 import cellprofiler.image
 import cellprofiler.measurement
@@ -3732,7 +3734,7 @@ def is_file_url(url):
 
 
 def url2pathname(url):
-    if isinstance(url, unicode):
+    if isinstance(url, text_type):
         url = url.encode("utf-8")
     if any([url.lower().startswith(x) for x in PASSTHROUGH_SCHEMES]):
         return url

--- a/cellprofiler/modules/loadimages.py
+++ b/cellprofiler/modules/loadimages.py
@@ -3740,7 +3740,7 @@ def url2pathname(url):
         return url
     assert is_file_url(url)
     utf8_url = urllib.url2pathname(url[len(FILE_SCHEME):])
-    return unicode(utf8_url, 'utf-8')
+    return utf8_url.encode('utf-8')
 
 
 def urlfilename(url):

--- a/cellprofiler/modules/loadimages.py
+++ b/cellprofiler/modules/loadimages.py
@@ -77,7 +77,7 @@ import urllib
 import urlparse
 import shutil
 
-from six import text_type
+import six
 
 from cellprofiler.modules import _help
 import cellprofiler.image
@@ -3734,7 +3734,7 @@ def is_file_url(url):
 
 
 def url2pathname(url):
-    if isinstance(url, text_type):
+    if isinstance(url, six.text_type):
         url = url.encode("utf-8")
     if any([url.lower().startswith(x) for x in PASSTHROUGH_SCHEMES]):
         return url

--- a/cellprofiler/modules/mergeoutputfiles.py
+++ b/cellprofiler/modules/mergeoutputfiles.py
@@ -69,6 +69,12 @@ import cellprofiler.measurement as cpmeas
 import cellprofiler.pipeline as cpp
 from cellprofiler.preferences import get_headless
 
+try:
+    cmp             # Python 2
+except NameError:
+    def cmp(a, b):  # Python 3
+        return (a > b) - (a < b)
+
 
 class MergeOutputFiles(cpm.Module):
     module_name = "MergeOutputFiles"

--- a/cellprofiler/modules/mergeoutputfiles.py
+++ b/cellprofiler/modules/mergeoutputfiles.py
@@ -67,13 +67,8 @@ import numpy as np
 import cellprofiler.module as cpm
 import cellprofiler.measurement as cpmeas
 import cellprofiler.pipeline as cpp
+import cellprofiler.utilities.legacy
 from cellprofiler.preferences import get_headless
-
-try:
-    cmp             # Python 2
-except NameError:
-    def cmp(a, b):  # Python 3
-        return (a > b) - (a < b)
 
 
 class MergeOutputFiles(cpm.Module):
@@ -314,7 +309,7 @@ class MergeOutputFiles(cpm.Module):
         '''
 
         def sortfn(item1, item2):
-            return cmp(order[item1], order[item2])
+            return cellprofiler.utilities.legacy.cmp(order[item1], order[item2])
 
         list_ctrl.SortItems(sortfn)
 

--- a/cellprofiler/modules/metadata.py
+++ b/cellprofiler/modules/metadata.py
@@ -7,6 +7,9 @@ import urllib
 
 import javabridge
 
+from six import string_types, text_type
+from six.moves import xrange
+
 from cellprofiler.modules import _help
 import cellprofiler.gui.help
 import cellprofiler.measurement
@@ -915,7 +918,7 @@ not being applied, your choice on this setting may be the culprit.
             if url.startswith("s3:"):
                 url = url.replace(" ", "+")
 
-            if isinstance(url, unicode):
+            if isinstance(url, text_type):
                 ourl = env.new_string(url)
             else:
                 ourl = env.new_string_utf(url)
@@ -1214,7 +1217,7 @@ not being applied, your choice on this setting may be the culprit.
 
     def get_data_type(self, key):
         '''Get the data type for a particular metadata key'''
-        if isinstance(key, basestring):
+        if isinstance(key, string_types):
             return self.get_data_type([key]).get(key, cellprofiler.measurement.COLTYPE_VARCHAR)
         result = {}
         if self.data_type_choice == DTC_CHOOSE:

--- a/cellprofiler/modules/metadata.py
+++ b/cellprofiler/modules/metadata.py
@@ -7,8 +7,8 @@ import urllib
 
 import javabridge
 
-from six import string_types, text_type
-from six.moves import xrange
+import six
+import six.moves
 
 from cellprofiler.modules import _help
 import cellprofiler.gui.help
@@ -918,7 +918,7 @@ not being applied, your choice on this setting may be the culprit.
             if url.startswith("s3:"):
                 url = url.replace(" ", "+")
 
-            if isinstance(url, text_type):
+            if isinstance(url, six.text_type):
                 ourl = env.new_string(url)
             else:
                 ourl = env.new_string_utf(url)
@@ -1217,7 +1217,7 @@ not being applied, your choice on this setting may be the culprit.
 
     def get_data_type(self, key):
         '''Get the data type for a particular metadata key'''
-        if isinstance(key, string_types):
+        if isinstance(key, six.string_types):
             return self.get_data_type([key]).get(key, cellprofiler.measurement.COLTYPE_VARCHAR)
         result = {}
         if self.data_type_choice == DTC_CHOOSE:
@@ -1334,7 +1334,7 @@ not being applied, your choice on this setting may be the culprit.
             # Allow metadata CSVs to be loaded from default io directories.
             groups = []
             n_groups = int(setting_values[3])
-            for group_idx in xrange(n_groups):
+            for group_idx in six.moves.xrange(n_groups):
                 # group offset: 4
                 # no. group settings: 9
                 group = setting_values[4 + (group_idx * 9):4 + ((group_idx + 1) * 9)]

--- a/cellprofiler/modules/namesandtypes.py
+++ b/cellprofiler/modules/namesandtypes.py
@@ -18,6 +18,7 @@ import cellprofiler.preferences
 import cellprofiler.setting
 import javabridge
 import skimage.color
+from six.moves import xrange
 from cellprofiler.modules import _help, identify, images, loadimages
 
 logger = logging.getLogger(__name__)

--- a/cellprofiler/modules/straightenworms.py
+++ b/cellprofiler/modules/straightenworms.py
@@ -115,6 +115,12 @@ from .untangleworms import F_LENGTH, ATTR_WORM_MEASUREMENTS
 from .untangleworms import read_params
 from .untangleworms import recalculate_single_worm_control_points
 
+try:
+    cmp             # Python 2
+except NameError:
+    def cmp(a, b):  # Python 3
+        return (a > b) - (a < b)
+
 FTR_MEAN_INTENSITY = "MeanIntensity"
 FTR_STD_INTENSITY = "StdIntensity"
 

--- a/cellprofiler/modules/straightenworms.py
+++ b/cellprofiler/modules/straightenworms.py
@@ -102,6 +102,7 @@ import cellprofiler.measurement as cpmeas
 import cellprofiler.object as cpo
 import cellprofiler.preferences as cpprefs
 import cellprofiler.setting as cps
+import cellprofiler.utilities.legacy
 from cellprofiler.modules._help import IO_FOLDER_CHOICE_HELP_TEXT
 from cellprofiler.setting import YES, NO
 import itertools
@@ -115,11 +116,6 @@ from .untangleworms import F_LENGTH, ATTR_WORM_MEASUREMENTS
 from .untangleworms import read_params
 from .untangleworms import recalculate_single_worm_control_points
 
-try:
-    cmp             # Python 2
-except NameError:
-    def cmp(a, b):  # Python 3
-        return (a > b) - (a < b)
 
 FTR_MEAN_INTENSITY = "MeanIntensity"
 FTR_STD_INTENSITY = "StdIntensity"
@@ -410,7 +406,7 @@ of the straightened worms.'''))
                 '''Sort by control point number'''
                 acp = int(a.split("_")[-1])
                 bcp = int(b.split("_")[-1])
-                return cmp(acp, bcp)
+                return cellprofiler.utilities.legacy.cmp(acp, bcp)
 
             cpx.sort(sort_fn)
             cpy.sort(sort_fn)

--- a/cellprofiler/pipeline.py
+++ b/cellprofiler/pipeline.py
@@ -35,8 +35,8 @@ import urllib
 import urllib2
 import re
 import numpy
-from six import string_types, text_type
-from six.moves import reload_module, xrange
+import six
+import six.moves
 
 logger = logging.getLogger(__name__)
 pipeline_stats_logger = logging.getLogger("PipelineStatistics")
@@ -428,7 +428,7 @@ def read_file_list(file_or_fd):
     "file:///imaging/analysis/singleplane.tif",,,
     """
 
-    if isinstance(file_or_fd, string_types):
+    if isinstance(file_or_fd, six.string_types):
         needs_close = True
         fd = open(file_or_fd, "r")
     else:
@@ -468,7 +468,7 @@ def write_file_list(file_or_fd, file_list):
     file_list - collection of URLs to be output
 
     '''
-    if isinstance(file_or_fd, string_types):
+    if isinstance(file_or_fd, six.string_types):
         fd = open(file_or_fd, "w")
         needs_close = True
     else:
@@ -480,7 +480,7 @@ def write_file_list(file_or_fd, file_list):
             len(file_list)))
         fd.write('"' + '","'.join([H_URL, H_SERIES, H_INDEX, H_CHANNEL]) + '"\n')
         for url in file_list:
-            if isinstance(url, text_type):
+            if isinstance(url, six.text_type):
                 url = url.encode("utf-8")
             url = url.encode("string_escape").replace('"', r'\"')
             line = "\"%s\",,,\n" % url
@@ -677,7 +677,7 @@ class Pipeline(object):
         """
         # clear previously seen errors on reload
         import cellprofiler.modules
-        reload_module(cellprofiler.modules)
+        six.moves.reload_module(cellprofiler.modules)
         cellprofiler.modules.reload_modules()
         # attempt to reinstantiate pipeline with new modules
         try:
@@ -983,7 +983,7 @@ class Pipeline(object):
         new_modules = []
         module_number = 1
         skip_attributes = ['svn_version', 'module_num']
-        for i in xrange(module_count):
+        for i in six.moves.xrange(module_count):
             line = rl()
             if line is None:
                 break
@@ -1197,7 +1197,7 @@ class Pipeline(object):
                                   attribute_string))
             for setting in module.settings():
                 setting_text = setting.text
-                if isinstance(setting_text, text_type):
+                if isinstance(setting_text, six.text_type):
                     # setting_text = setting_text.encode('utf-16')
                     setting_text = setting_text.encode('utf-8')
                 else:
@@ -2613,7 +2613,7 @@ class Pipeline(object):
 
         path - a path to a file or a URL
         '''
-        if isinstance(path_or_fd, string_types):
+        if isinstance(path_or_fd, six.string_types):
             from cellprofiler.modules.loadimages import \
                 url2pathname, FILE_SCHEME, PASSTHROUGH_SCHEMES
             pathname = path_or_fd
@@ -2658,7 +2658,7 @@ class Pipeline(object):
         returns an object that represents the state of the first instance
         of the named module or None if not in pipeline
         '''
-        if isinstance(module_name_or_module, string_types):
+        if isinstance(module_name_or_module, six.string_types):
             modules = [module for module in self.modules()
                        if module.module_name == module_name_or_module]
             if len(modules) == 0:
@@ -3928,14 +3928,14 @@ def encapsulate_strings_in_arrays(handles):
         # cells - descend recursively
         flat = handles.flat
         for i in range(0, len(flat)):
-            if isinstance(flat[i], string_types):
+            if isinstance(flat[i], six.string_types):
                 flat[i] = encapsulate_string(flat[i])
             elif isinstance(flat[i], numpy.ndarray):
                 encapsulate_strings_in_arrays(flat[i])
     elif handles.dtype.fields:
         # A structure: iterate over all structure elements.
         for field in handles.dtype.fields.keys():
-            if isinstance(handles[field], string_types):
+            if isinstance(handles[field], six.string_types):
                 handles[field] = encapsulate_string(handles[field])
             elif isinstance(handles[field], numpy.ndarray):
                 encapsulate_strings_in_arrays(handles[field])

--- a/cellprofiler/pipeline.py
+++ b/cellprofiler/pipeline.py
@@ -38,12 +38,6 @@ import numpy
 from six import string_types, text_type
 from six.moves import reload_module, xrange
 
-try:
-    cmp             # Python 2
-except NameError:
-    def cmp(a, b):  # Python 3
-        return (a > b) - (a < b)
-
 logger = logging.getLogger(__name__)
 pipeline_stats_logger = logging.getLogger("PipelineStatistics")
 import cellprofiler
@@ -54,6 +48,7 @@ import cellprofiler.object as cpo
 import cellprofiler.workspace as cpw
 import cellprofiler.setting as cps
 import cellprofiler.utilities.utf16encode
+import cellprofiler.utilities.legacy
 from bioformats.omexml import OMEXML
 from bioformats.formatreader import clear_image_reader_cache
 import javabridge as J
@@ -253,7 +248,7 @@ def map_feature_names(feature_names, max_size=63):
     seeded = False
 
     def shortest_first(a, b):
-        return -1 if len(a) < len(b) else 1 if len(b) < len(a) else cmp(a, b)
+        return -1 if len(a) < len(b) else 1 if len(b) < len(a) else cellprofiler.utilities.legacy.cmp(a, b)
 
     for feature_name in sorted(feature_names, shortest_first):
         if len(feature_name) > max_size:
@@ -3488,7 +3483,7 @@ def find_image_plane_details(exemplar, ipds):
     '''
     pos = bisect.bisect_left(ipds, exemplar)
     if (pos == len(ipds) or
-            cmp(ipds[pos], exemplar)):
+            cellprofiler.utilities.legacy.cmp(ipds[pos], exemplar)):
         return None
     return ipds[pos]
 

--- a/cellprofiler/pipeline.py
+++ b/cellprofiler/pipeline.py
@@ -35,6 +35,14 @@ import urllib
 import urllib2
 import re
 import numpy
+from six import string_types, text_type
+from six.moves import reload_module, xrange
+
+try:
+    cmp             # Python 2
+except NameError:
+    def cmp(a, b):  # Python 3
+        return (a > b) - (a < b)
 
 logger = logging.getLogger(__name__)
 pipeline_stats_logger = logging.getLogger("PipelineStatistics")
@@ -425,7 +433,7 @@ def read_file_list(file_or_fd):
     "file:///imaging/analysis/singleplane.tif",,,
     """
 
-    if isinstance(file_or_fd, basestring):
+    if isinstance(file_or_fd, string_types):
         needs_close = True
         fd = open(file_or_fd, "r")
     else:
@@ -465,7 +473,7 @@ def write_file_list(file_or_fd, file_list):
     file_list - collection of URLs to be output
 
     '''
-    if isinstance(file_or_fd, basestring):
+    if isinstance(file_or_fd, string_types):
         fd = open(file_or_fd, "w")
         needs_close = True
     else:
@@ -477,7 +485,7 @@ def write_file_list(file_or_fd, file_list):
             len(file_list)))
         fd.write('"' + '","'.join([H_URL, H_SERIES, H_INDEX, H_CHANNEL]) + '"\n')
         for url in file_list:
-            if isinstance(url, unicode):
+            if isinstance(url, text_type):
                 url = url.encode("utf-8")
             url = url.encode("string_escape").replace('"', r'\"')
             line = "\"%s\",,,\n" % url
@@ -674,7 +682,7 @@ class Pipeline(object):
         """
         # clear previously seen errors on reload
         import cellprofiler.modules
-        reload(cellprofiler.modules)
+        reload_module(cellprofiler.modules)
         cellprofiler.modules.reload_modules()
         # attempt to reinstantiate pipeline with new modules
         try:
@@ -1194,7 +1202,7 @@ class Pipeline(object):
                                   attribute_string))
             for setting in module.settings():
                 setting_text = setting.text
-                if isinstance(setting_text, unicode):
+                if isinstance(setting_text, text_type):
                     # setting_text = setting_text.encode('utf-16')
                     setting_text = setting_text.encode('utf-8')
                 else:
@@ -2610,7 +2618,7 @@ class Pipeline(object):
 
         path - a path to a file or a URL
         '''
-        if isinstance(path_or_fd, basestring):
+        if isinstance(path_or_fd, string_types):
             from cellprofiler.modules.loadimages import \
                 url2pathname, FILE_SCHEME, PASSTHROUGH_SCHEMES
             pathname = path_or_fd
@@ -2655,7 +2663,7 @@ class Pipeline(object):
         returns an object that represents the state of the first instance
         of the named module or None if not in pipeline
         '''
-        if isinstance(module_name_or_module, basestring):
+        if isinstance(module_name_or_module, string_types):
             modules = [module for module in self.modules()
                        if module.module_name == module_name_or_module]
             if len(modules) == 0:
@@ -3925,14 +3933,14 @@ def encapsulate_strings_in_arrays(handles):
         # cells - descend recursively
         flat = handles.flat
         for i in range(0, len(flat)):
-            if isinstance(flat[i], str) or isinstance(flat[i], unicode):
+            if isinstance(flat[i], string_types):
                 flat[i] = encapsulate_string(flat[i])
             elif isinstance(flat[i], numpy.ndarray):
                 encapsulate_strings_in_arrays(flat[i])
     elif handles.dtype.fields:
         # A structure: iterate over all structure elements.
         for field in handles.dtype.fields.keys():
-            if isinstance(handles[field], str) or isinstance(handles[field], unicode):
+            if isinstance(handles[field], string_types):
                 handles[field] = encapsulate_string(handles[field])
             elif isinstance(handles[field], numpy.ndarray):
                 encapsulate_strings_in_arrays(handles[field])

--- a/cellprofiler/setting.py
+++ b/cellprofiler/setting.py
@@ -22,14 +22,10 @@ from cellprofiler.preferences import \
     get_default_image_directory, get_default_output_directory, \
     standardize_default_folder_names
 import cellprofiler.measurement
+import cellprofiler.utilities.legacy
 
 import skimage.morphology
 
-try:
-    cmp             # Python 2
-except NameError:
-    def cmp(a, b):  # Python 3
-        return (a > b) - (a < b)
 
 '''Matlab CellProfiler uses this string for settings to be excluded'''
 DO_NOT_USE = 'Do not use'
@@ -3537,7 +3533,7 @@ class Table(Setting):
 
         def compare_fn(row1, row2):
             for index in indices:
-                x = cmp(row1[index], row2[index])
+                x = cellprofiler.utilities.legacy.cmp(row1[index], row2[index])
                 if x != 0:
                     return x
             return 0
@@ -3848,7 +3844,7 @@ class NumberConnector(object):
         return float(self.__fn())
 
     def __cmp__(self, other):
-        return cmp(self.__fn(), other)
+        return cellprofiler.utilities.legacy.cmp(self.__fn(), other)
 
     def __hash__(self):
         return self.__fn().__hash__()

--- a/cellprofiler/setting.py
+++ b/cellprofiler/setting.py
@@ -13,7 +13,7 @@ import sys
 import re
 import uuid
 
-from six import string_types, text_type
+import six
 
 from cellprofiler.preferences import \
     DEFAULT_INPUT_FOLDER_NAME, DEFAULT_OUTPUT_FOLDER_NAME, \
@@ -153,7 +153,7 @@ class Setting(object):
         override this to do things like compare whether an integer
         setting's value matches a given number
         '''
-        return self.value == text_type(x)
+        return self.value == six.text_type(x)
 
     def __ne__(self, x):
         return not self.__eq__(x)
@@ -193,7 +193,7 @@ class Setting(object):
 
         NOTE: strings are deprecated, use unicode_value instead.
         '''
-        if isinstance(self.__value, text_type):
+        if isinstance(self.__value, six.text_type):
             return str(self.__value.encode('utf-16'))
         if not isinstance(self.__value, str):
             raise ValidationError("%s was not a string" % self.__value, self)
@@ -204,7 +204,7 @@ class Setting(object):
         return self.get_unicode_value()
 
     def get_unicode_value(self):
-        return text_type(self.value_text)
+        return six.text_type(self.value_text)
 
 
 class HiddenCount(Setting):
@@ -240,7 +240,7 @@ class HiddenCount(Setting):
         return str(len(self.__sequence))
 
     def get_unicode_value(self):
-        return text_type(len(self.__sequence))
+        return six.text_type(len(self.__sequence))
 
 
 class Text(Setting):
@@ -706,7 +706,7 @@ class Number(Text):
 
     def __init__(self, text, value=0, minval=None, maxval=None, *args,
                  **kwargs):
-        if isinstance(value, string_types):
+        if isinstance(value, six.string_types):
             text_value = value
             value = self.str_to_value(value)
         else:
@@ -734,7 +734,7 @@ class Number(Text):
     def set_value(self, value):
         """Convert integer to string
         """
-        str_value = text_type(value) if isinstance(value, string_types) \
+        str_value = six.text_type(value) if isinstance(value, six.string_types) \
             else self.value_to_str(value)
         self.set_value_text(str_value)
 
@@ -854,7 +854,7 @@ class Range(Setting):
 
     def set_value(self, value):
         '''Set the value of this range using either a string or a two-tuple'''
-        if isinstance(value, string_types):
+        if isinstance(value, six.string_types):
             self.set_value_text(value)
         elif hasattr(value, "__getitem__") and len(value) == 2:
             self.set_value_text(",".join([self.value_to_str(v) for v in value]))
@@ -1604,7 +1604,7 @@ class Binary(Setting):
 
     def set_value(self, value):
         """When setting, translate true and false into yes and no"""
-        if value in (YES, NO) or isinstance(value, string_types):
+        if value in (YES, NO) or isinstance(value, six.string_types):
             super(Binary, self).set_value(value)
         else:
             str_value = (value and YES) or NO
@@ -1793,7 +1793,7 @@ class MultiChoice(Setting):
     def parse_value(self, value):
         if value is None:
             return ''
-        elif isinstance(value, string_types):
+        elif isinstance(value, six.string_types):
             return value
         elif hasattr(value, "__getitem__"):
             return ','.join(value)
@@ -3058,8 +3058,8 @@ class Filter(Setting):
         for element in structure:
             if isinstance(element, Filter.FilterPredicate):
                 s.append(
-                        cls.FilterPredicate.encode_symbol(text_type(element.symbol)))
-            elif isinstance(element, string_types):
+                        cls.FilterPredicate.encode_symbol(six.text_type(element.symbol)))
+            elif isinstance(element, six.string_types):
                 s.append(u'"' + cls.encode_literal(element) + u'"')
             else:
                 s.append(u"(" + cls.build_string(element) + ")")
@@ -3260,7 +3260,7 @@ class FileCollectionDisplay(Setting):
         or 3-tuples representing image planes within an image file. Branches
         are two-tuples composed of a path part and more branches / leaves
         '''
-        return len(mod) != 2 or not isinstance(mod[0], string_types)
+        return len(mod) != 2 or not isinstance(mod[0], six.string_types)
 
     def node_count(self, file_tree=None):
         '''Count the # of nodes (leaves + directories) in the tree'''

--- a/cellprofiler/utilities/hdf5_dict.py
+++ b/cellprofiler/utilities/hdf5_dict.py
@@ -17,7 +17,7 @@ import uuid
 
 import h5py
 import numpy as np
-from six import string_types, text_type
+import six
 
 import cellprofiler.utilities.legacy
 
@@ -374,8 +374,8 @@ class HDF5Dict(object):
 
     def __getitem__(self, idxs):
         assert isinstance(idxs, tuple), "Accessing HDF5_Dict requires a tuple of (object_name, feature_name[, integer])"
-        assert (isinstance(idxs[0], string_types) and
-                isinstance(idxs[1], string_types)), "First two indices must be of type str."
+        assert (isinstance(idxs[0], six.string_types) and
+                isinstance(idxs[1], six.string_types)), "First two indices must be of type str."
 
         object_name, feature_name, num_idx = idxs
         if np.isscalar(num_idx):
@@ -484,8 +484,8 @@ class HDF5Dict(object):
     def __setitem__(self, idxs, vals):
         assert isinstance(idxs, tuple), \
             "Assigning to HDF5_Dict requires a tuple of (object_name, feature_name, integer)"
-        assert (isinstance(idxs[0], string_types) and
-                isinstance(idxs[1], string_types)), "First two indices must be of type str."
+        assert (isinstance(idxs[0], six.string_types) and
+                isinstance(idxs[1], six.string_types)), "First two indices must be of type str."
         assert (not np.isscalar(idxs[2]) or self.__is_positive_int(idxs[2])), \
             "Third index must be a non-negative integer"
 
@@ -632,8 +632,8 @@ class HDF5Dict(object):
 
     def __delitem__(self, idxs):
         assert isinstance(idxs, tuple), "Accessing HDF5_Dict requires a tuple of (object_name, feature_name, integer)"
-        assert (isinstance(idxs[0], string_types) and
-                isinstance(idxs[1], string_types)), "First two indices must be of type str."
+        assert (isinstance(idxs[0], six.string_types) and
+                isinstance(idxs[1], six.string_types)), "First two indices must be of type str."
         if len(idxs) == 3:
             assert isinstance(idxs[2], int) and idxs[2] >= 0, "Third index must be a non-negative integer"
 
@@ -1049,7 +1049,7 @@ class HDF5FileList(object):
 
         returns a two tuple of schema + path part sequence
         '''
-        if isinstance(url, text_type):
+        if isinstance(url, six.text_type):
             url = url.encode("utf-8")
         else:
             url = str(url)
@@ -2010,7 +2010,7 @@ class VStringArray(object):
                 self.index[idx, :] = (self.VS_NULL, 0)
                 return
 
-            elif isinstance(value, text_type):
+            elif isinstance(value, six.text_type):
                 value = value.encode("utf8")
             else:
                 value = str(value)
@@ -2081,7 +2081,7 @@ class VStringArray(object):
         '''Store the strings passed, overwriting any previously stored data'''
         nulls = np.array([s is None for s in strings])
         strings = ["" if s is None
-                   else s.encode("utf-8") if isinstance(s, text_type)
+                   else s.encode("utf-8") if isinstance(s, six.text_type)
         else str(s) for s in strings]
         with self.lock:
             target_len = len(strings)
@@ -2184,7 +2184,7 @@ class VStringArray(object):
             return
         nulls = np.array([s is None for s in strings])
         strings = ["" if s is None
-                   else s.encode("utf-8") if isinstance(s, text_type)
+                   else s.encode("utf-8") if isinstance(s, six.text_type)
         else str(s) for s in strings]
         with self.lock:
             old_len = len(self)
@@ -2219,7 +2219,7 @@ class VStringArray(object):
         '''Return the insertion point for s, assuming the array is sorted'''
         if s is None:
             return 0
-        elif isinstance(s, text_type):
+        elif isinstance(s, six.text_type):
             s = s.encode("utf-8")
         else:
             s = str(s)
@@ -2423,7 +2423,7 @@ class StringReferencer(object):
     @staticmethod
     def string_to_uint8(s):
         '''Convert a utf-8 encoded string to a np.uint8 array'''
-        if isinstance(s, text_type):
+        if isinstance(s, six.text_type):
             s = s.encode('utf-8')
         elif not isinstance(s, str):
             s = str(s)

--- a/cellprofiler/utilities/hdf5_dict.py
+++ b/cellprofiler/utilities/hdf5_dict.py
@@ -12,7 +12,6 @@ import sys
 import tempfile
 import threading
 import time
-import urllib2
 import uuid
 
 import h5py
@@ -20,6 +19,11 @@ import numpy as np
 import six
 
 import cellprofiler.utilities.legacy
+
+from future.standard_library import install_aliases
+install_aliases()
+import urllib.parse
+
 
 try:
     buffer         # Python 2
@@ -1053,7 +1057,7 @@ class HDF5FileList(object):
             url = url.encode("utf-8")
         else:
             url = str(url)
-        schema, rest = urllib2.splittype(url)
+        schema, rest = urllib.parse.splittype(url)
         if schema is not None and schema.lower() == "omero":
             return schema, [rest]
         #

--- a/cellprofiler/utilities/hdf5_dict.py
+++ b/cellprofiler/utilities/hdf5_dict.py
@@ -19,16 +19,12 @@ import h5py
 import numpy as np
 from six import string_types, text_type
 
+import cellprofiler.utilities.legacy
+
 try:
     buffer         # Python 2
 except NameError:  # Python 3
     buffer = memoryview
-
-try:
-    cmp             # Python 2
-except NameError:
-    def cmp(a, b):  # Python 3
-        return (a > b) - (a < b)
 
 logger = logging.getLogger(__name__)
 
@@ -1107,7 +1103,7 @@ class HDF5FileList(object):
                         dest.extend(to_add)
                         sort_order = sorted(
                                 range(len(leaves)),
-                                cmp=lambda x, y: cmp(leaves[x], leaves[y]))
+                                cmp=lambda x, y: cellprofiler.utilities.legacy.cmp(leaves[x], leaves[y]))
                         dest.reorder(sort_order)
                         metadata.extend([None] * len(to_add))
                         metadata.reorder(sort_order)
@@ -2137,8 +2133,8 @@ class VStringArray(object):
                     dj = self.data[(j0 + idx):(j0 + idx_end)]
                     diff = np.argwhere(di != dj).flatten()
                     if len(diff) > 0:
-                        return cmp(di[diff[0]], dj[diff[0]])
-                return cmp(li, lj)
+                        return cellprofiler.utilities.legacy.cmp(di[diff[0]], dj[diff[0]])
+                return cellprofiler.utilities.legacy.cmp(li, lj)
 
             order = list(range(len(self)))
             order.sort(cmp=compare)

--- a/cellprofiler/utilities/hdf5_dict.py
+++ b/cellprofiler/utilities/hdf5_dict.py
@@ -17,6 +17,18 @@ import uuid
 
 import h5py
 import numpy as np
+from six import string_types, text_type
+
+try:
+    buffer         # Python 2
+except NameError:  # Python 3
+    buffer = memoryview
+
+try:
+    cmp             # Python 2
+except NameError:
+    def cmp(a, b):  # Python 3
+        return (a > b) - (a < b)
 
 logger = logging.getLogger(__name__)
 
@@ -366,8 +378,8 @@ class HDF5Dict(object):
 
     def __getitem__(self, idxs):
         assert isinstance(idxs, tuple), "Accessing HDF5_Dict requires a tuple of (object_name, feature_name[, integer])"
-        assert isinstance(idxs[0], basestring) and isinstance(idxs[1],
-                                                              basestring), "First two indices must be of type str."
+        assert (isinstance(idxs[0], string_types) and
+                isinstance(idxs[1], string_types)), "First two indices must be of type str."
 
         object_name, feature_name, num_idx = idxs
         if np.isscalar(num_idx):
@@ -476,8 +488,8 @@ class HDF5Dict(object):
     def __setitem__(self, idxs, vals):
         assert isinstance(idxs, tuple), \
             "Assigning to HDF5_Dict requires a tuple of (object_name, feature_name, integer)"
-        assert isinstance(idxs[0], basestring) and isinstance(idxs[1], basestring), \
-            "First two indices must be of type str."
+        assert (isinstance(idxs[0], string_types) and
+                isinstance(idxs[1], string_types)), "First two indices must be of type str."
         assert (not np.isscalar(idxs[2]) or self.__is_positive_int(idxs[2])), \
             "Third index must be a non-negative integer"
 
@@ -624,8 +636,8 @@ class HDF5Dict(object):
 
     def __delitem__(self, idxs):
         assert isinstance(idxs, tuple), "Accessing HDF5_Dict requires a tuple of (object_name, feature_name, integer)"
-        assert isinstance(idxs[0], basestring) and isinstance(idxs[1],
-                                                              basestring), "First two indices must be of type str."
+        assert (isinstance(idxs[0], string_types) and
+                isinstance(idxs[1], string_types)), "First two indices must be of type str."
         if len(idxs) == 3:
             assert isinstance(idxs[2], int) and idxs[2] >= 0, "Third index must be a non-negative integer"
 
@@ -1041,7 +1053,7 @@ class HDF5FileList(object):
 
         returns a two tuple of schema + path part sequence
         '''
-        if isinstance(url, unicode):
+        if isinstance(url, text_type):
             url = url.encode("utf-8")
         else:
             url = str(url)
@@ -2002,7 +2014,7 @@ class VStringArray(object):
                 self.index[idx, :] = (self.VS_NULL, 0)
                 return
 
-            elif isinstance(value, unicode):
+            elif isinstance(value, text_type):
                 value = value.encode("utf8")
             else:
                 value = str(value)
@@ -2073,7 +2085,7 @@ class VStringArray(object):
         '''Store the strings passed, overwriting any previously stored data'''
         nulls = np.array([s is None for s in strings])
         strings = ["" if s is None
-                   else s.encode("utf-8") if isinstance(s, unicode)
+                   else s.encode("utf-8") if isinstance(s, text_type)
         else str(s) for s in strings]
         with self.lock:
             target_len = len(strings)
@@ -2176,7 +2188,7 @@ class VStringArray(object):
             return
         nulls = np.array([s is None for s in strings])
         strings = ["" if s is None
-                   else s.encode("utf-8") if isinstance(s, unicode)
+                   else s.encode("utf-8") if isinstance(s, text_type)
         else str(s) for s in strings]
         with self.lock:
             old_len = len(self)
@@ -2211,7 +2223,7 @@ class VStringArray(object):
         '''Return the insertion point for s, assuming the array is sorted'''
         if s is None:
             return 0
-        elif isinstance(s, unicode):
+        elif isinstance(s, text_type):
             s = s.encode("utf-8")
         else:
             s = str(s)
@@ -2415,7 +2427,7 @@ class StringReferencer(object):
     @staticmethod
     def string_to_uint8(s):
         '''Convert a utf-8 encoded string to a np.uint8 array'''
-        if isinstance(s, unicode):
+        if isinstance(s, text_type):
             s = s.encode('utf-8')
         elif not isinstance(s, str):
             s = str(s)

--- a/cellprofiler/utilities/legacy.py
+++ b/cellprofiler/utilities/legacy.py
@@ -1,0 +1,15 @@
+"""
+Functions associated with legacy python
+"""
+
+try:
+    # Python 2
+    _cmp = cmp
+
+    def cmp(a, b):
+        return _cmp(a, b)
+
+except NameError:
+    # Python 3
+    def cmp(a, b):
+        return (a > b) - (a < b)

--- a/cellprofiler/utilities/rules.py
+++ b/cellprofiler/utilities/rules.py
@@ -5,7 +5,7 @@ import re
 
 import numpy as np
 
-from six import string_types
+import six
 
 import cellprofiler.measurement as cpmeas
 
@@ -91,7 +91,7 @@ class Rules(object):
                         "\\s*(?P<threshold>[^,]+)"
                         ",\\s*\\[\\s*(?P<true>[^\\]]+)\\s*\\]"
                         ",\\s*\\[\\s*(?P<false>[^\\]]+)\\s*\\]\\s*\\)$")
-        if isinstance(fd_or_file, string_types):
+        if isinstance(fd_or_file, six.string_types):
             fd = open(fd_or_file, 'r')
             needs_close = True
         else:

--- a/cellprofiler/utilities/rules.py
+++ b/cellprofiler/utilities/rules.py
@@ -5,6 +5,8 @@ import re
 
 import numpy as np
 
+from six import string_types
+
 import cellprofiler.measurement as cpmeas
 
 
@@ -89,7 +91,7 @@ class Rules(object):
                         "\\s*(?P<threshold>[^,]+)"
                         ",\\s*\\[\\s*(?P<true>[^\\]]+)\\s*\\]"
                         ",\\s*\\[\\s*(?P<false>[^\\]]+)\\s*\\]\\s*\\)$")
-        if isinstance(fd_or_file, str) or isinstance(fd_or_file, unicode):
+        if isinstance(fd_or_file, string_types):
             fd = open(fd_or_file, 'r')
             needs_close = True
         else:

--- a/cellprofiler/utilities/utf16encode.py
+++ b/cellprofiler/utilities/utf16encode.py
@@ -4,6 +4,8 @@ utf16encode.py - encode unicode strings as escaped utf16
 This is only used for pipeline version < 3 files
 """
 
+import six
+
 
 def utf16decode(x):
     """Decode an escaped utf8-encoded string
@@ -15,18 +17,18 @@ def utf16decode(x):
             if z == "\\":
                 state = 0
             else:
-                y += unicode(z)
+                y += six.text_type(z)
         elif state == 0:
             if z == "u":
                 state = 1
                 acc = ""
             else:
-                y += unicode(z)
+                y += six.text_type(z)
                 state = -1
         elif state < 4:
             state += 1
             acc += z
         else:
             state = -1
-            y += unichr(int(acc + z, 16))
+            y += six.unichr(int(acc + z, 16))
     return y

--- a/cellprofiler/utilities/zmqrequest.py
+++ b/cellprofiler/utilities/zmqrequest.py
@@ -12,7 +12,13 @@ import uuid
 import zmq
 import Queue
 import numpy as np
+from six import string_types
 import cellprofiler.grid as cpg
+
+try:
+    buffer         # Python 2
+except NameError:  # Python 3
+    buffer = memoryview
 
 NOTIFY_SOCKET_ADDR = 'inproc://BoundaryNotifications'
 SD_KEY_DICT = "__keydict__"
@@ -87,7 +93,7 @@ def make_sendable_dictionary(d):
     result = {}
     fake_key_idx = 1
     for k, v in d.items():
-        if (isinstance(k, basestring) and k.startswith('_')) or callable(d[k]):
+        if (isinstance(k, string_types) and k.startswith('_')) or callable(d[k]):
             continue
         if isinstance(v, dict):
             v = make_sendable_dictionary(v)

--- a/cellprofiler/utilities/zmqrequest.py
+++ b/cellprofiler/utilities/zmqrequest.py
@@ -12,7 +12,7 @@ import uuid
 import zmq
 import Queue
 import numpy as np
-from six import string_types
+import six
 import cellprofiler.grid as cpg
 
 try:
@@ -93,7 +93,7 @@ def make_sendable_dictionary(d):
     result = {}
     fake_key_idx = 1
     for k, v in d.items():
-        if (isinstance(k, string_types) and k.startswith('_')) or callable(d[k]):
+        if (isinstance(k, six.string_types) and k.startswith('_')) or callable(d[k]):
             continue
         if isinstance(v, dict):
             v = make_sendable_dictionary(v)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ requests==2.18.4
 scikit-image==0.14.0
 scikit-learn==0.19.1
 scipy==1.1.0
+six==1.11.0

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,8 @@ setuptools.setup(
         "requests",
         "scikit-image",
         "scikit-learn",
-        "scipy"
+        "scipy",
+        "six"
     ],
     license="BSD",
     name="CellProfiler",
@@ -88,7 +89,8 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=[
         "tests*"
     ]),
-    python_requires=">=2.7, <3",
+    # Allow experimentation with Travis' Python 3.6.3 but not many other Py3s
+    python_requires=">=2.7, !=3.0, !=3.1, !=3.2, !=3.3, !=3.4, !=3.5, <=3.6.3",
     setup_requires=[
         "pytest"
     ],

--- a/tests/modules/__init__.py
+++ b/tests/modules/__init__.py
@@ -19,15 +19,10 @@ import tempfile
 
 import scipy.io.matlab.mio
 from cellprofiler.preferences import set_headless
+import cellprofiler.utilities.legacy
 
 set_headless()
 from cellprofiler.modules import builtin_modules, all_modules
-
-try:
-    cmp             # Python 2
-except NameError:
-    def cmp(a, b):  # Python 3
-        return (a > b) - (a < b)
 
 __temp_example_images_folder = None
 
@@ -211,7 +206,7 @@ def make_12_bit_image(folder, filename, shape):
         np.array([2, 1, 3, 0, 1, 0, 0, 0, 12, 0, 0, 0], np.uint8),
         # max value = 4095
         np.array([25, 1, 3, 0, 1, 0, 0, 0, 255, 15, 0, 0], np.uint8)]
-    ifds = sorted(ifds, cmp=(lambda a, b: cmp(a.tolist(), b.tolist())))
+    ifds = sorted(ifds, cmp=(lambda a, b: cellprofiler.utilities.legacy.cmp(a.tolist(), b.tolist())))
     old_end = offset + 2 + nentries * 12
     new_end = offset + 2 + len(ifds) * 12
     diff = new_end - old_end

--- a/tests/modules/__init__.py
+++ b/tests/modules/__init__.py
@@ -23,6 +23,12 @@ from cellprofiler.preferences import set_headless
 set_headless()
 from cellprofiler.modules import builtin_modules, all_modules
 
+try:
+    cmp             # Python 2
+except NameError:
+    def cmp(a, b):  # Python 3
+        return (a > b) - (a < b)
+
 __temp_example_images_folder = None
 
 # FIXME: use a stable URI

--- a/tests/modules/test_exporttospreadsheet.py
+++ b/tests/modules/test_exporttospreadsheet.py
@@ -11,7 +11,7 @@ import zlib
 from StringIO import StringIO
 
 import numpy as np
-from six import string_types
+import six
 from cellprofiler.preferences import set_headless
 
 set_headless()
@@ -2292,7 +2292,7 @@ ExportToSpreadsheet:[module_num:1|svn_version:\'Unknown\'|variable_revision_numb
                             (object_name, feature, cpmeas.COLTYPE_VARCHAR))
                 elif image_number is not None:
                     data = m[object_name, feature, image_number]
-                    if isinstance(data, string_types):
+                    if isinstance(data, six.string_types):
                         columns.append(
                                 (object_name, feature, cpmeas.COLTYPE_VARCHAR))
                     else:

--- a/tests/modules/test_exporttospreadsheet.py
+++ b/tests/modules/test_exporttospreadsheet.py
@@ -11,6 +11,7 @@ import zlib
 from StringIO import StringIO
 
 import numpy as np
+from six import string_types
 from cellprofiler.preferences import set_headless
 
 set_headless()
@@ -2291,7 +2292,7 @@ ExportToSpreadsheet:[module_num:1|svn_version:\'Unknown\'|variable_revision_numb
                             (object_name, feature, cpmeas.COLTYPE_VARCHAR))
                 elif image_number is not None:
                     data = m[object_name, feature, image_number]
-                    if isinstance(data, basestring):
+                    if isinstance(data, string_types):
                         columns.append(
                                 (object_name, feature, cpmeas.COLTYPE_VARCHAR))
                     else:

--- a/tests/modules/test_exporttospreadsheet.py
+++ b/tests/modules/test_exporttospreadsheet.py
@@ -1671,7 +1671,7 @@ ExportToSpreadsheet:[module_num:1|svn_version:\'Unknown\'|variable_revision_numb
             self.assertEqual(header[1], "my_measurement")
             row = next(reader)
             self.assertEqual(row[0], "1")
-            self.assertEqual(unicode(row[1], 'utf8'), metadata_value)
+            self.assertEqual(row[1].decode('utf8'), metadata_value)
             self.assertRaises(StopIteration, reader.next)
         finally:
             fd.close()

--- a/tests/modules/test_loaddata.py
+++ b/tests/modules/test_loaddata.py
@@ -9,6 +9,7 @@ import unittest
 import zlib
 
 import numpy
+from six import text_type
 
 import bioformats
 import bioformats.formatreader
@@ -321,7 +322,7 @@ LoadData:[module_num:1|svn_version:\'Unknown\'|variable_revision_number:6|show_w
         pipeline, module, filename = self.make_pipeline(csv_text)
         m = pipeline.run()
         data = m.get_current_image_measurement("Test_Measurement")
-        self.assertTrue(isinstance(data, unicode), "Expected <type 'unicode'> got %s" % type(data))
+        self.assertTrue(isinstance(data, text_type), "Expected <type 'six.text_type'> got %s" % type(data))
         self.assertEqual(data, "1234567890123")
         os.remove(filename)
 

--- a/tests/modules/test_loaddata.py
+++ b/tests/modules/test_loaddata.py
@@ -9,7 +9,7 @@ import unittest
 import zlib
 
 import numpy
-from six import text_type
+import six
 
 import bioformats
 import bioformats.formatreader
@@ -322,7 +322,7 @@ LoadData:[module_num:1|svn_version:\'Unknown\'|variable_revision_number:6|show_w
         pipeline, module, filename = self.make_pipeline(csv_text)
         m = pipeline.run()
         data = m.get_current_image_measurement("Test_Measurement")
-        self.assertTrue(isinstance(data, text_type), "Expected <type 'six.text_type'> got %s" % type(data))
+        self.assertTrue(isinstance(data, six.text_type), "Expected <type 'six.text_type'> got %s" % type(data))
         self.assertEqual(data, "1234567890123")
         os.remove(filename)
 

--- a/tests/modules/test_measureimageoverlap.py
+++ b/tests/modules/test_measureimageoverlap.py
@@ -503,6 +503,7 @@ MeasureImageOverlap:[module_num:1|svn_version:\'Unknown\'|variable_revision_numb
         # All columns should be unique
         self.assertEqual(len(columns), len(set([x[1] for x in columns])))
         # All columns should be floats and done on images
+        x = columns[-1]
         self.assertTrue(all([x[0] == cellprofiler.measurement.IMAGE]))
         self.assertTrue(all([x[2] == cellprofiler.measurement.COLTYPE_FLOAT]))
         for feature in cellprofiler.modules.measureimageoverlap.FTR_ALL:

--- a/tests/modules/test_measureobjectoverlap.py
+++ b/tests/modules/test_measureobjectoverlap.py
@@ -77,6 +77,7 @@ class TestMeasureObjectOverlap(unittest.TestCase):
         # All columns should be unique
         self.assertEqual(len(columns), len(set([x[1] for x in columns])))
         # All columns should be floats and done on images
+        x = columns[-1]
         self.assertTrue(all([x[0] == cellprofiler.measurement.IMAGE]))
         self.assertTrue(all([x[2] == cellprofiler.measurement.COLTYPE_FLOAT]))
         for feature in cellprofiler.modules.measureobjectoverlap.FTR_ALL:

--- a/tests/modules/test_namesandtypes.py
+++ b/tests/modules/test_namesandtypes.py
@@ -5,6 +5,8 @@ import tempfile
 import unittest
 import urllib
 
+from six import string_types
+
 import cellprofiler.measurement
 import cellprofiler.modules.createbatchfiles
 import cellprofiler.modules.namesandtypes
@@ -741,7 +743,7 @@ NamesAndTypes:[module_num:3|svn_version:\'Unknown\'|variable_revision_number:4|s
     def make_ipd(self, url, metadata, series=0, index=0, channel=None):
         if channel is None:
             channel = "ALWAYS_MONOCHROME"
-        if isinstance(channel, basestring):
+        if isinstance(channel, string_types):
             channel = javabridge.run_script("""
             importPackage(Packages.org.cellprofiler.imageset);
             ImagePlane.%s;""" % channel)

--- a/tests/modules/test_namesandtypes.py
+++ b/tests/modules/test_namesandtypes.py
@@ -5,7 +5,7 @@ import tempfile
 import unittest
 import urllib
 
-from six import string_types
+import six
 
 import cellprofiler.measurement
 import cellprofiler.modules.createbatchfiles
@@ -743,7 +743,7 @@ NamesAndTypes:[module_num:3|svn_version:\'Unknown\'|variable_revision_number:4|s
     def make_ipd(self, url, metadata, series=0, index=0, channel=None):
         if channel is None:
             channel = "ALWAYS_MONOCHROME"
-        if isinstance(channel, string_types):
+        if isinstance(channel, six.string_types):
             channel = javabridge.run_script("""
             importPackage(Packages.org.cellprofiler.imageset);
             ImagePlane.%s;""" % channel)

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -17,6 +17,7 @@ import numpy as np
 import cellprofiler.image as cpi
 import cellprofiler.measurement as cpmeas
 from functools import reduce
+from six import text_type
 
 OBJECT_NAME = "myobjects"
 FEATURE_NAME = "feature"
@@ -34,7 +35,7 @@ class TestMeasurements(unittest.TestCase):
         for case in test:
             result = cpmeas.Measurements.unwrap_string(
                     cpmeas.Measurements.wrap_string(case))
-            if not isinstance(case, unicode):
+            if not isinstance(case, text_type):
                 case = case.decode("utf-8")
             self.assertEqual(result, case)
 
@@ -191,10 +192,10 @@ class TestMeasurements(unittest.TestCase):
         bad_order = r.permutation(np.arange(1, 101))
         for image_number in bad_order:
             m.add_measurement(cpmeas.IMAGE, "Feature",
-                              unicode(vals[image_number - 1]),
+                              text_type(vals[image_number - 1]),
                               image_set_number=image_number)
         result = m.get_all_measurements(cpmeas.IMAGE, "Feature")
-        self.assertTrue(all([r == unicode(v) for r, v in zip(result, vals)]))
+        self.assertTrue(all([r == text_type(v) for r, v in zip(result, vals)]))
 
     def test_04_02b_get_all_image_measurements_string_arrayinterface(self):
         r = np.random.RandomState()
@@ -203,9 +204,9 @@ class TestMeasurements(unittest.TestCase):
         vals = r.uniform(size=100)
         bad_order = r.permutation(np.arange(1, 101))
         for image_number in bad_order:
-            m[cpmeas.IMAGE, "Feature", image_number] = unicode(vals[image_number - 1])
+            m[cpmeas.IMAGE, "Feature", image_number] = text_type(vals[image_number - 1])
         result = m[cpmeas.IMAGE, "Feature", :]
-        self.assertTrue(all([r == unicode(v) for r, v in zip(result, vals)]))
+        self.assertTrue(all([r == text_type(v) for r, v in zip(result, vals)]))
 
     def test_04_03_get_all_image_measurements_unicode(self):
         r = np.random.RandomState()
@@ -218,7 +219,7 @@ class TestMeasurements(unittest.TestCase):
                               vals[image_number - 1],
                               image_set_number=image_number)
         result = m.get_all_measurements(cpmeas.IMAGE, "Feature")
-        self.assertTrue(all([r == unicode(v) for r, v in zip(result, vals)]))
+        self.assertTrue(all([r == text_type(v) for r, v in zip(result, vals)]))
 
     def test_04_03b_get_all_image_measurements_unicode_arrayinterface(self):
         r = np.random.RandomState()
@@ -229,7 +230,7 @@ class TestMeasurements(unittest.TestCase):
         for image_number in bad_order:
             m[cpmeas.IMAGE, "Feature", image_number] = vals[image_number - 1]
         result = m[cpmeas.IMAGE, "Feature", :]
-        self.assertTrue(all([r == unicode(v) for r, v in zip(result, vals)]))
+        self.assertTrue(all([r == text_type(v) for r, v in zip(result, vals)]))
 
     def test_04_04_get_all_object_measurements(self):
         r = np.random.RandomState()
@@ -527,8 +528,8 @@ class TestMeasurements(unittest.TestCase):
         result = m.get_groupings(["Metadata_A", "Metadata_B"])
         for d, image_numbers in result:
             for image_number in image_numbers:
-                self.assertEqual(d["Metadata_A"], unicode(aa[image_number - 1]))
-                self.assertEqual(d["Metadata_B"], unicode(bb[image_number - 1]))
+                self.assertEqual(d["Metadata_A"], text_type(aa[image_number - 1]))
+                self.assertEqual(d["Metadata_B"], text_type(bb[image_number - 1]))
 
     def test_10_01_remove_image_measurement(self):
         m = cpmeas.Measurements()

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -17,7 +17,7 @@ import numpy as np
 import cellprofiler.image as cpi
 import cellprofiler.measurement as cpmeas
 from functools import reduce
-from six import text_type
+import six
 
 OBJECT_NAME = "myobjects"
 FEATURE_NAME = "feature"
@@ -35,7 +35,7 @@ class TestMeasurements(unittest.TestCase):
         for case in test:
             result = cpmeas.Measurements.unwrap_string(
                     cpmeas.Measurements.wrap_string(case))
-            if not isinstance(case, text_type):
+            if not isinstance(case, six.text_type):
                 case = case.decode("utf-8")
             self.assertEqual(result, case)
 
@@ -192,10 +192,10 @@ class TestMeasurements(unittest.TestCase):
         bad_order = r.permutation(np.arange(1, 101))
         for image_number in bad_order:
             m.add_measurement(cpmeas.IMAGE, "Feature",
-                              text_type(vals[image_number - 1]),
+                              six.text_type(vals[image_number - 1]),
                               image_set_number=image_number)
         result = m.get_all_measurements(cpmeas.IMAGE, "Feature")
-        self.assertTrue(all([r == text_type(v) for r, v in zip(result, vals)]))
+        self.assertTrue(all([r == six.text_type(v) for r, v in zip(result, vals)]))
 
     def test_04_02b_get_all_image_measurements_string_arrayinterface(self):
         r = np.random.RandomState()
@@ -204,9 +204,9 @@ class TestMeasurements(unittest.TestCase):
         vals = r.uniform(size=100)
         bad_order = r.permutation(np.arange(1, 101))
         for image_number in bad_order:
-            m[cpmeas.IMAGE, "Feature", image_number] = text_type(vals[image_number - 1])
+            m[cpmeas.IMAGE, "Feature", image_number] = six.text_type(vals[image_number - 1])
         result = m[cpmeas.IMAGE, "Feature", :]
-        self.assertTrue(all([r == text_type(v) for r, v in zip(result, vals)]))
+        self.assertTrue(all([r == six.text_type(v) for r, v in zip(result, vals)]))
 
     def test_04_03_get_all_image_measurements_unicode(self):
         r = np.random.RandomState()
@@ -219,7 +219,7 @@ class TestMeasurements(unittest.TestCase):
                               vals[image_number - 1],
                               image_set_number=image_number)
         result = m.get_all_measurements(cpmeas.IMAGE, "Feature")
-        self.assertTrue(all([r == text_type(v) for r, v in zip(result, vals)]))
+        self.assertTrue(all([r == six.text_type(v) for r, v in zip(result, vals)]))
 
     def test_04_03b_get_all_image_measurements_unicode_arrayinterface(self):
         r = np.random.RandomState()
@@ -230,7 +230,7 @@ class TestMeasurements(unittest.TestCase):
         for image_number in bad_order:
             m[cpmeas.IMAGE, "Feature", image_number] = vals[image_number - 1]
         result = m[cpmeas.IMAGE, "Feature", :]
-        self.assertTrue(all([r == text_type(v) for r, v in zip(result, vals)]))
+        self.assertTrue(all([r == six.text_type(v) for r, v in zip(result, vals)]))
 
     def test_04_04_get_all_object_measurements(self):
         r = np.random.RandomState()
@@ -528,8 +528,8 @@ class TestMeasurements(unittest.TestCase):
         result = m.get_groupings(["Metadata_A", "Metadata_B"])
         for d, image_numbers in result:
             for image_number in image_numbers:
-                self.assertEqual(d["Metadata_A"], text_type(aa[image_number - 1]))
-                self.assertEqual(d["Metadata_B"], text_type(bb[image_number - 1]))
+                self.assertEqual(d["Metadata_A"], six.text_type(aa[image_number - 1]))
+                self.assertEqual(d["Metadata_B"], six.text_type(bb[image_number - 1]))
 
     def test_10_01_remove_image_measurement(self):
         m = cpmeas.Measurements()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -12,7 +12,7 @@ import traceback
 import unittest
 import zlib
 
-from six import text_type
+import six
 
 import cellprofiler.image as cpi
 import cellprofiler.measurement as cpmeas
@@ -1077,7 +1077,7 @@ HasImagePlaneDetails:False"""
         fd.seek(0)
         result = cpp.read_file_list(fd)
         for rr, tt in zip(result, test_data):
-            if isinstance(tt, text_type):
+            if isinstance(tt, six.text_type):
                 tt = tt.encode("utf-8")
             self.assertEquals(rr, tt)
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -12,6 +12,8 @@ import traceback
 import unittest
 import zlib
 
+from six import text_type
+
 import cellprofiler.image as cpi
 import cellprofiler.measurement as cpmeas
 import cellprofiler.module as cpm
@@ -1075,7 +1077,7 @@ HasImagePlaneDetails:False"""
         fd.seek(0)
         result = cpp.read_file_list(fd)
         for rr, tt in zip(result, test_data):
-            if isinstance(tt, unicode):
+            if isinstance(tt, text_type):
                 tt = tt.encode("utf-8")
             self.assertEquals(rr, tt)
 

--- a/tests/utilities/test_hdf5_dict.py
+++ b/tests/utilities/test_hdf5_dict.py
@@ -8,6 +8,7 @@ import unittest
 
 import h5py
 import numpy as np
+from six import string_types
 
 import cellprofiler.utilities.hdf5_dict as H5DICT
 
@@ -147,7 +148,7 @@ class TestHDF5Dict(unittest.TestCase):
         self.hdf5_dict[OBJECT_NAME, FEATURE_NAME, 1] = [2.5]
         self.hdf5_dict[OBJECT_NAME, FEATURE_NAME, 2] = ["alfalfa"]
         data = self.hdf5_dict[OBJECT_NAME, FEATURE_NAME, 1]
-        self.assertIsInstance(data[0], basestring)
+        self.assertIsInstance(data[0], string_types)
 
     def test_02_08_write_twice(self):
         self.hdf5_dict[OBJECT_NAME, FEATURE_NAME, (1, 2)] = [1.2, 3.4]

--- a/tests/utilities/test_hdf5_dict.py
+++ b/tests/utilities/test_hdf5_dict.py
@@ -8,7 +8,7 @@ import unittest
 
 import h5py
 import numpy as np
-from six import string_types
+import six
 
 import cellprofiler.utilities.hdf5_dict as H5DICT
 
@@ -148,7 +148,7 @@ class TestHDF5Dict(unittest.TestCase):
         self.hdf5_dict[OBJECT_NAME, FEATURE_NAME, 1] = [2.5]
         self.hdf5_dict[OBJECT_NAME, FEATURE_NAME, 2] = ["alfalfa"]
         data = self.hdf5_dict[OBJECT_NAME, FEATURE_NAME, 1]
-        self.assertIsInstance(data[0], string_types)
+        self.assertIsInstance(data[0], six.string_types)
 
     def test_02_08_write_twice(self):
         self.hdf5_dict[OBJECT_NAME, FEATURE_NAME, (1, 2)] = [1.2, 3.4]

--- a/tests/utilities/test_zmqrequest.py
+++ b/tests/utilities/test_zmqrequest.py
@@ -12,7 +12,7 @@ import zmq
 import unittest
 import uuid
 import numpy as np
-
+from six import string_types
 import cellprofiler.utilities.zmqrequest as Z
 
 CLIENT_MESSAGE = "Hello, server"
@@ -267,7 +267,7 @@ class TestZMQRequest(unittest.TestCase):
     def same(self, a, b):
         if isinstance(a, (float, int)):
             self.assertAlmostEquals(a, b)
-        elif isinstance(a, basestring):
+        elif isinstance(a, string_types):
             self.assertEquals(a, b)
         elif isinstance(a, dict):
             self.assertTrue(isinstance(b, dict))

--- a/tests/utilities/test_zmqrequest.py
+++ b/tests/utilities/test_zmqrequest.py
@@ -12,7 +12,7 @@ import zmq
 import unittest
 import uuid
 import numpy as np
-from six import string_types
+import six
 import cellprofiler.utilities.zmqrequest as Z
 
 CLIENT_MESSAGE = "Hello, server"
@@ -267,7 +267,7 @@ class TestZMQRequest(unittest.TestCase):
     def same(self, a, b):
         if isinstance(a, (float, int)):
             self.assertAlmostEquals(a, b)
-        elif isinstance(a, string_types):
+        elif isinstance(a, six.string_types):
             self.assertEquals(a, b)
         elif isinstance(a, dict):
             self.assertTrue(isinstance(b, dict))


### PR DESCRIPTION
Adds the popular [__six__](http://six.readthedocs.io) module for compatibility between Python 2 and Python 3.

I could uses some guidance on how to handle the conversion of [__unicode(x, "utf-8")__.](https://travis-ci.org/CellProfiler/CellProfiler/jobs/435299908#L969)..

For a later PR, we should look at __six.StringIO__ vs __six.moves.cStringIO__.