### PR TITLE
Can’t set "Manual" bit depth for more than one image

### DIFF
--- a/cellprofiler/modules/namesandtypes.py
+++ b/cellprofiler/modules/namesandtypes.py
@@ -1020,7 +1020,7 @@ requests an object selection.
                 ):
                     result += [assignment.rescale]
                     if assignment.rescale == INTENSITY_MANUAL:
-                        result += [self.manual_rescale]
+                        result += [assignment.manual_rescale]
                 result += [assignment.copy_button]
                 if assignment.can_remove:
                     result += [assignment.remover]


### PR DESCRIPTION
Fixes #2095. NamesAndTypes was trying to add the global "manual bit depth" setting rather than the specific image's.