### PR TITLE
Fix python 2/3 imports preventing python 3 tests from running

### DIFF
--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -11,7 +11,6 @@ import cellprofiler.utilities.hdf5_dict
 import cellprofiler.utilities.zmqrequest
 import cellprofiler.worker
 import cellprofiler.workspace
-import cStringIO
 import h5py
 import json
 import logging
@@ -26,6 +25,7 @@ import re
 import site
 import sys
 import tempfile
+import six.moves
 
 OMERO_CK_HOST = "host"
 OMERO_CK_PORT = "port"
@@ -675,7 +675,7 @@ def run_pipeline_headless(options, args):
 
         pipeline_text = pipeline_text.encode('us-ascii')
 
-        pipeline.load(cStringIO.StringIO(pipeline_text))
+        pipeline.load(six.moves.StringIO(pipeline_text))
 
         if not pipeline.in_batch_mode():
             #

--- a/cellprofiler/analysis.py
+++ b/cellprofiler/analysis.py
@@ -1,8 +1,7 @@
 """analysis.py - Run pipelines on imagesets to produce measurements.
 """
 
-import Queue
-import cStringIO as StringIO
+import queue
 import collections
 import logging
 import multiprocessing
@@ -18,6 +17,7 @@ import h5py
 import numpy as np
 import zmq
 import six
+import six.moves
 
 import cellprofiler
 import cellprofiler.image as cpimage
@@ -185,9 +185,9 @@ class AnalysisRunner(object):
         self.paused = False
         self.cancelled = False
 
-        self.work_queue = Queue.Queue()
-        self.in_process_queue = Queue.Queue()
-        self.finished_queue = Queue.Queue()
+        self.work_queue = queue.Queue()
+        self.in_process_queue = queue.Queue()
+        self.finished_queue = queue.Queue()
 
         # We use a queue size of 10 because we keep measurements in memory (as
         # their HDF5 file contents) until they get merged into the full
@@ -196,7 +196,7 @@ class AnalysisRunner(object):
         # than interface() doing so.  Currently, passing measurements in this
         # way seems like it might be buggy:
         # http://code.google.com/p/h5py/issues/detail?id=244
-        self.received_measurements_queue = Queue.Queue(maxsize=10)
+        self.received_measurements_queue = queue.Queue(maxsize=10)
 
         self.shared_dicts = None
 
@@ -553,7 +553,7 @@ class AnalysisRunner(object):
         # all the requests from workers, of which there might be several.
 
         # start the zmqrequest Boundary
-        request_queue = Queue.Queue()
+        request_queue = queue.Queue()
         boundary = register_analysis(analysis_id,
                                      request_queue)
         #
@@ -584,7 +584,7 @@ class AnalysisRunner(object):
 
             try:
                 req = request_queue.get(timeout=0.25)
-            except Queue.Empty:
+            except queue.Empty:
                 continue
 
             if isinstance(req, PipelinePreferencesRequest):
@@ -673,7 +673,7 @@ class AnalysisRunner(object):
             self.interface_work_cv.notify()
 
     def pipeline_as_string(self):
-        s = StringIO.StringIO()
+        s = six.moves.StringIO()
         self.pipeline.savetxt(s)
         return s.getvalue()
 

--- a/cellprofiler/image.py
+++ b/cellprofiler/image.py
@@ -4,8 +4,6 @@ Image        - Represents an image with secondary attributes such as a mask and 
 ImageSetList - Represents the list of image filenames that make up a pipeline run
 """
 
-import StringIO
-import cPickle
 import logging
 import math
 import struct
@@ -15,6 +13,7 @@ import zlib
 import numpy
 
 import six
+import six.moves
 
 logger = logging.getLogger(__name__)
 
@@ -753,14 +752,14 @@ class ImageSetList(object):
         load_state will restore the image set list's state. No image_set can
         have image providers before this call.
         '''
-        f = StringIO.StringIO()
-        cPickle.dump(self.count(), f)
+        f = six.moves.StringIO()
+        six.moves.cPickle.dump(self.count(), f)
         for i in range(self.count()):
             image_set = self.get_image_set(i)
             assert isinstance(image_set, ImageSet)
             assert len(image_set.providers) == 0, "An image set cannot have providers while saving its state"
-            cPickle.dump(image_set.keys, f)
-        cPickle.dump(self.legacy_fields, f)
+            six.moves.cPickle.dump(image_set.keys, f)
+        six.moves.cPickle.dump(self.legacy_fields, f)
         return f.getvalue()
 
     def load_state(self, state):
@@ -770,7 +769,7 @@ class ImageSetList(object):
         self.__image_sets_by_key = {}
 
         # Make a safe unpickler
-        p = cPickle.Unpickler(StringIO.StringIO(state))
+        p = six.moves.cPickle.Unpickler(six.moves.StringIO(state))
 
         def find_global(module_name, class_name):
             logger.debug("Pickler wants %s:%s", module_name, class_name)

--- a/cellprofiler/worker.py
+++ b/cellprofiler/worker.py
@@ -120,12 +120,11 @@ if __name__ == "__main__":
 
 import time
 import threading
-import thread
 import random
 import zmq
-import cStringIO as StringIO
 import traceback
 from weakref import WeakSet
+import six.moves
 
 import cellprofiler.workspace as cpw
 import cellprofiler.measurement as cpmeas
@@ -330,7 +329,7 @@ class AnalysisWorker(object):
                 logger.debug("Loading pipeline")
                 pipeline_blob = rep.pipeline_blob.tostring()
                 current_pipeline = cpp.Pipeline()
-                current_pipeline.loadtxt(StringIO.StringIO(pipeline_blob),
+                current_pipeline.loadtxt(six.moves.StringIO(pipeline_blob),
                                          raise_on_error=True)
                 logger.debug("Pipeline loaded")
                 current_pipeline.add_listener(

--- a/cellprofiler/workspace.py
+++ b/cellprofiler/workspace.py
@@ -4,10 +4,10 @@
 import logging
 
 logger = logging.getLogger(__name__)
-from cStringIO import StringIO
 import numpy as np
 import h5py
 import os
+from six.moves import StringIO
 
 from cellprofiler.grid import Grid
 from .utilities.hdf5_dict import HDF5FileList, HDF5Dict


### PR DESCRIPTION
Regarding StringIO, Queue, tread, and cPickle.

This doesn't fix any actual unit tests (yet), but it at least makes it so that the unittest can run at all!