### PR TITLE
JAVA_HOME

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
       - run: sudo apt-get install default-jdk libgstreamer-plugins-base1.0-dev libgtk-3-dev libhdf5-serial-dev
       - run: sudo -H pip install --progress-bar off cython numpy
       - run: sudo -H pip install --find-links https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-18.04 wxpython
+      - run: echo 'export JAVA_HOME=/usr/lib/jvm/default-java' >> $BASH_ENV
       - run: sudo -H pip install --progress-bar off .[test]
       - run: py.test
 workflows:


### PR DESCRIPTION
javabridge setup was unable to find JAVA_HOME so setting to /usr/lib/jvm/default-java

using https://circleci.com/gh/CellProfiler/CellProfiler/304?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link as reference