### PR TITLE
Fix "Open A New CP Window"

### DIFF
--- a/cellprofiler/gui/cpframe.py
+++ b/cellprofiler/gui/cpframe.py
@@ -658,14 +658,15 @@ class CPFrame(wx.Frame):
         self.__menu_file.Append(
             ID_FILE_RUN_MULTIPLE_PIPELINES, "Run Multiple Pipelines"
         )
-        if os.name == "posix":
-            self.__menu_file.Append(ID_FILE_NEW_CP, "Open a New CP Window")
         self.__menu_file.Append(
             ID_FILE_RESTART,
             "Resume Pipeline",
             "Resume a pipeline from a saved measurements file.",
         )
         self.__menu_file.AppendSeparator()
+        if sys.platform == "darwin":
+            self.__menu_file.Append(ID_FILE_NEW_CP, "Open A New CP Window")
+            self.__menu_file.AppendSeparator()
         self.__menu_file.Append(
             ID_OPTIONS_PREFERENCES,
             "&Preferences...",
@@ -1113,12 +1114,10 @@ class CPFrame(wx.Frame):
 
     @staticmethod
     def __on_new_cp(event):
-        import os
-
-        if not hasattr(sys, "frozen"):
-            os.system("open CellProfiler_python.command")
+        if hasattr(sys, "frozen"):
+            os.system("open -na /Applications/CellProfiler-{}.app".format(cellprofiler.__version__))
         else:
-            os.system("open -na CellProfiler.app")
+            os.system("cellprofiler")
 
     def __on_help_path_list(self, event):
         import cellprofiler.gui.htmldialog

--- a/cellprofiler/gui/cpframe.py
+++ b/cellprofiler/gui/cpframe.py
@@ -1117,7 +1117,7 @@ class CPFrame(wx.Frame):
         if hasattr(sys, "frozen"):
             os.system("open -na /Applications/CellProfiler-{}.app".format(cellprofiler.__version__))
         else:
-            os.system("cellprofiler")
+            os.system("python3 -m cellprofiler")
 
     def __on_help_path_list(self, event):
         import cellprofiler.gui.htmldialog


### PR DESCRIPTION
Closes #3334, Closes #3359 and Closes #3735.

By somewhat popular demand, this menu button should now work. I've made it OSX-specific as opposed to OSX and Linux.

I've also moved the menu button to a more sensible spot rather than having it between the two pipeline running options.