### PR TITLE
Add context menu for handling multiple modules in pipeline list

### DIFF
--- a/cellprofiler/gui/cpframe.py
+++ b/cellprofiler/gui/cpframe.py
@@ -687,23 +687,23 @@ class CPFrame(wx.Frame):
         self.menu_edit.AppendSeparator()
         self.menu_edit.Append(
             ID_EDIT_MOVE_UP,
-            "Move Module &Up",
-            "Move module toward the start of the pipeline",
+            "Move Selected Modules &Up",
+            "Move selected modules toward the start of the pipeline",
         )
         self.menu_edit.Append(
             ID_EDIT_MOVE_DOWN,
-            "Move Module &Down",
-            "Move module toward the end of the pipeline",
+            "Move Selected Modules &Down",
+            "Move selected modules toward the end of the pipeline",
         )
         self.menu_edit.Append(
-            ID_EDIT_DELETE, "&Delete Module", "Delete selected modules"
+            ID_EDIT_DELETE, "&Delete Selected Modules", "Delete selected modules"
         )
         self.menu_edit.Append(
-            ID_EDIT_DUPLICATE, "Duplicate Module", "Duplicate selected modules"
+            ID_EDIT_DUPLICATE, "Duplicate Selected Modules", "Duplicate selected modules"
         )
         self.menu_edit.Append(
             ID_EDIT_ENABLE_MODULE,
-            "Disable Module",
+            "Disable Selected Modules",
             "Disable a module to skip it when running the pipeline",
         )
         self.menu_edit_add_module = wx.Menu()

--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -2598,12 +2598,19 @@ class PipelineController(object):
 
         event - an UpdateUIEvent for the item
         """
+        num_modules = len(self.__pipeline_list_view.get_selected_modules())
         active_module = self.__pipeline_list_view.get_active_module()
-        if active_module is not None:
+        if num_modules > 1:
             event.SetText(
-                "Disable module {}".format(active_module.module_num)
+                "Disable selected modules ({})".format(num_modules)
+                if self.__pipeline_list_view.get_selected_modules()[0].enabled
+                else "Enable selected modules ({})".format(num_modules)
+            )
+        elif active_module is not None:
+            event.SetText(
+                "Disable {} (#{})".format(active_module.module_name, active_module.module_num)
                 if active_module.enabled
-                else "Enable module {}".format(active_module.module_num)
+                else "Enable {} (#{})".format(active_module.module_name, active_module.module_num)
             )
         if active_module is None or active_module.is_input_module():
             event.Enable(False)
@@ -2613,6 +2620,16 @@ class PipelineController(object):
     def on_module_enable(self, event):
         """Toggle the active module's enable state"""
         active_module = self.__pipeline_list_view.get_active_module()
+        selected_modules = self.__pipeline_list_view.get_selected_modules()
+        if len(selected_modules) > 1:
+            if selected_modules[0].enabled:
+                for module in selected_modules:
+                    self.__pipeline.disable_module(module)
+            else:
+                for module in selected_modules:
+                    self.__pipeline.enable_module(module)
+            return
+
         if active_module is None:
             logger.warn(
                 "User managed to fire the enable/disable module event and no module was active"

--- a/cellprofiler/gui/pipelinelistview.py
+++ b/cellprofiler/gui/pipelinelistview.py
@@ -604,39 +604,54 @@ class PipelineListView(object):
         menu = wx.Menu()
         try:
             module = self.get_active_module()
+            num_modules = len(self.get_selected_modules())
             if self.list_ctrl.active_item is not None:
-                sub_menu = wx.Menu()
-                self.__controller.populate_edit_menu(sub_menu)
-                menu.AppendSubMenu(sub_menu, "&Add")
-                menu.Append(
-                    ID_EDIT_DELETE, "&Delete module {}".format(module.module_num)
-                )
-                menu.Append(
-                    ID_EDIT_DUPLICATE, "Duplicate module {}".format(module.module_num)
-                )
-                menu.Append(
-                    ID_EDIT_ENABLE_MODULE, "Enable module {}".format(module.module_num)
-                )
-                menu.Append(
-                    ID_HELP_MODULE, "&Help for module {}".format(module.module_num)
-                )
-                if self.__debug_mode:
-                    _, active_index = self.get_ctrl_and_index(module)
-                    _, debug_index = self.get_ctrl_and_index(
-                        self.get_current_debug_module()
+                if num_modules == 1:
+                    sub_menu = wx.Menu()
+                    self.__controller.populate_edit_menu(sub_menu)
+                    menu.AppendSubMenu(sub_menu, "&Add")
+                    menu.Append(
+                        ID_EDIT_DELETE, "&Delete {} (#{})".format(module.module_name, module.module_num)
+                    )
+                    menu.Append(
+                        ID_EDIT_DUPLICATE, "Duplicate {} (#{})".format(module.module_name, module.module_num)
+                    )
+                    menu.Append(
+                        ID_EDIT_ENABLE_MODULE, "Enable {} (#{})".format(module.module_name, module.module_num)
+                    )
+                    menu.Append(
+                        ID_HELP_MODULE, "&Help for {} (#{})".format(module.module_name, module.module_num)
+                    )
+                    if self.__debug_mode:
+                        _, active_index = self.get_ctrl_and_index(module)
+                        _, debug_index = self.get_ctrl_and_index(
+                            self.get_current_debug_module()
+                        )
+
+                        if active_index <= debug_index:
+                            menu.Append(
+                                ID_DEBUG_RUN_FROM_THIS_MODULE,
+                                "&Run from {} (#{})".format(module.module_name, module.module_num),
+                            )
+                            menu.Append(
+                                ID_DEBUG_STEP_FROM_THIS_MODULE,
+                                "&Step from {} (#{})".format(module.module_name, module.module_num),
+                            )
+                elif num_modules > 1:
+                    # Multiple modules are selected
+                    menu.Append(
+                        ID_EDIT_DELETE, "&Delete selected modules ({})".format(num_modules)
+                    )
+                    menu.Append(
+                        ID_EDIT_DUPLICATE, "Duplicate selected modules ({})".format(num_modules)
+                    )
+                    menu.Append(
+                        ID_EDIT_ENABLE_MODULE, "Enable selected modules ({})".format(num_modules)
                     )
 
-                    if active_index <= debug_index:
-                        menu.Append(
-                            ID_DEBUG_RUN_FROM_THIS_MODULE,
-                            "&Run from module {}".format(module.module_num),
-                        )
-                        menu.Append(
-                            ID_DEBUG_STEP_FROM_THIS_MODULE,
-                            "&Step from module {}".format(module.module_num),
-                        )
             else:
                 self.__controller.populate_edit_menu(menu)
+
             self.__frame.PopupMenu(menu)
         finally:
             menu.Destroy()


### PR DESCRIPTION
Resolves #3878 

Currently the right click menus on the module list allow a user to duplicate/delete/disable a module, however if multiple modules are selected some of these functions operate on all selected modules while others only edit the active module.

This change makes it so that having multiple modules selected will apply operations to all of them. To avoid menu clutter having multiple selections will only give context menu options that operate on multiple modules.

When selecting a single module I've also added a module's name to the menu options. So you see "Delete IdentifyPrimaryObjects (#4)" rather than "Delete Module 4". This should make it clearer which module is being operated on.