### PR TITLE
Fix settings bug

### DIFF
--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -2737,7 +2737,7 @@ class PipelineController(object):
             % (str(event))
         )
         setting = event.get_setting()
-        if setting == "module_notes":
+        if isinstance(setting, str) and setting == "module_notes":
             self.__dirty_workspace = True
             self.set_title()
             self.__pipeline.edit_module(event.get_module().module_num, False)


### PR DESCRIPTION
For some reason comparing a yes/no setting class to a string returns True, which broke settings updates. Sorry! This should be more robust.