### PR TITLE
Reset 'undo' functions when creating a new workspace.

### DIFF
--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -920,6 +920,7 @@ class PipelineController(object):
         self.__pipeline_list_view.select_one_module(1)
         self.enable_module_controls_panel_buttons()
         self.set_title()
+        self.__pipeline._Pipeline__undo_stack = []
 
     def __on_save_as_workspace(self, event):
         """Handle the Save Workspace As menu command"""


### PR DESCRIPTION
Fixes #3864. It turns out that trying to undo actions immediately after creating or loading a workspace would also break the undo button until CellProfiler is restarted. I've made it so that creating a new workspace clears the undo buffer.