### PR TITLE
#3677 Add default measurements for RelateObjects

### DIFF
--- a/cellprofiler/modules/relateobjects.py
+++ b/cellprofiler/modules/relateobjects.py
@@ -410,6 +410,8 @@ parents or children of the parent object."""
 
         objects.add_objects(y, y_name)
 
+        self.add_measurements(workspace)
+
         if self.show_window:
             workspace.display_data.parent_labels = parents.segmented
 
@@ -743,7 +745,8 @@ parents or children of the parent object."""
 
     def get_measurement_columns(self, pipeline):
         '''Return the column definitions for this module's measurements'''
-        columns = [
+        columns = super(RelateObjects, self).get_measurement_columns(pipeline)
+        columns += [
             (
                 self.x_child_name.value,
                 cellprofiler.measurement.FF_PARENT % self.x_name.value,

--- a/cellprofiler/modules/relateobjects.py
+++ b/cellprofiler/modules/relateobjects.py
@@ -4,6 +4,7 @@ import re
 import numpy
 import scipy.ndimage
 import skimage.segmentation
+import skimage.measure
 import cellprofiler.measurement
 import cellprofiler.module
 import cellprofiler.setting
@@ -404,7 +405,9 @@ parents or children of the parent object."""
 
         y = cellprofiler.object.Objects()
 
-        y.segmented = parent_labeled_children
+        y_data = skimage.measure.label(parent_labeled_children)
+
+        y.segmented = y_data
 
         y.parent_image = children.parent_image
 

--- a/tests/modules/test_relateobjects.py
+++ b/tests/modules/test_relateobjects.py
@@ -76,7 +76,13 @@ class TestRelateObjects(unittest.TestCase):
                      for feature in measurements.get_feature_names(object_name)
                      if feature not in (MEASUREMENT, IGNORED_MEASUREMENT)]
                     for object_name in object_names]
-        columns = module.get_measurement_columns(pipeline)
+        # The default ObjectProcessing measurements also add an 
+        # Image_Count<foo> measurement to the set. These are filtered out
+        # for the features above when defining object_names above,
+        # but we now also need to filter it out here.
+        columns = [column 
+                   for column in module.get_measurement_columns(pipeline)
+                   if column[0] != cellprofiler.measurement.IMAGE]
         self.assertEqual(sum([len(f) for f in features]), len(columns))
         for column in columns:
             index = object_names.index(column[0])


### PR DESCRIPTION
Since we're overriding the "run" method, we also have to make sure that `add_measurements` is called to add the default measurements for an ObjectProcessing module. 

@bethac07 do you mind making sure this works? It looks like it works on my machine (the run is successful and a CSV is made). 