### PR TITLE
Unlink subplot axes in Crop and Resize module results display.

### DIFF
--- a/cellprofiler/modules/crop.py
+++ b/cellprofiler/modules/crop.py
@@ -537,7 +537,6 @@ objects:
             0,
             cropped_pixel_data,
             self.cropped_image_name.value,
-            sharexy=figure.subplot(0, 0),
         )
 
     def get_measurement_columns(self, pipeline):

--- a/cellprofiler/modules/resize.py
+++ b/cellprofiler/modules/resize.py
@@ -421,8 +421,6 @@ resized with the same settings as the first image.""",
 
         figure.set_subplots((2, len(input_images)), dimensions=dimensions)
 
-        share_axes = figure.subplot(0, 0)
-
         for (
             i,
             (
@@ -447,7 +445,6 @@ resized with the same settings as the first image.""",
                     i,
                     input_image_pixels,
                     title=input_image_name,
-                    sharexy=None if i == 0 else share_axes,
                 )
 
                 figure.subplot_imshow(
@@ -455,7 +452,6 @@ resized with the same settings as the first image.""",
                     i,
                     output_image_pixels,
                     title=output_image_name,
-                    sharexy=share_axes,
                 )
             else:
                 figure.subplot_imshow_bw(
@@ -463,7 +459,6 @@ resized with the same settings as the first image.""",
                     i,
                     input_image_pixels,
                     title=input_image_name,
-                    sharexy=None if i == 0 else share_axes,
                 )
 
                 figure.subplot_imshow_bw(
@@ -471,7 +466,6 @@ resized with the same settings as the first image.""",
                     i,
                     output_image_pixels,
                     title=output_image_name,
-                    sharexy=share_axes,
                 )
 
     def upgrade_settings(


### PR DESCRIPTION
Resolves #3387. Forcing the same zoom levels tends to confuse users as it looks like the original image has been cropped or resized inappropriately. It's not immediately obvious that they can pan the original image and it's only showing the cropped area at the scale of the result image.