### PR TITLE
Stop using rank ordered data for median filter

### DIFF
--- a/cellprofiler/modules/correctilluminationcalculate.py
+++ b/cellprofiler/modules/correctilluminationcalculate.py
@@ -833,7 +833,7 @@ fewer iterations, but less accuracy.
         elif self.smoothing_method == SM_MEDIAN_FILTER:
             filter_sigma = max(1, int(sigma+.5))
             strel = strel_disk(filter_sigma)
-            rescaled_pixel_data=pixel_data*65535
+            rescaled_pixel_data = pixel_data * 65535
             rescaled_pixel_data = rescaled_pixel_data.astype(np.uint16)
             output_pixels = skimage.filters.median(rescaled_pixel_data, strel, mask=mask)
         elif self.smoothing_method == SM_TO_AVERAGE:

--- a/cellprofiler/modules/correctilluminationcalculate.py
+++ b/cellprofiler/modules/correctilluminationcalculate.py
@@ -833,9 +833,9 @@ fewer iterations, but less accuracy.
         elif self.smoothing_method == SM_MEDIAN_FILTER:
             filter_sigma = max(1, int(sigma+.5))
             strel = strel_disk(filter_sigma)
-            indices, values = rank_order(pixel_data, 65535)
-            indices = indices.astype(np.uint16)
-            output_pixels = skimage.filters.median(pixel_data, strel, mask=mask)
+            rescaled_pixel_data=pixel_data*65535
+            rescaled_pixel_data = rescaled_pixel_data.astype(np.uint16)
+            output_pixels = skimage.filters.median(rescaled_pixel_data, strel, mask=mask)
         elif self.smoothing_method == SM_TO_AVERAGE:
             mean = np.mean(pixel_data[mask])
             output_pixels = np.ones(pixel_data.shape, pixel_data.dtype) * mean


### PR DESCRIPTION
Resolves #2898 , as well as some other issues people had sent to me privately re: using median filter in illumination correction.  

The skimage median filter only works on ints, not floats (though it's on their roadmap to support floats), so SOME sort of transformation had to be done, but I don't understand why you would choose to rank-order the pixels rather than just make them an int.  If someone remembers/understands why and wants to argue strongly for why to do it on ranking, happy to listen, but otherwise I think this is a better solution.  