### PR TITLE
ExportToSpreadsheet tries to write into wrong folder

### DIFF
--- a/cellprofiler/setting.py
+++ b/cellprofiler/setting.py
@@ -503,10 +503,12 @@ class DirectoryPath(Text):
             and self.custom_path.find(r"\g<") != -1
         ):
             raise ValidationError("Metadata not supported for this setting", self)
-        if self.dir_choice == ABSOLUTE_FOLDER_NAME and (
-            (self.custom_path is None) or (len(self.custom_path) == 0)
-        ):
-            raise ValidationError("Please enter a valid path", self)
+        if self.dir_choice == ABSOLUTE_FOLDER_NAME:
+            if self.custom_path is None or len(self.custom_path) == 0:
+                raise ValidationError("Please enter a path", self)
+            elif os.path.join(self.custom_path, self.custom_path) != os.path.join(self.custom_path):
+                # Custom path does not stand alone (path.join removes previous units when adding a full path).
+                raise ValidationError("Please enter a valid, complete path", self)
 
 
 class FilenameText(Text):

--- a/cellprofiler/setting.py
+++ b/cellprofiler/setting.py
@@ -408,7 +408,7 @@ class DirectoryPath(Text):
         elif self.dir_choice == DEFAULT_OUTPUT_SUBFOLDER_NAME:
             root_directory = get_default_output_directory()
         elif self.dir_choice == ABSOLUTE_FOLDER_NAME:
-            root_directory = os.curdir
+            root_directory = get_default_output_directory()
         elif self.dir_choice == URL_FOLDER_NAME:
             root_directory = ""
         elif self.dir_choice == NO_FOLDER_NAME:


### PR DESCRIPTION
Fixes #3756.

For some reason the 'Elsewhere' option when selecting a file was set to fetch the current directory CellProfiler is running from as a base path. This causes problems on Windows as CP's workers don't have permissions to write to those folders.

When a path is generated CP attempts to join a starting directory to whatever the user entered in the subfolder box. Given that 'Elsewhere' should be a full folder path rather than just a subfolder, I've added a little more validation to check that whatever the user entered actually functions as a path on it's own. This still won't fully check write permissions because Windows, but it's at least a sanity check.

I've also changed the default 'starting' directory for 'Elsewhere' from the working directory to the default output folder. This shouldn't technically matter since a full path is required, but if somebody does manage to fool it any written files should at least end up within the output directory instead of in random locations. This default directory will also apply to selecting input files, but that's still better than the install folder. 

Note that javabridge seems to be broken in CP4 at the moment, so I've only been able to test these fixes in 3.1.9 and port them over. I don't anticipate problems though.