### PR TITLE
Disable mousewheel on dropdown menus

### DIFF
--- a/cellprofiler/gui/moduleview.py
+++ b/cellprofiler/gui/moduleview.py
@@ -857,6 +857,10 @@ class ModuleView(object):
             def callback(event, setting=v, control=control):
                 self.__on_combobox_change(event, setting, control)
 
+            def ignore_mousewheel(event):
+                return
+
+            control.Bind(wx.EVT_MOUSEWHEEL, ignore_mousewheel)
             self.__module_panel.Bind(wx.EVT_COMBOBOX, callback, control)
             if style == wx.CB_DROPDOWN:
 
@@ -1176,6 +1180,10 @@ class ModuleView(object):
             def callback(event, setting=v, control=combo):
                 self.__on_combobox_change(event, setting, combo)
 
+            def ignore_mousewheel(event):
+                return
+
+            combo.Bind(wx.EVT_MOUSEWHEEL, ignore_mousewheel)
             self.__module_panel.Bind(wx.EVT_COMBOBOX, callback, combo)
         else:
             combo = control.FindWindowByName(combobox_ctrl_name(v))
@@ -2039,7 +2047,11 @@ class ModuleView(object):
                 self.notify(setting_edited_event)
                 self.reset_view()
 
+            def ignore_mousewheel(evt):
+                return
+
             for ctrl in (category_ctrl, feature_ctrl, object_ctrl, scale_ctrl):
+                panel.Bind(wx.EVT_MOUSEWHEEL, ignore_mousewheel)
                 panel.Bind(wx.EVT_COMBOBOX, on_change, ctrl)
         else:
             #

--- a/cellprofiler/gui/moduleview.py
+++ b/cellprofiler/gui/moduleview.py
@@ -1832,6 +1832,9 @@ class ModuleView(object):
             )
             sizer.Add(absrel_ctrl, 0, wx.EXPAND | wx.RIGHT, 1)
 
+            def ignore_mousewheel(event):
+                return
+
             def on_min_change(event, setting=v, control=min_ctrl):
                 if not self.__handle_change:
                     return
@@ -1843,6 +1846,7 @@ class ModuleView(object):
                 self.fit_ctrl(control)
 
             self.__module_panel.Bind(wx.EVT_TEXT, on_min_change, min_ctrl)
+            absrel_ctrl.Bind(wx.EVT_MOUSEWHEEL, ignore_mousewheel)
 
             def on_max_change(
                 event, setting=v, control=max_ctrl, absrel_ctrl=absrel_ctrl
@@ -2715,6 +2719,7 @@ class FilterPanelController(object):
             wx.EVT_CHOICE,
             lambda event: self.on_predicate_changed(event, index, address),
         )
+        choice_ctrl.Bind(wx.EVT_MOUSEWHEEL, self.ignore_mousewheel)
         self.add_to_sizer(sizer, choice_ctrl, index, address)
         return choice_ctrl
 
@@ -2832,6 +2837,7 @@ class FilterPanelController(object):
             name=self.anyall_choice_name(address),
         )
         anyall.Bind(wx.EVT_CHOICE, lambda event: self.on_anyall_changed(event, address))
+        anyall.Bind(wx.EVT_MOUSEWHEEL, self.ignore_mousewheel)
         return anyall
 
     def on_anyall_changed(self, event, address):
@@ -2984,6 +2990,9 @@ class FilterPanelController(object):
 
     def static_text_name(self, index, address):
         return "%s_static_text_%d_%s" % (self.key, index, self.saddress(address))
+
+    def ignore_mousewheel(self, event):
+        return
 
 
 class FileCollectionDisplayController(object):

--- a/cellprofiler/gui/namesubscriber.py
+++ b/cellprofiler/gui/namesubscriber.py
@@ -75,10 +75,14 @@ class NameSubscriberComboBox(wx.Panel):
 
         self.combo_dlg.Bind(wx.EVT_COMBOBOX, self.choice_made)
         self.combo_dlg.Bind(wx.EVT_RIGHT_DOWN, self.right_menu)
+        self.combo_dlg.Bind(wx.EVT_MOUSEWHEEL, self.ignore_mousewheel)
         for child in self.combo_dlg.Children:
             # Mac implements read_only combobox as a choice in a child
             child.Bind(wx.EVT_RIGHT_DOWN, self.right_menu)
         self.callbacks = []
+
+    def ignore_mousewheel(self, event):
+        return
 
     def choice_made(self, evt):
         choice = self.orig_choices[self.combo_dlg.GetSelection()]


### PR DESCRIPTION
Closes #2363. Closes #3726.

This is a common problem seen when training users - using the scroll wheel while hovering over a dropdown menu will change the selected item. Users tend to scroll down module settings panels quickly and accidentally change settings while doing so because of this. This change will ignore mousewheel events over such widgets.