### PR TITLE
Update setup.py to specify version requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -432,10 +432,12 @@ setuptools.setup(
         "h5py<=2.7.0",
         "inflect",
         "javabridge",
-        "matplotlib",
+        "matplotlib>=2.0.0, <3.0.0",
         "MySQL-python",
+        "pillow>=4.3.0"
         "prokaryote==2.3.3",
         "python-bioformats==1.4.0",
+        "python-dateutils>=2.5.0",
         "pyzmq",
         "scipy"
     ],


### PR DESCRIPTION
Following instructions at https://github.com/CellProfiler/CellProfiler/wiki/Source-installation-(Ubuntu-16.04-LTS), the system will install some older versions of python libraries and setup.py will not update them as required by CellProfiler.

```
pkg_resources.ContextualVersionConflict: (matplotlib 1.5.1 (/usr/lib/python2.7/dist-packages), Requirement.parse('matplotlib>=2.0.0'), set(['scikit-image']))
pkg_resources.ContextualVersionConflict: (Pillow 3.1.2 (/usr/lib/python2.7/dist-packages), Requirement.parse('pillow>=4.3.0'), set(['scikit-image']))
pkg_resources.ContextualVersionConflict: (python-dateutil 2.4.2 (/usr/lib/python2.7/dist-packages), Requirement.parse('python-dateutil>=2.5.0'), set(['pandas']))
```

    Matplotlib 3.0+ does not support Python 2.x, 3.0, 3.1, 3.2, 3.3, or 3.4.
    Beginning with Matplotlib 3.0, Python 3.5 and above is required.