### PR TITLE
Set numpy to be higher than the travis default (1.13)

### DIFF
--- a/unpinned_requirements.txt
+++ b/unpinned_requirements.txt
@@ -8,7 +8,7 @@ joblib
 mahotas
 matplotlib>=2.0.0,!=2.1.0
 mysqlclient==1.3.13
-numpy>=1.12.0
+numpy>1.13.0
 prokaryote==2.4.0
 python-bioformats==1.5.2
 pyzmq==15.3.0

--- a/unpinned_requirements.txt
+++ b/unpinned_requirements.txt
@@ -8,7 +8,7 @@ joblib
 mahotas
 matplotlib>=2.0.0,!=2.1.0
 mysqlclient==1.3.13
-numpy>1.13.0
+numpy>1.14.0
 prokaryote==2.4.0
 python-bioformats==1.5.2
 pyzmq==15.3.0


### PR DESCRIPTION
I don't want to merge this until we have fixes for the failing `unpinned_dependency.txt` builds