### PR TITLE
Add ability to display accepted maxima to IdentifyPrimaryObjects

### DIFF
--- a/cellprofiler/modules/identifyprimaryobjects.py
+++ b/cellprofiler/modules/identifyprimaryobjects.py
@@ -1549,7 +1549,7 @@ If "*{NO}*" is selected, the following settings are used:
                     labels=[border_excluded_labeled_image],
                 ),
             ]
-            if self.want_plot_maxima:
+            if self.unclump_method != UN_NONE and self.watershed_method != WA_NONE and self.want_plot_maxima:
                 # Generate static colormap for alpha overlay
                 from matplotlib.colors import ListedColormap
                 cmap = ListedColormap(self.maxima_color.value)

--- a/cellprofiler/modules/identifyprimaryobjects.py
+++ b/cellprofiler/modules/identifyprimaryobjects.py
@@ -275,7 +275,7 @@ OFF_ADAPTIVE_WINDOW_SIZE_V9 = 33
 OFF_FILL_HOLES_V10 = 12
 
 """The number of settings, exclusive of threshold settings"""
-N_SETTINGS = 16
+N_SETTINGS = 18
 
 UN_INTENSITY = "Intensity"
 UN_SHAPE = "Shape"
@@ -290,6 +290,8 @@ WA_NONE = "None"
 LIMIT_NONE = "Continue"
 LIMIT_TRUNCATE = "Truncate"
 LIMIT_ERASE = "Erase"
+
+DEFAULT_MAXIMA_COLOR = "Blue"
 
 """Never fill holes"""
 FH_NEVER = "Never"
@@ -319,7 +321,7 @@ SHAPE_DECLUMPING_ICON = cellprofiler.gui.help.content.image_resource(
 
 
 class IdentifyPrimaryObjects(cellprofiler.module.ImageSegmentation):
-    variable_revision_number = 13
+    variable_revision_number = 14
 
     category = "Object Processing"
 
@@ -794,7 +796,7 @@ documentation for the previous setting for details.""",
 
         self.maxima_color = cellprofiler.setting.Color(
             "Select maxima color",
-            "Blue",
+            DEFAULT_MAXIMA_COLOR,
             doc="Maxima will be displayed in this color.",
         )
 
@@ -872,10 +874,10 @@ If "*{NO}*" is selected, the following settings are used:
             self.fill_holes,
             self.automatic_smoothing,
             self.automatic_suppression,
-            self.want_plot_maxima,
-            self.maxima_color,
             self.limit_choice,
             self.maximum_object_count,
+            self.want_plot_maxima,
+            self.maxima_color,
             self.use_advanced,
         ]
 
@@ -931,6 +933,15 @@ If "*{NO}*" is selected, the following settings are used:
             setting_values = new_setting_values
 
             variable_revision_number = 13
+
+        if variable_revision_number == 13:
+            new_setting_values = setting_values[: N_SETTINGS - 3]
+            new_setting_values += [cellprofiler.setting.NO, DEFAULT_MAXIMA_COLOR]
+            new_setting_values += setting_values[N_SETTINGS - 3 :]
+
+            setting_values = new_setting_values
+
+            variable_revision_number = 14
 
         threshold_setting_values = setting_values[N_SETTINGS:]
 


### PR DESCRIPTION
Closes #3907

As suggested by @DeboraOlivier, advanced users would appreciate seeing more information to fine-tune their declumping parameters more quickly. I understand that we don't want to overcomplicate the settings and output window so I've just added maxima for now. While this won't display intermediate filtering steps as proposed, seeing the detected maxima should give a better idea of what those steps are doing and doesn't add large numbers of options to an already complex module. This setting will be disabled by default.

I've made the colour customisable but have that defaulting to blue. As maxima tend to be 1 pixel spots there's no single colour that will show obviously against both bright and dark backgrounds without zooming in, but this seems to make a nice compromise.