### PR TITLE
Fix RelateObjects Tests

### DIFF
--- a/tests/modules/test_relateobjects.py
+++ b/tests/modules/test_relateobjects.py
@@ -1,4 +1,5 @@
 import numpy
+import unittest
 
 import cellprofiler.image
 import cellprofiler.measurement
@@ -48,53 +49,49 @@ class TestRelateObjects(unittest.TestCase):
             cellprofiler.modules.relateobjects.D_NONE
         )
         module.wants_child_objects_saved.value = False
-        module.module_num = 2 if fake_measurement else 1
+        new_module_num = 2 if fake_measurement else 1
+        module.set_module_num(new_module_num)
         pipeline.add_module(module)
-    module = cellprofiler.modules.relateobjects.Relate()
-    module.x_name.value = PARENT_OBJECTS
-    module.x_child_name.value = CHILD_OBJECTS
-    module.find_parent_child_distances.value = cellprofiler.modules.relateobjects.D_NONE
-    module.set_module_num(2) if fake_measurement else 1
-    pipeline.add_module(module)
-    object_set = cellprofiler.object.ObjectSet()
-    image_set_list = cellprofiler.image.ImageSetList()
-    image_set = image_set_list.get_image_set(0)
-    m = cellprofiler.measurement.Measurements()
-    m.add_image_measurement(cellprofiler.measurement.GROUP_NUMBER, 1)
-    m.add_image_measurement(cellprofiler.measurement.GROUP_INDEX, 1)
-    workspace = cellprofiler.workspace.Workspace(
-        pipeline, module, image_set, object_set, m, image_set_list
-    )
-    o = cellprofiler.object.Objects()
-    if parents.shape[1] == 3:
-        # IJV format
-        o.ijv = parents
-    else:
-        o.segmented = parents
-    object_set.add_objects(o, PARENT_OBJECTS)
-    o = cellprofiler.object.Objects()
-    if children.shape[1] == 3:
-        o.ijv = children
-    else:
-        o.segmented = children
-    object_set.add_objects(o, CHILD_OBJECTS)
-    return workspace, module
+        object_set = cellprofiler.object.ObjectSet()
+        image_set_list = cellprofiler.image.ImageSetList()
+        image_set = image_set_list.get_image_set(0)
+        m = cellprofiler.measurement.Measurements()
+        m.add_image_measurement(cellprofiler.measurement.GROUP_NUMBER, 1)
+        m.add_image_measurement(cellprofiler.measurement.GROUP_INDEX, 1)
+        workspace = cellprofiler.workspace.Workspace(
+            pipeline, module, image_set, object_set, m, image_set_list
+        )
+        o = cellprofiler.object.Objects()
+        if parents.shape[1] == 3:
+            # IJV format
+            o.ijv = parents
+        else:
+            o.segmented = parents
+        object_set.add_objects(o, PARENT_OBJECTS)
+        o = cellprofiler.object.Objects()
+        if children.shape[1] == 3:
+            o.ijv = children
+        else:
+            o.segmented = children
+        object_set.add_objects(o, CHILD_OBJECTS)
+        return workspace, module
 
-
-def features_and_columns_match(workspace):
-    module = workspace.module
-    pipeline = workspace.pipeline
-    measurements = workspace.measurements
-    object_names = [
-        x
-        for x in measurements.get_object_names()
-        if x != cellprofiler.measurement.IMAGE
-    ]
-    features = [
-        [
+    def features_and_columns_match(self, workspace):
+        module = workspace.module
+        pipeline = workspace.pipeline
+        measurements = workspace.measurements
+        object_names = [
+            x
+            for x in measurements.get_object_names()
+            if x != cellprofiler.measurement.IMAGE
+        ]
+        features = [
+            [
             feature
             for feature in measurements.get_feature_names(object_name)
             if feature not in (MEASUREMENT, IGNORED_MEASUREMENT)
+        ]
+            for object_name in object_names
         ]
         columns = [
             x 
@@ -530,26 +527,30 @@ def test_relate_zeros_with_step_parent():
     actual = workspace.measurements.get_current_measurement(
         CHILD_OBJECTS, cellprofiler.modules.relateobjects.FF_MINIMUM % "Step"
     )
-        numpy.testing.assert_array_equal(actual, expected)
+    numpy.testing.assert_array_equal(actual, expected)
 
-     def test_relate_and_make_new_objects(self):
-        '''Relate one parent to one child, but save children as a new set'''
-        parent_labels = numpy.ones((10, 10), int)
-        child_labels = numpy.zeros((10, 10), int)
-        child_labels[3:5, 4:7] = 1
-        workspace, module = self.make_workspace(parent_labels, child_labels)
-        module.wants_child_objects_saved.value = True
-        module.output_child_objects_name.value = 'outputobjects'
-        module.wants_per_parent_means.value = False
-        module.run(workspace)
-        m = workspace.measurements
-        parents_of = m.get_current_measurement(CHILD_OBJECTS,
-                                               "Parent_%s" % PARENT_OBJECTS)
-        self.assertEqual(numpy.product(parents_of.shape), 1)
-        self.assertEqual(parents_of[0], 1)
-        child_count = m.get_current_measurement(PARENT_OBJECTS,
-                                                "Children_%s_Count" %
-                                                CHILD_OBJECTS)
-        self.assertEqual(numpy.product(child_count.shape), 1)
-        self.assertEqual(child_count[0], 1)
-        self.features_and_columns_match(workspace)
+def test_relate_and_make_new_objects(self):
+    '''Relate one parent to one child, but save children as a new set'''
+    parent_labels = numpy.ones((10, 10), int)
+    child_labels = numpy.zeros((10, 10), int)
+    child_labels[3:5, 4:7] = 1
+    workspace, module = self.make_workspace(parent_labels, child_labels)
+    module.wants_child_objects_saved.value = True
+    module.output_child_objects_name.value = 'outputobjects'
+    module.wants_per_parent_means.value = False
+    module.run(workspace)
+    m = workspace.measurements
+    parents_of = m.get_current_measurement(CHILD_OBJECTS,
+                                           "Parent_%s" % PARENT_OBJECTS)
+    self.assertEqual(numpy.product(parents_of.shape), 1)
+    self.assertEqual(parents_of[0], 1)
+    child_count = m.get_current_measurement(PARENT_OBJECTS,
+                                            "Children_%s_Count" %
+                                            CHILD_OBJECTS)
+    self.assertEqual(numpy.product(child_count.shape), 1)
+    self.assertEqual(child_count[0], 1)
+    self.features_and_columns_match(workspace)
+
+
+
+


### PR DESCRIPTION
Looks like something went badly wrong when merging #3832. Some of the tests weren't converted into class methods properly and others were duplicated. I believe I've got them all working again.