### PR TITLE
Fix Random Image Set, add Random Image Group

### DIFF
--- a/cellprofiler/gui/cpframe.py
+++ b/cellprofiler/gui/cpframe.py
@@ -125,6 +125,7 @@ ID_DEBUG_NEXT_GROUP = wx.NewId()
 ID_DEBUG_CHOOSE_GROUP = wx.NewId()
 ID_DEBUG_CHOOSE_IMAGE_SET = wx.NewId()
 ID_DEBUG_CHOOSE_RANDOM_IMAGE_SET = wx.NewId()
+ID_DEBUG_CHOOSE_RANDOM_IMAGE_GROUP = wx.NewId()
 ID_DEBUG_RELOAD = wx.NewId()
 ID_DEBUG_PDB = wx.NewId()
 ID_DEBUG_RUN_FROM_THIS_MODULE = wx.NewId()
@@ -773,14 +774,19 @@ class CPFrame(wx.Frame):
             "Advance to a random image set",
         )
         self.__menu_debug.Append(
-            ID_DEBUG_CHOOSE_GROUP,
-            "Choose Image Group",
-            "Choose which image set group to process in test-mode",
+            ID_DEBUG_CHOOSE_RANDOM_IMAGE_GROUP,
+            "Random Image Group",
+            "Advance to a random image group",
         )
         self.__menu_debug.Append(
             ID_DEBUG_CHOOSE_IMAGE_SET,
             "Choose Image Set",
             "Choose any of the available image sets",
+        )
+        self.__menu_debug.Append(
+            ID_DEBUG_CHOOSE_GROUP,
+            "Choose Image Group",
+            "Choose which image set group to process in test-mode",
         )
         if not hasattr(sys, "frozen") or os.getenv("CELLPROFILER_DEBUG"):
             self.__menu_debug.Append(ID_DEBUG_RELOAD, "Reload Modules' Source")
@@ -796,6 +802,7 @@ class CPFrame(wx.Frame):
         self.__menu_debug.Enable(ID_DEBUG_CHOOSE_GROUP, False)
         self.__menu_debug.Enable(ID_DEBUG_CHOOSE_IMAGE_SET, False)
         self.__menu_debug.Enable(ID_DEBUG_CHOOSE_RANDOM_IMAGE_SET, False)
+        self.__menu_debug.Enable(ID_DEBUG_CHOOSE_RANDOM_IMAGE_GROUP, False)
 
         self.__menu_window = wx.Menu()
         self.__menu_window.Append(
@@ -1050,6 +1057,7 @@ class CPFrame(wx.Frame):
         ID_DEBUG_CHOOSE_GROUP,
         ID_DEBUG_CHOOSE_IMAGE_SET,
         ID_DEBUG_CHOOSE_RANDOM_IMAGE_SET,
+        ID_DEBUG_CHOOSE_RANDOM_IMAGE_GROUP,
     )
 
     def enable_debug_commands(self):

--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -325,6 +325,11 @@ class PipelineController(object):
         )
         frame.Bind(
             wx.EVT_MENU,
+            self.on_debug_random_image_group,
+            id=cellprofiler.gui.cpframe.ID_DEBUG_CHOOSE_RANDOM_IMAGE_GROUP,
+        )
+        frame.Bind(
+            wx.EVT_MENU,
             self.on_debug_reload,
             id=cellprofiler.gui.cpframe.ID_DEBUG_RELOAD,
         )
@@ -3647,21 +3652,30 @@ class PipelineController(object):
             )
 
     def on_debug_random_image_set(self, event):
-        group_index = (
-            0
-            if len(self.__groupings) == 1
-            else numpy.random.randint(0, len(self.__groupings) - 1, size=1)
-        )
-        keys, image_numbers = self.__groupings[group_index]
+        keys, image_numbers = self.__groupings[self.__grouping_index]
+        numpy.random.seed()
         if len(image_numbers) == 0:
             return
-        numpy.random.seed()
-        image_number_index = numpy.random.randint(1, len(image_numbers), size=1)[0]
-        self.__within_group_index = (image_number_index - 1) % len(image_numbers)
+        elif len(image_numbers) == 1:
+            self.__within_group_index = 0
+        else:
+            self.__within_group_index = numpy.random.randint(0, len(image_numbers))
         image_number = image_numbers[self.__within_group_index]
         self.__debug_measurements.next_image_set(image_number)
         self.debug_init_imageset()
         self.__debug_outlines = {}
+
+    def on_debug_random_image_group(self, event):
+        """Choose a group"""
+        if len(self.__groupings) < 2:
+            wx.MessageBox(
+                "There is only one group and it is currently running in test mode",
+                "Random image group",
+            )
+            return
+        numpy.random.seed()
+        group_index = numpy.random.randint(0, len(self.__groupings))
+        self.debug_choose_group(group_index)
 
     def debug_choose_group(self, index):
         self.__grouping_index = index

--- a/cellprofiler/modules/groups.py
+++ b/cellprofiler/modules/groups.py
@@ -444,8 +444,6 @@ desired behavior.
         if is_valid:
             if needs_prepare_run:
                 result = self.prepare_run(self.workspace)
-                if not result:
-                    return
             self.update_tables()
 
     def update_tables(self):


### PR DESCRIPTION
Fixes #2549. Related to #3873.

The logic in the original version of these commands was a bit weird.

It attempted to select a random image group but never actually set that group up to run, so random numbers were generated based on the length of a random group what wasn't running. I expect this is why the % operation was needed - so that if the proposed index was too high you'd still get a valid result, but this would then bias you towards low index numbers.

It also seems that in modern numpy specifying size=1 in numpy randomint forces it to return an array rather than a single int.

To resolve this I've revised the randomisation approach and split random into two functions - Random Image Set and Random Image Group. These use separate menu buttons. Random image set will now only randomise within the current group (which it did anyway but probably wasn't intended to). I imagine that keeping them separate gives the user more control than having them as a single function, since you can always click both and "I want a random field from only this group" is a common scenario.