### PR TITLE
Fix figure display padding issues

### DIFF
--- a/cellprofiler/gui/figure.py
+++ b/cellprofiler/gui/figure.py
@@ -364,7 +364,8 @@ class Figure(wx.Frame):
         self.widgets = []
         self.mouse_down = None
         self.remove_menu = []
-        self.figure = matplotlib.pyplot.Figure()
+        self.figure = matplotlib.pyplot.Figure(constrained_layout=True)
+        self.figure.set_constrained_layout_pads(w_pad=0.1, h_pad=0.05, wspace=0, hspace=0)
         self.panel = matplotlib.backends.backend_wxagg.FigureCanvasWxAgg(
             self, -1, self.figure
         )
@@ -941,6 +942,7 @@ class Figure(wx.Frame):
         else:
             if dimensions == 2:
                 self.subplots = numpy.zeros(subplots, dtype=object)
+                self.gridspec = matplotlib.gridspec.GridSpec(subplots[1], subplots[0], figure=self.figure)
             else:
                 self.set_grids(subplots)
 
@@ -957,13 +959,17 @@ class Figure(wx.Frame):
         """
         if self.dimensions == 3:
             return None
-
         if not self.subplots[x, y]:
-            rows, cols = self.subplots.shape
-
-            plot = self.figure.add_subplot(
-                cols, rows, x + y * rows + 1, sharex=sharex, sharey=sharey
-            )
+            if self.gridspec:
+                # Add the plot to a premade subplot layout
+                plot = self.figure.add_subplot(
+                    self.gridspec[y,x], sharex=sharex, sharey=sharey,
+                )
+            else:
+                rows, cols = self.subplots.shape
+                plot = self.figure.add_subplot(
+                    cols, rows, x + y * rows + 1, sharex=sharex, sharey=sharey
+                )
 
             self.subplots[x, y] = plot
 

--- a/cellprofiler/gui/figure.py
+++ b/cellprofiler/gui/figure.py
@@ -1596,7 +1596,7 @@ class Figure(wx.Frame):
             subplot = self.subplot(x, y, sharex=sharex, sharey=sharey)
             subplot.set_adjustable("box", True)
             subplot.plot([0, 0], list(image.shape[:2]), "k")
-            subplot.set_xlim([-0.5, image.shape[1] - 0.5])
+            subplot.set_xlim([0, image.shape[1]])
             subplot.set_ylim([image.shape[0] - 0.5, -0.5])
             subplot.set_aspect("equal")
 

--- a/cellprofiler/gui/figure.py
+++ b/cellprofiler/gui/figure.py
@@ -1363,6 +1363,7 @@ class Figure(wx.Frame):
 
     def set_grids(self, shape):
         self.__gridspec = matplotlib.gridspec.GridSpec(*shape[::-1])
+        self.figure.set_constrained_layout(False)
 
     def gridshow(
         self, x, y, image, title=None, colormap="gray", colorbar=False, normalize=True

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setuptools.setup(
         "javabridge>=1.0",
         "joblib>=0.13",
         "mahotas>=1.4",
-        "matplotlib>=2.0.0, !=2.1.0",
+        "matplotlib>=3.1.1",
         "mysqlclient==1.4.5",
         "numpy>=1.16",
         "prokaryote==2.4.1",


### PR DESCRIPTION
Resolves #2899 - in the figure window titles tend to overlap with axes and look bad.

As mentioned in the original thread, Matplotlib added a constrained_layout function to aid in displaying multiple subplots without elements overlapping. I've had a go at adding this to CellProfiler. There are some positives and negatives to this approach.

- Plot axes will no longer overlap with title text, instead maintaining a nice spacing.

- constrained_layout requires a predefined subplot grid rather than adding plots sequentially (As CP does). I've therefore made CP construct a GridSpec class when a module announces the number of subplots it needs. If this exists then plots will be applied to the GridSpec rather than straight onto the figure, allowing them to be laid out more neatly with the constrained function.

- Using this layout does mean that the plots are able to utilise far more of the figure window. I've added some padding, but the options are limited as the inbuilt padding also applies between subplots. One option might be to use a second GridSpec containing the one holding the subplots, or perhaps we could add some sort of border to the frame itself, but I'm not sure if bigger plots are a problem anyway?

- The main cost is much slower performance when resizing a window, as the positioning needs to be recalculated. I'm not sure if this can be improved.

- This may also interfere with the changes in #3903, will need to check this.

Thoughts welcome!