### PR TITLE
Prevent module duplication when dragging on mac

### DIFF
--- a/cellprofiler/gui/pipelinelistview.py
+++ b/cellprofiler/gui/pipelinelistview.py
@@ -671,7 +671,7 @@ class PipelineListView(object):
         try:
             result = drop_source.DoDragDrop(wx.Drag_AllowMove)
             self.drag_underway = False
-            if result == wx.DragMove:
+            if result in (wx.DragMove, wx.DragCopy):
                 for identifier in selected_module_ids:
                     for module in self.__pipeline.modules(False):
                         if module.id == identifier:


### PR DESCRIPTION
It seems that on mac dragging a module returns a wx DragCopy object rather than DragMove. On Windows this can be triggered by holding control when dragging, which does sometimes happen when selecting and moving multiple modules quickly.

This will disable module duplication by ctrl+drag, but fixes moving modules by dragging on mac. If ctrl+drag duplication was precious perhaps we could try making this OS-specific?