### PR TITLE
Weird behavior in EditObjectsManually "Undo" button

### DIFF
--- a/cellprofiler/gui/editobjectsdlg.py
+++ b/cellprofiler/gui/editobjectsdlg.py
@@ -224,7 +224,7 @@ class EditObjectsDialog(wx.Dialog):
         self.last_artist_save = artist_save
         self.last_to_keep = self.to_keep
         temp = cellprofiler.object.Objects()
-        temp.ijv = self.last_ijv
+        temp.set_ijv(self.last_ijv, shape=self.shape)
         self.labels = [l for l, c in temp.get_labels()]
         self.init_labels()
         #


### PR DESCRIPTION
A temporary objects matrix for running 'undo' was being constructed with the wrong shape. Should now match the main matrix used to store objects. I think that fixes #3683 and fixes #3814