### PR TITLE
Notes don't save in 3.1.8

### DIFF
--- a/cellprofiler/gui/moduleview.py
+++ b/cellprofiler/gui/moduleview.py
@@ -775,6 +775,7 @@ class ModuleView(object):
             if self.__module is not None:
                 notes = self.module_notes_control.GetValue()
                 self.__module.notes = notes.split("\n")
+                self.notify(SettingEditedEvent("module_notes", self.__module, notes, event))
 
         self.notes_panel.Bind(wx.EVT_TEXT, on_notes_changed, self.module_notes_control)
 

--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -2720,6 +2720,10 @@ class PipelineController(object):
             % (str(event))
         )
         setting = event.get_setting()
+        if setting == "module_notes":
+            self.__dirty_workspace = True
+            self.set_title()
+            return
         proposed_value = event.get_proposed_value()
         setting.set_value_text(proposed_value)
         module = event.get_module()

--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -2723,6 +2723,7 @@ class PipelineController(object):
         if setting == "module_notes":
             self.__dirty_workspace = True
             self.set_title()
+            self.__pipeline.edit_module(event.get_module().module_num, False)
             return
         proposed_value = event.get_proposed_value()
         setting.set_value_text(proposed_value)


### PR DESCRIPTION
Fixes #3839

Notes aren't considered as a 'real' setting and so only changing notes in a pipeline wasn't registered as something to save. I've made editing notes trigger part of the settings event handling sequence. This might not be particularly slick but works without having to give notes all the attributes proper settings have.