### PR TITLE
Make prepare_group work with grid modules

### DIFF
--- a/cellprofiler/pipeline.py
+++ b/cellprofiler/pipeline.py
@@ -2357,9 +2357,10 @@ class Pipeline(object):
                 image_set = m
                 object_set = cellprofiler.object.ObjectSet()
                 old_providers = list(image_set.providers)
+                grid_set = {}
                 for module in pipeline.modules():
                     w = cellprofiler.workspace.Workspace(
-                        self, module, image_set, object_set, m, image_set_list
+                        self, module, image_set, object_set, m, image_set_list, grids=grid_set
                     )
                     if module == stop_module:
                         yield w
@@ -2369,6 +2370,7 @@ class Pipeline(object):
                         break
                     else:
                         self.run_module(module, w)
+                        grid_set = w._Workspace__grid
                     if progress_dialog is not None:
                         should_continue, skip = progress_dialog.Update(i + 1)
                         if not should_continue:

--- a/cellprofiler/workspace.py
+++ b/cellprofiler/workspace.py
@@ -62,6 +62,7 @@ class Workspace(object):
         frame=None,
         create_new_window=False,
         outlines=None,
+        grids={},
     ):
         """Workspace constructor
 
@@ -88,7 +89,7 @@ class Workspace(object):
         self.__outlines = outlines
         self.__windows_used = []
         self.__create_new_window = create_new_window
-        self.__grid = {}
+        self.__grid = grids
         self.__disposition = DISPOSITION_CONTINUE
         self.__disposition_listeners = []
         self.__in_background = (


### PR DESCRIPTION
Closes #3196.

The pipeline in question was still throwing errors when trying to use "Max of all images". The pre-group workflow involves creating temporary workspaces for each module to figure out which images and stats will be generated, but this wasn't passing down any grids made as these aren't proper measurement groups. This would trip up on IdentifyObjectsInGrid since the temporary workspaces would be lacking the necessary grid maps. I've (a bit clunkily) allowed the pipeline pass grids between temporary workspaces to fix this issue.