### PR TITLE
add JVM environment fix

### DIFF
--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -1,13 +1,14 @@
 from __future__ import print_function
 
 import os
-import os.path
 import sys
 if sys.platform.startswith("win") and hasattr(sys, 'frozen'):
-    # Allow us to package java with windows builds
+    # For Windows builds, if JAVA_HOME is not already set, use the copy of Java packaged with CP
+    # We specify this location by setting 'CP_JAVA_HOME' at install.
+    # JAVA_HOME must be set before bioformats import.
     if 'JAVA_HOME' not in os.environ:
-        if 'CP_JAVAHOME' in os.environ:
-            os.environ['JAVA_HOME'] = os.environ['CP_JAVAHOME']
+        if 'CP_JAVA_HOME' in os.environ:
+            os.environ['JAVA_HOME'] = os.environ['CP_JAVA_HOME']
 
 import bioformats.formatreader
 import ctypes
@@ -28,6 +29,7 @@ import logging.config
 import matplotlib
 import numpy
 import optparse
+import os.path
 import pkg_resources
 import re
 import site

--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -1,14 +1,14 @@
 from __future__ import print_function
 
 import os
+import os.path
 import sys
 if sys.platform.startswith("win") and hasattr(sys, 'frozen'):
     # For Windows builds, if JAVA_HOME is not already set, use the copy of Java packaged with CP
     # We specify this location by setting 'CP_JAVA_HOME' at install.
     # JAVA_HOME must be set before bioformats import.
-    if 'JAVA_HOME' not in os.environ:
-        if 'CP_JAVA_HOME' in os.environ:
-            os.environ['JAVA_HOME'] = os.environ['CP_JAVA_HOME']
+    if 'JAVA_HOME' not in os.environ and if 'CP_JAVA_HOME' in os.environ:
+        os.environ['JAVA_HOME'] = os.environ['CP_JAVA_HOME']
 
 import bioformats.formatreader
 import ctypes
@@ -29,7 +29,6 @@ import logging.config
 import matplotlib
 import numpy
 import optparse
-import os.path
 import pkg_resources
 import re
 import site

--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -1,4 +1,14 @@
 from __future__ import print_function
+
+import os
+import os.path
+import sys
+if sys.platform.startswith("win") and hasattr(sys, 'frozen'):
+    # Allow us to package java with windows builds
+    if 'JAVA_HOME' not in os.environ:
+        if 'CP_JAVAHOME' in os.environ:
+            os.environ['JAVA_HOME'] = os.environ['CP_JAVAHOME']
+
 import bioformats.formatreader
 import ctypes
 import cellprofiler
@@ -18,12 +28,9 @@ import logging.config
 import matplotlib
 import numpy
 import optparse
-import os
-import os.path
 import pkg_resources
 import re
 import site
-import sys
 import tempfile
 import six.moves
 
@@ -117,6 +124,7 @@ def main(args=None):
         cellprofiler.preferences.set_data_file(os.path.abspath(options.data_file))
 
     try:
+
         if not options.show_gui:
             cellprofiler.utilities.cpjvm.cp_start_vm()
 

--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -7,7 +7,7 @@ if sys.platform.startswith("win") and hasattr(sys, 'frozen'):
     # For Windows builds, if JAVA_HOME is not already set, use the copy of Java packaged with CP
     # We specify this location by setting 'CP_JAVA_HOME' at install.
     # JAVA_HOME must be set before bioformats import.
-    if 'JAVA_HOME' not in os.environ and if 'CP_JAVA_HOME' in os.environ:
+    if 'JAVA_HOME' not in os.environ and 'CP_JAVA_HOME' in os.environ:
         os.environ['JAVA_HOME'] = os.environ['CP_JAVA_HOME']
 
 import bioformats.formatreader

--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -124,7 +124,6 @@ def main(args=None):
         cellprofiler.preferences.set_data_file(os.path.abspath(options.data_file))
 
     try:
-
         if not options.show_gui:
             cellprofiler.utilities.cpjvm.cp_start_vm()
 


### PR DESCRIPTION
This is ugly, and I'm very sorry about that, but it has to be called before bioformats is imported because bioformats checks if it can spin up javabridge upon import.  It also works to add this in the init if you find it less gross to have it there.