### PR TITLE
Revert to saved confirmation, fix module window placement, help updates

### DIFF
--- a/cellprofiler/data/help/other_plugins.rst
+++ b/cellprofiler/data/help/other_plugins.rst
@@ -25,7 +25,7 @@ directory to the folder containing your new module(s).  Once you've done so,
 simply restart CellProfiler; if the module loads correctly then you should be 
 able to see it in the list of modules and add it to your pipeline. 
 If it does not load correctly, we encourage you to please check the log (see 
-*Help > Configuring Logging* ) for more information then check for known issues 
+*Help > Other Features > Configuring Logging* ) for more information then check for known issues 
 and/or notify us on the `issues`_ page or the CellProfiler `forum`_.
 
 Additionally, if you write your own module based on our `recommendations`_, you

--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -2358,7 +2358,10 @@ class PipelineController(object):
     def __on_add_module(self, event):
         if not self.__add_module_frame.IsShownOnScreen():
             x, y = self.__frame.GetPosition()
-            x = max(x - self.__add_module_frame.GetSize().width, 0)
+            if x > self.__add_module_frame.GetSize().width:
+                x -= self.__add_module_frame.GetSize().width
+            else:
+                x += self.__module_controls_panel.GetSize().width
             self.__add_module_frame.SetPosition((x, y))
         self.__add_module_frame.Show()
         self.__add_module_frame.Raise()

--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -689,7 +689,16 @@ class PipelineController(object):
     def __on_revert_workspace(self, event):
         path = cellprofiler.preferences.get_current_workspace_path()
         if path is not None:
-            self.do_open_workspace(path)
+            if (
+            wx.MessageBox(
+                "Do you really want to revert all unsaved changes?",
+                "Revert to saved file",
+                wx.YES_NO | wx.ICON_QUESTION,
+                self.__frame,
+            )
+            == wx.YES
+        ):
+                self.do_open_workspace(path)
 
     def do_open_workspace_dlg(self):
         """Display the open workspace dialog, returning the chosen file

--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -668,9 +668,9 @@ class PipelineController(object):
     def show_test_controls(self):
         """Show the controls for dealing with test mode"""
         self.__test_controls_panel.GetSizer().Show(self.__tcp_test_sizer)
+        self.__test_controls_panel.Layout()
         self.__test_controls_panel.GetSizer().Hide(self.__tcp_launch_sizer)
         self.__test_controls_panel.GetSizer().Hide(self.__tcp_analysis_sizer)
-        self.__test_controls_panel.Layout()
         self.__test_controls_panel.GetParent().Layout()
         self.__frame.enable_debug_commands()
 

--- a/cellprofiler/modules/morphologicalskeleton.py
+++ b/cellprofiler/modules/morphologicalskeleton.py
@@ -14,7 +14,7 @@ Supports 2D? Supports 3D? Respects masks?
 YES          YES          NO
 ============ ============ ===============
 
-.. _this tutorial: http://scikit-image.org/docs/dev/auto_examples/xx_applications/plot_morphology.html#skeletonize
+.. _this tutorial: https://scikit-image.org/docs/0.14.x/auto_examples/xx_applications/plot_morphology.html#skeletonize
 
 """
 


### PR DESCRIPTION
Per Nasim's suggestion - the "Revert to saved" button is right next to the standard save buttons, so a yes/no confirmation dialog would avoid frustration when people mis-click (as just happened). I've tried to add one!