### PR TITLE
Export cppipe as text with no encoding

### DIFF
--- a/cellprofiler/pipeline.py
+++ b/cellprofiler/pipeline.py
@@ -153,7 +153,7 @@ FMT_MATLAB = "Matlab"
 FMT_NATIVE = "Native"
 
 """The current pipeline file format version"""
-NATIVE_VERSION = 4
+NATIVE_VERSION = 5
 
 """The version of the image plane descriptor section"""
 IMAGE_PLANE_DESCRIPTOR_VERSION = 1
@@ -1020,8 +1020,10 @@ class Pipeline(object):
                     )
                 elif 1 < version < 4:
                     do_deprecated_utf16_decode = True
-                elif version >= 4:
+                elif version == 4:
                     do_utf16_decode = True
+                elif version == 5:
+                    pass
             elif kwd in (H_SVN_REVISION, H_DATE_REVISION):
                 pipeline_version = int(value)
                 CURRENT_VERSION = int(
@@ -1152,8 +1154,7 @@ class Pipeline(object):
                 module.module_num = module_number
                 #
                 # Decode the attributes. These are turned into strings using
-                # repr, so True -> 'True', etc. They are then encoded using
-                # Pipeline.encode_txt.
+                # repr, so True -> 'True', etc.
                 #
                 if (
                     len(attribute_string) < 2
@@ -1238,20 +1239,6 @@ class Pipeline(object):
         else:
             raise NotImplementedError("Unknown pipeline file format: %s" % format)
 
-    def encode_txt(self, s):
-        """Encode a string for saving in the text format
-
-        s - input string
-        Encode for automatic decoding using the 'string_escape' decoder.
-        We encode the special characters, '[', ':', '|' and ']' using the '\\x'
-        syntax.
-        """
-        s = six.text_type(s)
-        s = s.replace(":", "\\x3A")
-        s = s.replace("|", "\\x7C")
-        s = s.replace("[", "\\x5B").replace("]", "\\x5D")
-        return s
-
     def savetxt(
         self, fd_or_filename, modules_to_save=None, save_image_plane_details=True
     ):
@@ -1266,9 +1253,6 @@ class Pipeline(object):
                           URL, series, index, channel and metadata)
 
         The format of the file is the following:
-        Strings are encoded using a backslash escape sequence. The colon
-        character is encoded as \\x3A if it should happen to appear in a string
-        and any non-printing character is encoded using the \\x## convention.
 
         Line 1: The cookie, identifying this as a CellProfiler pipeline file.
         The header, i
@@ -1338,7 +1322,6 @@ class Pipeline(object):
             attribute_values = [
                 repr(getattr(module, attribute)) for attribute in attributes
             ]
-            attribute_values = [self.encode_txt(v) for v in attribute_values]
             attribute_strings = [
                 attribute + ":" + value
                 for attribute, value in zip(attributes, attribute_values)
@@ -1347,7 +1330,7 @@ class Pipeline(object):
 
             fd.write(
                 "%s:%s\n"
-                % (self.encode_txt(module.module_name), six.text_type(attribute_string))
+                % (module.module_name, six.text_type(attribute_string))
             )
 
             for setting in module.settings():
@@ -1357,17 +1340,11 @@ class Pipeline(object):
                 else:
                     setting_text = str(setting_text)
 
-                encoded_setting_text = self.encode_txt(setting_text)
-
-                encoded_unicode_value = self.encode_txt(
-                    setting.unicode_value
-                )
-
                 fd.write(
                     "    %s:%s\n"
                     % (
-                        six.text_type(encoded_setting_text),
-                        six.text_type(encoded_unicode_value),
+                        six.text_type(setting_text),
+                        six.text_type(setting.unicode_value),
                     )
                 )
         if save_image_plane_details:


### PR DESCRIPTION
when exporting cppipe, it will no longer encode :|[]\ into \x__ sequences
also bumped up cppipe format versioning

This PR is meant to work in conjunction with PR https://github.com/CellProfiler/CellProfiler/pull/3766 but was separated to make it easier to scrap if incorrect.

@0x00b1 @AetherUnbound @bethac07 