### PR TITLE
Fix pipeline list view error warnings

### DIFF
--- a/cellprofiler/setting.py
+++ b/cellprofiler/setting.py
@@ -4192,6 +4192,7 @@ class ValidationError(ValueError):
         """Initialize with an explanatory message and the setting that caused the problem
         """
         super(ValidationError, self).__init__(message)
+        self.message = message
         self.__setting = setting
 
     def get_setting(self):


### PR DESCRIPTION
Fixes #3929. Python 3 exceptions don't possess a .message by default.