### PR TITLE
MaskObjects with objects is broken in Master

### DIFF
--- a/cellprofiler/modules/maskobjects.py
+++ b/cellprofiler/modules/maskobjects.py
@@ -439,8 +439,8 @@ controls how remaining objects are associated with their predecessors:
         # and the outlines of removed objects red.
         #
         final_outlines = outline(final_labels) > 0
-        original_color = np.array(cpprefs.get_secondary_outline_color(), float) / 255
-        final_color = np.array(cpprefs.get_primary_outline_color(), float) / 255
+        original_color = np.array(cpprefs.get_secondary_outline_color()[0:3], float) / 255
+        final_color = np.array(cpprefs.get_primary_outline_color()[0:3], float) / 255
         image[outlines, :] = original_color[np.newaxis, :]
         image[final_outlines, :] = final_color[np.newaxis, :]
 

--- a/cellprofiler/workspace.py
+++ b/cellprofiler/workspace.py
@@ -492,7 +492,7 @@ class Workspace(object):
         for key in hdf5src:
             obj = hdf5src[key]
             if isinstance(obj, h5py.Dataset):
-                hdf5dest[key] = obj.value
+                hdf5dest[key] = obj[()]
             else:
                 hdf5src.copy(hdf5src[key], hdf5dest, key)
         for key in hdf5src.attrs:


### PR DESCRIPTION
Turns out the presence of an alpha channel value in the result from get_secondary_outline_color was causing this. It was fine in Python 2, but using this with numpy in Python 3 throws an error because of the extra data. This should be the only module in which this occurs.

Also corrected a h5py deprecation warning, didn't think it was worth another branch.