### PR TITLE
Fix RescaleIntensity crashing when told to scale a color image

### DIFF
--- a/cellprofiler/modules/rescaleintensity.py
+++ b/cellprofiler/modules/rescaleintensity.py
@@ -13,6 +13,11 @@ texture measurements derived from images that have been rescaled because
 certain options for this module do not preserve the relative intensities
 from image to image.
 
+As this module rescales data it will not attempt to normalize displayed previews
+(as this could appear to undo the scaling). As a result images rescaled
+to large ranges may appear washed out. To normalize values for viewing,
+right-click an image and choose an image contrast transform.
+
 |
 
 ============ ============ ===============

--- a/cellprofiler/modules/rescaleintensity.py
+++ b/cellprofiler/modules/rescaleintensity.py
@@ -14,8 +14,8 @@ certain options for this module do not preserve the relative intensities
 from image to image.
 
 As this module rescales data it will not attempt to normalize displayed previews
-(as this could appear to undo the scaling). As a result images rescaled
-to large ranges may appear washed out. To normalize values for viewing,
+(as this could make it appear that the scaling had done nothing). As a result images rescaled
+to large ranges may appear dim after scaling. To normalize values for viewing,
 right-click an image and choose an image contrast transform.
 
 |

--- a/cellprofiler/modules/rescaleintensity.py
+++ b/cellprofiler/modules/rescaleintensity.py
@@ -428,6 +428,32 @@ Select the measurement value to use as the divisor for the final image.
 
             workspace.display_data.dimensions = input_image.dimensions
 
+    def display(self, workspace, figure):
+        figure.set_subplots((2, 1))
+
+        figure.set_subplots(
+            dimensions=workspace.display_data.dimensions, subplots=(2,1)
+        )
+
+        figure.subplot_imshow(
+            image=workspace.display_data.x_data,
+            title=self.x_name.value,
+            normalize=False,
+            colormap="gray",
+            x=0,
+            y=0,
+        )
+
+        figure.subplot_imshow(
+            image=workspace.display_data.y_data,
+            sharexy=figure.subplot(0, 0),
+            title=self.y_name.value,
+            colormap="gray",
+            x=1,
+            y=0,
+        )
+
+
     def rescale(self, image, in_range, out_range=(0.0, 1.0)):
         data = 1.0 * image.pixel_data
 

--- a/cellprofiler/modules/rescaleintensity.py
+++ b/cellprofiler/modules/rescaleintensity.py
@@ -469,9 +469,8 @@ Select the measurement value to use as the divisor for the final image.
         data = input_image.pixel_data
         mask = input_image.mask
 
-        if len(data.shape) == len(mask.shape) + 1:
-            #Image is multi-channel
-            splitaxis = len(data.shape)-1
+        if input_image.multichannel:
+            splitaxis = data.ndim - 1
             singlechannels = numpy.split(data, data.shape[-1], splitaxis)
             newchannels = []
             for channel in singlechannels:

--- a/cellprofiler/modules/rescaleintensity.py
+++ b/cellprofiler/modules/rescaleintensity.py
@@ -450,6 +450,7 @@ Select the measurement value to use as the divisor for the final image.
             sharexy=figure.subplot(0, 0),
             title=self.y_name.value,
             colormap="gray",
+            normalize=False,
             x=1,
             y=0,
         )

--- a/cellprofiler/modules/rescaleintensity.py
+++ b/cellprofiler/modules/rescaleintensity.py
@@ -84,7 +84,8 @@ There are a number of options for rescaling the input image:
 -  *%(M_STRETCH)s:* Find the minimum and maximum values within the
    unmasked part of the image (or the whole image if there is no mask)
    and rescale every pixel so that the minimum has an intensity of zero
-   and the maximum has an intensity of one.
+   and the maximum has an intensity of one. If performed on color images
+   each channel will be considered separately.
 -  *%(M_MANUAL_INPUT_RANGE)s:* Pixels are scaled from an original range
    (which you provide) to the range 0 to 1. Options are
    available to handle values outside of the original range.


### PR DESCRIPTION
Fixes #3506.

I considered just adding a warning when trying to use a color image with this module, but it turns out that all the modes aside from 'stretch intensity' already worked just fine with color images. You might also imagine a scenario where a user wants to rescale their channels before splitting them.

I've made it so that if the input image has multiple colour channels the 'stretch intensity' mode will be applied to each channel individually. An alternative solution might be to have max intensity across all channels considered as the stretching 'target'. Either is better than the module just breaking when you do this.

I also noticed that the output display for RescaleIntensity was the default viewer. Since this includes intensity normalisation prior to display it seems to make it difficult to see the actual results of the module (it gets rescaled again for display). That's especially problematic for multi-colour images. I've added a dedicated display method which disables the normalisation. I'm not sure if we'll want this or not, since while it'll visualise rescaling of low values better the plots would look washed out if the resulting values exceed 1.0. - Thoughts welcome!