### PR TITLE
Inform user which image is active for interactive modules

### DIFF
--- a/cellprofiler/gui/editobjectsdlg.py
+++ b/cellprofiler/gui/editobjectsdlg.py
@@ -37,7 +37,7 @@ class EditObjectsDialog(wx.Dialog):
     no labels matrix is provided, initially, there are no objects. If there
     is no guide image, a black background is displayed.
 
-    The resutls of EditObjectsDialog are available in the "labels" attribute
+    The results of EditObjectsDialog are available in the "labels" attribute
     if the return code is wx.OK.
     """
 

--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -3473,7 +3473,7 @@ class PipelineController(object):
 
             def cancel_handler(cancelled=None):
                 if cancelled is None:
-                    cancelled = cancelled
+                    cancelled = []
                 cancelled[0] = True
 
             workspace.cancel_handler = cancel_handler

--- a/cellprofiler/modules/definegrid.py
+++ b/cellprofiler/modules/definegrid.py
@@ -243,7 +243,7 @@ entering the coordinates of the cells.
         )
 
         self.manual_image = cps.ImageNameSubscriber(
-            "Select the image to display",
+            "Select the image to display when drawing",
             cps.NONE,
             doc="""\
 *(Used only if you selected "%(AM_MANUAL)s" and "%(MAN_MOUSE)s" to define
@@ -571,7 +571,9 @@ first image.
             workspace.image_set.add(self.save_image_name.value, image)
 
     def get_background_image(self, workspace, gridding):
-        if self.display_image_name.value == cps.LEAVE_BLANK:
+        if self.auto_or_manual == AM_MANUAL and self.manual_choice == MAN_MOUSE and gridding is None:
+            image = workspace.image_set.get_image(self.manual_image.value).pixel_data
+        elif self.display_image_name.value == cps.LEAVE_BLANK:
             if gridding is None:
                 return None
             image = np.zeros(

--- a/cellprofiler/modules/definegrid.py
+++ b/cellprofiler/modules/definegrid.py
@@ -710,7 +710,7 @@ first image.
         #    status bar
         #
         figure = matplotlib.figure.Figure()
-        frame = wx.Dialog(wx.GetApp().TopWindow, title="Select grid cells")
+        frame = wx.Dialog(wx.GetApp().TopWindow, title="Select grid cells, image cycle #%d:" % (image_set_number))
         top_sizer = wx.BoxSizer(wx.VERTICAL)
         frame.SetSizer(top_sizer)
         canvas = backend.FigureCanvasWxAgg(frame, -1, figure)

--- a/cellprofiler/modules/flipandrotate.py
+++ b/cellprofiler/modules/flipandrotate.py
@@ -279,7 +279,7 @@ negative as clockwise."""
                 ):
                     angle = d[D_ANGLE]
                 else:
-                    angle = workspace.interaction_request(self, pixel_data)
+                    angle = workspace.interaction_request(self, pixel_data, workspace.measurements.image_set_number)
                 if self.how_often == IO_ONCE:
                     d[D_ANGLE] = angle
             else:
@@ -404,7 +404,7 @@ negative as clockwise."""
                 sharexy=figure.subplot(0, 0),
             )
 
-    def handle_interaction(self, pixel_data):
+    def handle_interaction(self, pixel_data, image_set_number):
         """Run a UI that gets an angle from the user"""
         import wx
 
@@ -430,7 +430,8 @@ negative as clockwise."""
         #
         # Make a dialog box that contains the image
         #
-        dialog = wx.Dialog(None, title="Rotate image")
+        dialog_title = "Rotate image - Cycle #%d:" % (image_set_number)
+        dialog = wx.Dialog(None, title=dialog_title)
         sizer = wx.BoxSizer(wx.VERTICAL)
         dialog.SetSizer(sizer)
         sizer.Add(

--- a/cellprofiler/modules/flipandrotate.py
+++ b/cellprofiler/modules/flipandrotate.py
@@ -474,7 +474,7 @@ negative as clockwise."""
                 )
             )
             buff = x.astype(np.uint8).tostring()
-            bitmap = wx.BitmapFromBuffer(x.shape[1], x.shape[0], buff)
+            bitmap = wx.Bitmap.FromBuffer(x.shape[1], x.shape[0], buff)
             canvas.SetBitmap(bitmap)
 
         imshow()
@@ -483,12 +483,12 @@ negative as clockwise."""
         #
         dragging = [False]
         initial_angle = [0]
-        hand_cursor = wx.StockCursor(wx.CURSOR_HAND)
-        arrow_cursor = wx.StockCursor(wx.CURSOR_ARROW)
+        hand_cursor = wx.Cursor(wx.CURSOR_HAND)
+        arrow_cursor = wx.Cursor(wx.CURSOR_ARROW)
 
         def get_angle(event):
             center = np.array(canvas.Size) / 2
-            point = np.array(event.GetPositionTuple())
+            point = np.array(event.GetPosition())
             offset = point - center
             return -np.arctan2(offset[1], offset[0]) * 180.0 / np.pi
 

--- a/cellprofiler/object.py
+++ b/cellprofiler/object.py
@@ -876,7 +876,7 @@ class Segmentation(object):
         counts = counts[mask]
         if len(counts) == 0:
             dense = numpy.zeros([1] + list(self.shape), labels.dtype)
-            dense[[0] + positional_columns] = labels
+            dense[tuple([0] + positional_columns)] = labels
             return self.__set_dense(dense)
         #
         # There are n * n-1 pairs for each coordinate (n = # labels)


### PR DESCRIPTION
Resolves #1167.

I've made some fixes to get these modules running properly in CP4. I've made is so that manual editing popup windows will display the current cycle number in the titlebar, since these lack subplots which would show the normal title. This was already done for some of the modules.

While showing the full filename would be nice to have, this may not be trivial since these modules don't necessarily operate on an input image that has such a name. If that's in high demand it may be something to raise in the future.