### PR TITLE
[WIP] Revised GUI for selecting multiple image or object sets

### DIFF
--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -27,11 +27,19 @@ import cellprofiler.worker
 import cellprofiler.workspace
 
 if sys.platform.startswith("win") and hasattr(sys, "frozen"):
-    # For Windows builds, if JAVA_HOME is not already set, use the copy of Java packaged with CP
-    # We specify this location by setting 'CP_JAVA_HOME' at install.
+    # For Windows builds, use built-in Java for CellProfiler, otherwise try to use Java from elsewhere on the system.
+    # Users can use a custom java installation by removing CP_JAVA_HOME.
     # JAVA_HOME must be set before bioformats import.
-    if "JAVA_HOME" not in os.environ and "CP_JAVA_HOME" in os.environ:
-        os.environ["JAVA_HOME"] = os.environ["CP_JAVA_HOME"]
+    try:
+        if "CP_JAVA_HOME" in os.environ:
+            os.environ["JAVA_HOME"] = os.environ["CP_JAVA_HOME"]
+        assert "JAVA_HOME" in os.environ
+    except AssertionError:
+        print("CellProfiler Startup ERROR: Could not find path to Java environment directory.\n"
+              "Please set the CP_JAVA_HOME system environment variable.\n"
+              "Visit http://broad.io/cpjava for instructions.")
+        os.system("pause")  # Keep console window open until keypress.
+        os._exit(1)
 
 OMERO_CK_HOST = "host"
 OMERO_CK_PORT = "port"

--- a/cellprofiler/gui/cpframe.py
+++ b/cellprofiler/gui/cpframe.py
@@ -125,6 +125,7 @@ ID_DEBUG_NEXT_GROUP = wx.NewId()
 ID_DEBUG_CHOOSE_GROUP = wx.NewId()
 ID_DEBUG_CHOOSE_IMAGE_SET = wx.NewId()
 ID_DEBUG_CHOOSE_RANDOM_IMAGE_SET = wx.NewId()
+ID_DEBUG_CHOOSE_RANDOM_IMAGE_GROUP = wx.NewId()
 ID_DEBUG_RELOAD = wx.NewId()
 ID_DEBUG_PDB = wx.NewId()
 ID_DEBUG_RUN_FROM_THIS_MODULE = wx.NewId()
@@ -773,14 +774,19 @@ class CPFrame(wx.Frame):
             "Advance to a random image set",
         )
         self.__menu_debug.Append(
-            ID_DEBUG_CHOOSE_GROUP,
-            "Choose Image Group",
-            "Choose which image set group to process in test-mode",
+            ID_DEBUG_CHOOSE_RANDOM_IMAGE_GROUP,
+            "Random Image Group",
+            "Advance to a random image group",
         )
         self.__menu_debug.Append(
             ID_DEBUG_CHOOSE_IMAGE_SET,
             "Choose Image Set",
             "Choose any of the available image sets",
+        )
+        self.__menu_debug.Append(
+            ID_DEBUG_CHOOSE_GROUP,
+            "Choose Image Group",
+            "Choose which image set group to process in test-mode",
         )
         if not hasattr(sys, "frozen") or os.getenv("CELLPROFILER_DEBUG"):
             self.__menu_debug.Append(ID_DEBUG_RELOAD, "Reload Modules' Source")
@@ -796,6 +802,7 @@ class CPFrame(wx.Frame):
         self.__menu_debug.Enable(ID_DEBUG_CHOOSE_GROUP, False)
         self.__menu_debug.Enable(ID_DEBUG_CHOOSE_IMAGE_SET, False)
         self.__menu_debug.Enable(ID_DEBUG_CHOOSE_RANDOM_IMAGE_SET, False)
+        self.__menu_debug.Enable(ID_DEBUG_CHOOSE_RANDOM_IMAGE_GROUP, False)
 
         self.__menu_window = wx.Menu()
         self.__menu_window.Append(
@@ -1050,6 +1057,7 @@ class CPFrame(wx.Frame):
         ID_DEBUG_CHOOSE_GROUP,
         ID_DEBUG_CHOOSE_IMAGE_SET,
         ID_DEBUG_CHOOSE_RANDOM_IMAGE_SET,
+        ID_DEBUG_CHOOSE_RANDOM_IMAGE_GROUP,
     )
 
     def enable_debug_commands(self):

--- a/cellprofiler/gui/moduleview.py
+++ b/cellprofiler/gui/moduleview.py
@@ -2267,7 +2267,7 @@ class ModuleView(object):
     def __on_checklistbox_change(self, event, setting, control):
         if not self.__handle_change:
             return
-        self.on_value_change(setting, control, control.GetChecked(), event)
+        self.on_value_change(setting, control, control.GetChecked(), event, timeout=CHECK_TIMEOUT_SEC * 1000)
 
     def __on_multichoice_change(self, event, setting, control):
         if not self.__handle_change:

--- a/cellprofiler/gui/moduleview.py
+++ b/cellprofiler/gui/moduleview.py
@@ -516,7 +516,8 @@ class ModuleView(object):
                         v, v.get_choices(), control_name, wx.CB_READONLY, control
                     )
                     flag = wx.ALIGN_LEFT
-                elif isinstance(v, cellprofiler.setting.ListImageNameSubscriber):
+                elif isinstance(v, (cellprofiler.setting.ListImageNameSubscriber,
+                                   cellprofiler.setting.ListObjectNameSubscriber)):
                     choices = v.get_choices(self.__pipeline)
                     control = self.make_list_name_subscriber_control(
                         v, choices, control_name, control
@@ -835,7 +836,7 @@ class ModuleView(object):
         return control
 
     def make_list_name_subscriber_control(self, v, choices, control_name, control):
-        """Make a read-only combobox with extra feedback about source modules,
+        """Make a read-only combnobox with extra feedback about source modules,
         and a context menu with choices navigable by module name.
 
         v            - the setting
@@ -843,13 +844,12 @@ class ModuleView(object):
         control_name - assign this name to the control
         """
         if not control:
+            namelabel = "Image" if isinstance(v, cellprofiler.setting.ListImageNameSubscriber) else "Object"
             control = namesubscriber.NameSubscriberListBox(
-                self.__module_panel, checked=v.value, choices=choices, name=control_name
+                self.__module_panel, checked=v.value, choices=choices, name=control_name, nametype=namelabel,
             )
             def callback(event, setting=v, control=control):
-                # the NameSubscriberComboBox behaves like a combobox
                 self.__on_checklistbox_change(event, setting, control)
-
             control.add_callback(callback)
         else:
             if list(choices) != list(control.Items):

--- a/cellprofiler/gui/namesubscriber.py
+++ b/cellprofiler/gui/namesubscriber.py
@@ -178,6 +178,7 @@ class NameSubscriberComboBox(wx.Panel):
 
     Value = property(GetValue, SetValue)
 
+
 class NameSubscriberListBox(wx.Panel):
     """A list of checkboxes with extra annotation, and a context menu.
 
@@ -185,13 +186,13 @@ class NameSubscriberListBox(wx.Panel):
     multiple items.
     """
 
-    def __init__(self, annotation, choices=None, checked=[], name=""):
+    def __init__(self, annotation, choices=None, checked=[], name="", nametype="Image"):
         wx.Panel.__init__(self, annotation, name=name)
         if choices is None:
             choices = []
         self.checked = checked
         self.choice_names = self.get_choice_names(choices)
-
+        self.nametype = nametype
         self.list_dlg = wx.CheckListBox(
             self,
             choices=[self.get_choice_label(choice) for choice in choices],
@@ -224,7 +225,6 @@ class NameSubscriberListBox(wx.Panel):
         menu.Destroy()
 
     def select_all(self, evt):
-        print("Selecting all")
         self.SetChecked(self.choice_names)
         self.checked = self.GetChecked()
         for cb in self.callbacks:
@@ -237,7 +237,6 @@ class NameSubscriberListBox(wx.Panel):
             cb(evt)
 
     def item_selected(self, evt):
-        print("Selected item")
         selected = self.choice_names[evt.Selection]
         if self.list_dlg.IsChecked(evt.Selection):
             self.checked.remove(selected)
@@ -248,7 +247,6 @@ class NameSubscriberListBox(wx.Panel):
         for cb in self.callbacks:
             cb(evt)
         self.list_dlg.Deselect(evt.Selection)
-
 
     def choice_made(self, evt):
         for cb in self.callbacks:
@@ -264,11 +262,9 @@ class NameSubscriberListBox(wx.Panel):
             else:
                 end = "(from %s #%02d)" % (module_name, module_num)
         else:
-            end = "(Module Missing!)"
+            end = "(%s Missing!)" % self.nametype
         whitespace = " "*max(10, (90 - len(name) - len(end)))
         return "".join((name, whitespace, end))
-
-
 
     def get_choice_names(self, choices):
         choice_names = [choice[0] for choice in choices]

--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -2737,7 +2737,7 @@ class PipelineController(object):
             % (str(event))
         )
         setting = event.get_setting()
-        if setting == "module_notes":
+        if isinstance(setting, str) and setting == "module_notes":
             self.__dirty_workspace = True
             self.set_title()
             self.__pipeline.edit_module(event.get_module().module_num, False)

--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -325,6 +325,11 @@ class PipelineController(object):
         )
         frame.Bind(
             wx.EVT_MENU,
+            self.on_debug_random_image_group,
+            id=cellprofiler.gui.cpframe.ID_DEBUG_CHOOSE_RANDOM_IMAGE_GROUP,
+        )
+        frame.Bind(
+            wx.EVT_MENU,
             self.on_debug_reload,
             id=cellprofiler.gui.cpframe.ID_DEBUG_RELOAD,
         )
@@ -3634,21 +3639,30 @@ class PipelineController(object):
             )
 
     def on_debug_random_image_set(self, event):
-        group_index = (
-            0
-            if len(self.__groupings) == 1
-            else numpy.random.randint(0, len(self.__groupings) - 1, size=1)
-        )
-        keys, image_numbers = self.__groupings[group_index]
+        keys, image_numbers = self.__groupings[self.__grouping_index]
+        numpy.random.seed()
         if len(image_numbers) == 0:
             return
-        numpy.random.seed()
-        image_number_index = numpy.random.randint(1, len(image_numbers), size=1)[0]
-        self.__within_group_index = (image_number_index - 1) % len(image_numbers)
+        elif len(image_numbers) == 1:
+            self.__within_group_index = 0
+        else:
+            self.__within_group_index = numpy.random.randint(0, len(image_numbers))
         image_number = image_numbers[self.__within_group_index]
         self.__debug_measurements.next_image_set(image_number)
         self.debug_init_imageset()
         self.__debug_outlines = {}
+
+    def on_debug_random_image_group(self, event):
+        """Choose a group"""
+        if len(self.__groupings) < 2:
+            wx.MessageBox(
+                "There is only one group and it is currently running in test mode",
+                "Random image group",
+            )
+            return
+        numpy.random.seed()
+        group_index = numpy.random.randint(0, len(self.__groupings))
+        self.debug_choose_group(group_index)
 
     def debug_choose_group(self, index):
         self.__grouping_index = index

--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -2562,13 +2562,6 @@ class PipelineController(object):
             self.__pipeline.move_module(
                 module.module_num, cellprofiler.pipeline.DIRECTION_UP
             )
-        #
-        # Major event - restart from scratch
-        #
-        if self.is_in_debug_mode():
-            self.stop_debugging()
-            if cellprofiler.preferences.get_show_exiting_test_mode_dlg():
-                self.show_exiting_test_mode()
 
     def on_module_down(self, event):
         """Move the currently selected modules down"""
@@ -2585,13 +2578,6 @@ class PipelineController(object):
             self.__pipeline.move_module(
                 module.module_num, cellprofiler.pipeline.DIRECTION_DOWN
             )
-        #
-        # Major event - restart from scratch
-        #
-        if self.is_in_debug_mode():
-            self.stop_debugging()
-            if cellprofiler.preferences.get_show_exiting_test_mode_dlg():
-                self.show_exiting_test_mode()
 
     def on_update_module_enable(self, event):
         """Update the UI for the ENABLE_MODULE menu item / button

--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -3301,6 +3301,14 @@ class PipelineController(object):
 
     def on_stop_running(self, event):
         """Handle a user interface request to stop running"""
+        result = wx.MessageBox(
+            "Are you sure you want to abort this analysis run?",
+            "Stop analysis run",
+            wx.YES_NO | wx.ICON_QUESTION,
+            self.__frame,
+        )
+        if result == wx.NO:
+            return
         self.__stop_analysis_button.Enable(False)
         self.pipeline_list = []
         if (self.__analysis is not None) and self.__analysis.check_running():

--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -920,6 +920,7 @@ class PipelineController(object):
         self.__pipeline_list_view.select_one_module(1)
         self.enable_module_controls_panel_buttons()
         self.set_title()
+        self.__pipeline._Pipeline__undo_stack = []
 
     def __on_save_as_workspace(self, event):
         """Handle the Save Workspace As menu command"""

--- a/cellprofiler/gui/pipelinelistview.py
+++ b/cellprofiler/gui/pipelinelistview.py
@@ -1216,6 +1216,9 @@ class PipelineListCtrl(wx.ScrolledWindow):
         self.Bind(wx.EVT_KILL_FOCUS, self.on_focus_change)
         self.Bind(wx.EVT_SET_FOCUS, self.on_focus_change)
 
+    def AdjustScrollbars(self):
+        self.SetScrollbars(1, self.line_height, self.BestSize[0], len(self.items))
+
     def on_focus_change(self, event):
         self.Refresh(eraseBackground=False)
 

--- a/cellprofiler/gui/regexp_editor.py
+++ b/cellprofiler/gui/regexp_editor.py
@@ -272,7 +272,7 @@ class RegexpDialog(wx.Dialog):
         try:
             parse(self.__value, RegexpState())
         except ValueError as e:
-            self.test_display.Text = e.message
+            self.test_display.Text = e.args[0]
             self.test_display.StartStyling(0, 0xFF)
             self.test_display.SetStyling(len(self.test_display.Text), STYLE_ERROR)
             return

--- a/cellprofiler/modules/classifyobjects.py
+++ b/cellprofiler/modules/classifyobjects.py
@@ -852,7 +852,7 @@ example, to be saved by a **SaveImages** module).
         mapping[1:] = np.arange(1, nobjects + 1)
         for i in range(2):
             saved_values = workspace.display_data.saved_values[i]
-            mapping[np.isnan(saved_values)] = 0
+            mapping[1:][np.isnan(saved_values)] = 0
         labels = object_codes[mapping[workspace.display_data.labels]]
         figure.subplot_imshow_labels(0, 1, labels, title=object_name)
         #

--- a/cellprofiler/modules/correctilluminationapply.py
+++ b/cellprofiler/modules/correctilluminationapply.py
@@ -235,6 +235,19 @@ somewhat empirical.
         else:
             if illum_function_pixel_data.ndim == 2:
                 illum_function_pixel_data = illum_function_pixel_data[:, :, np.newaxis]
+        # Throw an error if image and illum data are incompatible
+        if orig_image.pixel_data.shape != illum_function_pixel_data.shape:
+            raise ValueError(
+                "This module requires that the image and illumination function have equal dimensions.\n"
+                "The %s image and %s illumination function do not (%s vs %s).\n"
+                "If they are paired correctly you may want to use the Resize or Crop module to make them the same size."
+                % (
+                    image_name,
+                    illum_correct_name,
+                    orig_image.pixel_data.shape,
+                    illum_function_pixel_data.shape,
+                )
+            )
         #
         # Either divide or subtract the illumination image from the original
         #

--- a/cellprofiler/modules/groups.py
+++ b/cellprofiler/modules/groups.py
@@ -444,8 +444,6 @@ desired behavior.
         if is_valid:
             if needs_prepare_run:
                 result = self.prepare_run(self.workspace)
-                if not result:
-                    return
             self.update_tables()
 
     def update_tables(self):

--- a/cellprofiler/modules/identifysecondaryobjects.py
+++ b/cellprofiler/modules/identifysecondaryobjects.py
@@ -524,6 +524,19 @@ segmentation.""",
         img = image.pixel_data
         mask = image.mask
         objects = workspace.object_set.get_objects(self.x_name.value)
+        if img.shape != objects.shape:
+            raise ValueError(
+                "This module requires that the input image and object sets are the same size.\n"
+                "The %s image and %s objects are not (%s vs %s).\n"
+                "If they are paired correctly you may want to use the Resize, ResizeObjects or "
+                "Crop module(s) to make them the same size."
+                % (
+                    image_name,
+                    self.x_name.value,
+                    img.shape,
+                    objects.shape,
+                )
+            )
         global_threshold = None
         if self.method == M_DISTANCE_N:
             has_threshold = False

--- a/cellprofiler/modules/identifytertiaryobjects.py
+++ b/cellprofiler/modules/identifytertiaryobjects.py
@@ -253,6 +253,21 @@ but the results will be zero or not-a-number (NaN).
                     tertiary_image, _ = cpo.size_similarly(
                         secondary_labels, tertiary_image
                     )
+        # If size/shape differences were too extreme, raise an error.
+        if primary_labels.shape != secondary_labels.shape:
+            raise ValueError(
+                "This module requires that the object sets have matching widths and matching heights.\n"
+                "The %s and %s objects do not (%s vs %s).\n"
+                "If they are paired correctly you may want to use the ResizeObjects module "
+                "to make them the same size."
+                % (
+                    self.secondary_objects_name,
+                    self.primary_objects_name,
+                    secondary_labels.shape,
+                    primary_labels.shape,
+                )
+            )
+
         #
         # Find the outlines of the primary image and use this to shrink the
         # primary image by one. This guarantees that there is something left

--- a/cellprofiler/modules/measureobjectintensity.py
+++ b/cellprofiler/modules/measureobjectintensity.py
@@ -206,16 +206,8 @@ class MeasureObjectIntensity(cellprofiler.module.Module):
             num_imgs = int(setting_values[0])
             images_list = setting_values[1:num_imgs+1]
             objects_list = setting_values[num_imgs+1:]
-            setting_values = [images_list, objects_list]
+            setting_values = [", ".join(map(str, images_list)), ", ".join(map(str, objects_list))]
             variable_revision_number = 4
-        else:
-            # Convert saved image and object lists back into python lists
-            for i in (0, 1):
-                to_convert = setting_values[i]
-                if to_convert == '[]':
-                    setting_values[i] = []
-                else:
-                    setting_values[i] = to_convert.replace('\'', '').strip('][').split(', ')
         return setting_values, variable_revision_number, from_matlab
 
     def validate_module(self, pipeline):

--- a/cellprofiler/modules/measureobjectsizeshape.py
+++ b/cellprofiler/modules/measureobjectsizeshape.py
@@ -217,7 +217,7 @@ F_STANDARD = [
 
 class MeasureObjectSizeShape(cellprofiler.module.Module):
     module_name = "MeasureObjectSizeShape"
-    variable_revision_number = 1
+    variable_revision_number = 2
     category = "Measurement"
 
     def create_settings(self):
@@ -226,13 +226,12 @@ class MeasureObjectSizeShape(cellprofiler.module.Module):
         The module allows for an unlimited number of measured objects, each
         of which has an entry in self.object_groups.
         """
-        self.object_groups = []
-        self.add_object(can_remove=False)
-        self.spacer = cellprofiler.setting.Divider(line=True)
-        self.add_objects = cellprofiler.setting.DoSomething(
-            "", "Add another object", self.add_object
+        self.objects_list = cellprofiler.setting.ListObjectNameSubscriber(
+            "Select object sets to measure",
+            [],
+            doc="""Select the object sets whose size and shape you want to measure.""",
         )
-
+        self.spacer = cellprofiler.setting.Divider(line=True)
         self.calculate_zernikes = cellprofiler.setting.Binary(
             text="Calculate the Zernike features?",
             value=True,
@@ -246,63 +245,25 @@ module.""".format(
             ),
         )
 
-    def add_object(self, can_remove=True):
-        """Add a slot for another object"""
-        group = cellprofiler.setting.SettingsGroup()
-        if can_remove:
-            group.append("divider", cellprofiler.setting.Divider(line=False))
-
-        group.append(
-            "name",
-            cellprofiler.setting.ObjectNameSubscriber(
-                "Select objects to measure",
-                cellprofiler.setting.NONE,
-                doc="""Select the objects that you want to measure.""",
-            ),
-        )
-
-        if can_remove:
-            group.append(
-                "remove",
-                cellprofiler.setting.RemoveSettingButton(
-                    "", "Remove this object", self.object_groups, group
-                ),
-            )
-
-        self.object_groups.append(group)
-
     def settings(self):
         """The settings as they appear in the save file"""
-        result = [og.name for og in self.object_groups]
-        result.append(self.calculate_zernikes)
+        result = [self.objects_list, self.calculate_zernikes]
         return result
-
-    def prepare_settings(self, setting_values):
-        """Adjust the number of object groups based on the number of setting_values"""
-        object_group_count = len(setting_values) - 1
-        while len(self.object_groups) > object_group_count:
-            self.remove_object(object_group_count)
-
-        while len(self.object_groups) < object_group_count:
-            self.add_object()
 
     def visible_settings(self):
         """The settings as they appear in the module viewer"""
-        result = []
-        for og in self.object_groups:
-            result += og.visible_settings()
-        result.extend([self.add_objects, self.spacer, self.calculate_zernikes])
+        result = [self.objects_list, self.spacer, self.calculate_zernikes]
         return result
 
     def validate_module(self, pipeline):
         """Make sure chosen objects are selected only once"""
         objects = set()
-        for group in self.object_groups:
-            if group.name.value in objects:
+        for object_name in self.objects_list.value:
+            if object_name in objects:
                 raise cellprofiler.setting.ValidationError(
-                    "%s has already been selected" % group.name.value, group.name
+                    "%s has already been selected" % object_name, object_name
                 )
-            objects.add(group.name.value)
+            objects.add(object_name)
 
     def get_categories(self, pipeline, object_name):
         """Get the categories of measurements supplied for the given object name
@@ -311,8 +272,9 @@ module.""".format(
         object_name - name of labels in question (or 'Images')
         returns a list of category names
         """
-        if object_name in [og.name for og in self.object_groups]:
-            return [AREA_SHAPE]
+        for object_set in self.objects_list.value:
+            if object_set == object_name:
+                return [AREA_SHAPE]
         else:
             return []
 
@@ -370,8 +332,8 @@ module.""".format(
 
             workspace.display_data.statistics = []
 
-        for object_group in self.object_groups:
-            self.run_on_objects(object_group.name.value, workspace)
+        for object_name in self.objects_list.value:
+            self.run_on_objects(object_name, workspace)
 
     def run_on_objects(self, object_name, workspace):
         """Run, computing the area measurements for a single map of objects"""
@@ -652,10 +614,9 @@ module.""".format(
     def get_measurement_columns(self, pipeline):
         """Return measurement column definitions.
         All cols returned as float even though "Area" will only ever be int"""
-        object_names = [s.value for s in self.settings()][:-1]
         measurement_names = self.get_feature_names(pipeline)
         cols = []
-        for oname in object_names:
+        for oname in self.objects_list.value:
             for mname in measurement_names:
                 cols += [
                     (
@@ -694,6 +655,10 @@ module.""".format(
             )
             variable_revision_number = 1
             from_matlab = False
+        if not from_matlab and variable_revision_number == 1:
+            objects_list = setting_values[:-1]
+            setting_values = [", ".join(map(str, objects_list)), setting_values[-1]]
+            variable_revision_number = 2
         return setting_values, variable_revision_number, from_matlab
 
     def volumetric(self):

--- a/cellprofiler/modules/measureobjectsizeshape.py
+++ b/cellprofiler/modules/measureobjectsizeshape.py
@@ -59,7 +59,7 @@ ellipse with the same second-moments as each object.
 -  *Volume:* *(3D only)* The number of voxels in the region.
 -  *Perimeter:* *(2D only)* The total number of pixels around the boundary of each
    region in the image.
--  *SurfaceArea:* *(3D only)# The total number of voxels around the boundary of
+-  *SurfaceArea:* *(3D only)* The total number of voxels around the boundary of
    each region in the image.
 -  *FormFactor:* *(2D only)* Calculated as 4\*π\*Area/Perimeter\ :sup:`2`. Equals 1
    for a perfectly circular object.

--- a/cellprofiler/modules/resizeobjects.py
+++ b/cellprofiler/modules/resizeobjects.py
@@ -42,14 +42,14 @@ See also
 class ResizeObjects(cellprofiler.module.ObjectProcessing):
     module_name = "ResizeObjects"
 
-    variable_revision_number = 1
+    variable_revision_number = 2
 
     def create_settings(self):
         super(ResizeObjects, self).create_settings()
 
         self.method = cellprofiler.setting.Choice(
             "Method",
-            ["Dimensions", "Factor"],
+            ["Dimensions", "Factor", "Match Image"],
             doc="""\
 The following options are available:
 
@@ -89,10 +89,19 @@ Enter the desired width of the final objects, in pixels.""",
 Enter the desired height of the final objects, in pixels.""",
         )
 
+        self.specific_image = cellprofiler.setting.ImageNameSubscriber(
+            "Select the image with the desired dimensions",
+            cellprofiler.setting.NONE,
+            doc="""\
+        *(Used only if resizing by specifying desired final dimensions using an image)*
+
+        The input object set will be resized to the dimensions of the specified image.""",
+        )
+
     def settings(self):
         settings = super(ResizeObjects, self).settings()
 
-        settings += [self.method, self.factor, self.width, self.height]
+        settings += [self.method, self.factor, self.width, self.height, self.specific_image]
 
         return settings
 
@@ -103,19 +112,45 @@ Enter the desired height of the final objects, in pixels.""",
 
         if self.method.value == "Dimensions":
             visible_settings += [self.width, self.height]
-        else:
+        elif self.method.value == "Factor":
             visible_settings += [self.factor]
-
+        else:
+            visible_settings += [self.specific_image]
         return visible_settings
 
     def run(self, workspace):
-        self.function = (
-            lambda data, method, factor, width, height: resize(data, (height, width))
-            if method == "Dimensions"
-            else rescale(data, factor)
-        )
+        x_name = self.x_name.value
+        y_name = self.y_name.value
+        objects = workspace.object_set
+        x = objects.get_objects(x_name)
+        dimensions = x.dimensions
+        x_data = x.segmented
 
-        super(ResizeObjects, self).run(workspace)
+        if self.method.value == "Dimensions":
+            y_data = resize(x_data, (self.height.value, self.width.value))
+        elif self.method.value == "Match Image":
+            target_image = workspace.image_set.get_image(self.specific_image.value)
+            if target_image.volumetric:
+                tgt_height, tgt_width = target_image.pixel_data.shape[1:3]
+            else:
+                tgt_height, tgt_width = target_image.pixel_data.shape[:2]
+            size = (tgt_height, tgt_width)
+            y_data = resize(x_data, size)
+        else:
+            y_data = rescale(x_data, self.factor.value)
+
+        y = cellprofiler.object.Objects()
+        y.segmented = y_data
+        y.parent_image = x.parent_image
+        objects.add_objects(y, y_name)
+        self.add_measurements(workspace)
+
+        if self.show_window:
+            workspace.display_data.x_data = x_data
+
+            workspace.display_data.y_data = y_data
+
+            workspace.display_data.dimensions = dimensions
 
     def add_measurements(
         self, workspace, input_object_name=None, output_object_name=None
@@ -143,6 +178,14 @@ Enter the desired height of the final objects, in pixels.""",
             unique_labels,
         )
 
+    def upgrade_settings(
+        self, setting_values, variable_revision_number, module_name, from_matlab
+    ):
+        if variable_revision_number == 1:
+            setting_values += [cellprofiler.setting.NONE]
+            variable_revision_number = 2
+        return setting_values, variable_revision_number, from_matlab
+
 
 def resize(data, size):
     if data.ndim == 3:
@@ -164,3 +207,4 @@ def rescale(data, factor):
         factor = (1,) + factor
 
     return scipy.ndimage.zoom(data, factor, order=0, mode="nearest")
+

--- a/cellprofiler/pipeline.py
+++ b/cellprofiler/pipeline.py
@@ -2357,9 +2357,10 @@ class Pipeline(object):
                 image_set = m
                 object_set = cellprofiler.object.ObjectSet()
                 old_providers = list(image_set.providers)
+                grid_set = {}
                 for module in pipeline.modules():
                     w = cellprofiler.workspace.Workspace(
-                        self, module, image_set, object_set, m, image_set_list
+                        self, module, image_set, object_set, m, image_set_list, grids=grid_set
                     )
                     if module == stop_module:
                         yield w
@@ -2369,6 +2370,7 @@ class Pipeline(object):
                         break
                     else:
                         self.run_module(module, w)
+                        grid_set = w._Workspace__grid
                     if progress_dialog is not None:
                         should_continue, skip = progress_dialog.Update(i + 1)
                         if not should_continue:

--- a/cellprofiler/setting.py
+++ b/cellprofiler/setting.py
@@ -4274,6 +4274,7 @@ class ValidationError(ValueError):
         """Initialize with an explanatory message and the setting that caused the problem
         """
         super(ValidationError, self).__init__(message)
+        self.message = message
         self.__setting = setting
 
     def get_setting(self):

--- a/cellprofiler/setting.py
+++ b/cellprofiler/setting.py
@@ -1591,6 +1591,7 @@ class ImageNameSubscriber(NameSubscriber):
             text, IMAGE_GROUP, value, can_be_blank, blank_text, *args, **kwargs
         )
 
+
 class ListImageNameSubscriber(NameSubscriber):
     """A setting that provides an image name
     """
@@ -1606,6 +1607,24 @@ class ListImageNameSubscriber(NameSubscriber):
     ):
         super(ListImageNameSubscriber, self).__init__(
             text, IMAGE_GROUP, value, can_be_blank, blank_text, *args, **kwargs
+        )
+
+
+class ListObjectNameSubscriber(NameSubscriber):
+    """A setting that provides an image name
+    """
+
+    def __init__(
+        self,
+        text,
+        value=None,
+        can_be_blank=False,
+        blank_text=LEAVE_BLANK,
+        *args,
+        **kwargs,
+    ):
+        super(ListObjectNameSubscriber, self).__init__(
+            text, OBJECT_GROUP, value, can_be_blank, blank_text, *args, **kwargs
         )
 
 

--- a/cellprofiler/setting.py
+++ b/cellprofiler/setting.py
@@ -1535,7 +1535,6 @@ class ListNameSubscriber(NameSubscriber):
         else:
             value = value.split(", ")
         self._Setting__value = value
-        print("Internally setting ", self._Setting__value)
 
     def __internal_get_value(self):
         return self.get_value()

--- a/cellprofiler/setting.py
+++ b/cellprofiler/setting.py
@@ -1521,7 +1521,6 @@ class ListNameSubscriber(NameSubscriber):
             text, group, value, can_be_blank, blank_text, *args, **kwargs
         )
         self.value = value
-        self.value_text = value
 
     def get_value_text(self):
         """Convert the underlying list to a string"""
@@ -1531,7 +1530,7 @@ class ListNameSubscriber(NameSubscriber):
         self.set_value_text(value)
 
     def set_value_text(self, value):
-        self.value = value
+        self._Setting__value = value
 
     value_text = property(get_value_text, __internal_set_value_text)
 

--- a/cellprofiler/setting.py
+++ b/cellprofiler/setting.py
@@ -1502,6 +1502,47 @@ class NameSubscriber(Setting):
             )
 
 
+class ListNameSubscriber(NameSubscriber):
+    """Stores name provider names as a list"""
+
+    def __init__(
+        self,
+        text,
+        group,
+        value=None,
+        can_be_blank=False,
+        blank_text=LEAVE_BLANK,
+        *args,
+        **kwargs,
+    ):
+        super(ListNameSubscriber, self).__init__(
+            text, group, value, can_be_blank, blank_text, *args, **kwargs
+        )
+
+    def get_value_text(self):
+        """Convert the underlying list to a string"""
+        return ", ".join(map(str, self._Setting__value))
+
+    def __internal_set_value_text(self, value):
+        self.set_value_text(value)
+
+    value_text = property(get_value_text, __internal_set_value_text)
+
+    def __internal_set_value(self, value):
+        """Convert a saved string into a list"""
+        if len(value) == 0:
+            value = []
+        else:
+            value = value.split(", ")
+        self._Setting__value = value
+        print("Internally setting ", self._Setting__value)
+
+    def __internal_get_value(self):
+        return self.get_value()
+
+    value = property(__internal_get_value, __internal_set_value)
+
+
 def filter_duplicate_names(name_list):
     """remove any repeated names from a list of (name, ...) keeping the last occurrence."""
     name_dict = dict(list(zip((n[0] for n in name_list), name_list)))
@@ -1592,7 +1633,7 @@ class ImageNameSubscriber(NameSubscriber):
         )
 
 
-class ListImageNameSubscriber(NameSubscriber):
+class ListImageNameSubscriber(ListNameSubscriber):
     """A setting that provides an image name
     """
 
@@ -1607,24 +1648,6 @@ class ListImageNameSubscriber(NameSubscriber):
     ):
         super(ListImageNameSubscriber, self).__init__(
             text, IMAGE_GROUP, value, can_be_blank, blank_text, *args, **kwargs
-        )
-
-
-class ListObjectNameSubscriber(NameSubscriber):
-    """A setting that provides an image name
-    """
-
-    def __init__(
-        self,
-        text,
-        value=None,
-        can_be_blank=False,
-        blank_text=LEAVE_BLANK,
-        *args,
-        **kwargs,
-    ):
-        super(ListObjectNameSubscriber, self).__init__(
-            text, OBJECT_GROUP, value, can_be_blank, blank_text, *args, **kwargs
         )
 
 
@@ -1701,6 +1724,24 @@ class ObjectNameSubscriber(NameSubscriber):
         **kwargs,
     ):
         super(ObjectNameSubscriber, self).__init__(
+            text, OBJECT_GROUP, value, can_be_blank, blank_text, *args, **kwargs
+        )
+
+
+class ListObjectNameSubscriber(ListNameSubscriber):
+    """A setting that provides an image name
+    """
+
+    def __init__(
+        self,
+        text,
+        value=None,
+        can_be_blank=False,
+        blank_text=LEAVE_BLANK,
+        *args,
+        **kwargs,
+    ):
+        super(ListObjectNameSubscriber, self).__init__(
             text, OBJECT_GROUP, value, can_be_blank, blank_text, *args, **kwargs
         )
 

--- a/cellprofiler/setting.py
+++ b/cellprofiler/setting.py
@@ -1591,6 +1591,23 @@ class ImageNameSubscriber(NameSubscriber):
             text, IMAGE_GROUP, value, can_be_blank, blank_text, *args, **kwargs
         )
 
+class ListImageNameSubscriber(NameSubscriber):
+    """A setting that provides an image name
+    """
+
+    def __init__(
+        self,
+        text,
+        value=None,
+        can_be_blank=False,
+        blank_text=LEAVE_BLANK,
+        *args,
+        **kwargs,
+    ):
+        super(ListImageNameSubscriber, self).__init__(
+            text, IMAGE_GROUP, value, can_be_blank, blank_text, *args, **kwargs
+        )
+
 
 class FileImageNameSubscriber(ImageNameSubscriber):
     """A setting that provides image names loaded from files"""

--- a/cellprofiler/setting.py
+++ b/cellprofiler/setting.py
@@ -1547,6 +1547,20 @@ class ListNameSubscriber(NameSubscriber):
 
     value = property(__internal_get_value, __internal_set_value)
 
+    def test_valid(self, pipeline):
+        choices = self.get_choices(pipeline)
+        if len(choices) == 0:
+            raise ValidationError(
+                "No prior instances of %s were defined" % self.group, self
+            )
+        for name in self.value:
+            if name not in [c[0] for c in choices]:
+                raise ValidationError(
+                    "%s not in %s"
+                    % (name, ", ".join(c[0] for c in self.get_choices(pipeline))),
+                    self,
+                )
+
 
 def filter_duplicate_names(name_list):
     """remove any repeated names from a list of (name, ...) keeping the last occurrence."""

--- a/cellprofiler/setting.py
+++ b/cellprofiler/setting.py
@@ -1515,9 +1515,13 @@ class ListNameSubscriber(NameSubscriber):
         *args,
         **kwargs,
     ):
+        if value is None:
+            value = ""
         super(ListNameSubscriber, self).__init__(
             text, group, value, can_be_blank, blank_text, *args, **kwargs
         )
+        self.value = value
+        self.value_text = value
 
     def get_value_text(self):
         """Convert the underlying list to a string"""
@@ -1525,6 +1529,9 @@ class ListNameSubscriber(NameSubscriber):
 
     def __internal_set_value_text(self, value):
         self.set_value_text(value)
+
+    def set_value_text(self, value):
+        self.value = value
 
     value_text = property(get_value_text, __internal_set_value_text)
 

--- a/cellprofiler/workspace.py
+++ b/cellprofiler/workspace.py
@@ -62,6 +62,7 @@ class Workspace(object):
         frame=None,
         create_new_window=False,
         outlines=None,
+        grids={},
     ):
         """Workspace constructor
 
@@ -88,7 +89,7 @@ class Workspace(object):
         self.__outlines = outlines
         self.__windows_used = []
         self.__create_new_window = create_new_window
-        self.__grid = {}
+        self.__grid = grids
         self.__disposition = DISPOSITION_CONTINUE
         self.__disposition_listeners = []
         self.__in_background = (

--- a/tests/modules/test_measureobjectintensity.py
+++ b/tests/modules/test_measureobjectintensity.py
@@ -36,9 +36,9 @@ def measurements():
 def module():
     module = cellprofiler.modules.measureobjectintensity.MeasureObjectIntensity()
 
-    module.images_list.value = [IMAGE_NAME]
+    module.images_list.value = IMAGE_NAME
 
-    module.objects_list.value = [OBJECT_NAME]
+    module.objects_list.value = OBJECT_NAME
 
     return module
 
@@ -122,9 +122,9 @@ def assert_features_and_columns_match(measurements, module):
 
 def test_supplied_measurements(module):
     """Test the get_category / get_measurements, get_measurement_images functions"""
-    module.images_list.value = ["MyImage"]
+    module.images_list.value = "MyImage"
 
-    module.objects_list.value = ["MyObjects1", "MyObjects2"]
+    module.objects_list.value = "MyObjects1, MyObjects2"
 
     expected_categories = tuple(
         sorted(
@@ -174,9 +174,9 @@ def test_supplied_measurements(module):
 
 def test_get_measurement_columns(module):
     """test the get_measurement_columns method"""
-    module.images_list.value = ["MyImage"]
+    module.images_list.value = "MyImage"
 
-    module.objects_list.value = ["MyObjects1", "MyObjects2"]
+    module.objects_list.value = "MyObjects1, MyObjects2"
 
     columns = module.get_measurement_columns(None)
 

--- a/tests/modules/test_measureobjectintensity.py
+++ b/tests/modules/test_measureobjectintensity.py
@@ -36,9 +36,9 @@ def measurements():
 def module():
     module = cellprofiler.modules.measureobjectintensity.MeasureObjectIntensity()
 
-    module.images[0].name.value = IMAGE_NAME
+    module.images_list.value = [IMAGE_NAME]
 
-    module.objects[0].name.value = OBJECT_NAME
+    module.objects_list.value = [OBJECT_NAME]
 
     return module
 
@@ -122,13 +122,9 @@ def assert_features_and_columns_match(measurements, module):
 
 def test_supplied_measurements(module):
     """Test the get_category / get_measurements, get_measurement_images functions"""
-    module.images[0].name.value = "MyImage"
+    module.images_list.value = ["MyImage"]
 
-    module.add_object()
-
-    module.objects[0].name.value = "MyObjects1"
-
-    module.objects[1].name.value = "MyObjects2"
+    module.objects_list.value = ["MyObjects1", "MyObjects2"]
 
     expected_categories = tuple(
         sorted(
@@ -178,13 +174,9 @@ def test_supplied_measurements(module):
 
 def test_get_measurement_columns(module):
     """test the get_measurement_columns method"""
-    module.images[0].name.value = "MyImage"
+    module.images_list.value = ["MyImage"]
 
-    module.add_object()
-
-    module.objects[0].name.value = "MyObjects1"
-
-    module.objects[1].name.value = "MyObjects2"
+    module.objects_list.value = ["MyObjects1", "MyObjects2"]
 
     columns = module.get_measurement_columns(None)
 

--- a/tests/modules/test_measureobjectsizeshape.py
+++ b/tests/modules/test_measureobjectsizeshape.py
@@ -28,7 +28,7 @@ def make_workspace(labels):
     m = cellprofiler.measurement.Measurements()
     module = cellprofiler.modules.measureobjectsizeshape.MeasureObjectAreaShape()
     module.set_module_num(1)
-    module.object_groups[0].name.value = OBJECTS_NAME
+    module.objects_list.value = OBJECTS_NAME
     pipeline = cellprofiler.pipeline.Pipeline()
 
     def callback(caller, event):
@@ -60,8 +60,8 @@ def test_01_load_v1():
     assert isinstance(
         module, cellprofiler.modules.measureobjectsizeshape.MeasureObjectSizeShape
     )
-    assert len(module.object_groups) == 2
-    for og, expected in zip(module.object_groups, ("Nuclei", "Cells")):
+    assert len(module.objects_list.value) == 2
+    for og, expected in zip(module.objects_list.value, ("Nuclei", "Cells")):
         assert og.name == expected
     assert module.calculate_zernikes
 
@@ -226,7 +226,7 @@ def test_measurements_no_zernike():
 def test_non_contiguous():
     """make sure MeasureObjectAreaShape doesn't crash if fed non-contiguous objects"""
     module = cellprofiler.modules.measureobjectsizeshape.MeasureObjectAreaShape()
-    module.object_groups[0].name.value = "SomeObjects"
+    module.objects_list.value.append("SomeObjects")
     module.calculate_zernikes.value = True
     object_set = cellprofiler.object.ObjectSet()
     labels = numpy.zeros((10, 20), int)
@@ -274,7 +274,7 @@ def test_zernikes_are_different():
     object_set = cellprofiler.object.ObjectSet()
     object_set.add_objects(objects, "SomeObjects")
     module = cellprofiler.modules.measureobjectsizeshape.MeasureObjectAreaShape()
-    module.object_groups[0].name.value = "SomeObjects"
+    module.objects_list.value.append("SomeObjects")
     module.calculate_zernikes.value = True
     module.set_module_num(1)
     image_set_list = cellprofiler.image.ImageSetList()
@@ -308,7 +308,7 @@ def test_zernikes_are_different():
 
 def test_extent():
     module = cellprofiler.modules.measureobjectsizeshape.MeasureObjectAreaShape()
-    module.object_groups[0].name.value = "SomeObjects"
+    module.objects_list.value.append("SomeObjects")
     module.calculate_zernikes.value = True
     object_set = cellprofiler.object.ObjectSet()
     labels = numpy.zeros((10, 20), int)
@@ -375,7 +375,7 @@ def test_overlapping():
     olist.append(objects)
     for objects in olist:
         module = cellprofiler.modules.measureobjectsizeshape.MeasureObjectAreaShape()
-        module.object_groups[0].name.value = "SomeObjects"
+        module.objects_list.value.append("SomeObjects")
         module.calculate_zernikes.value = True
         object_set = cellprofiler.object.ObjectSet()
         object_set.add_objects(objects, "SomeObjects")

--- a/tests/modules/test_relateobjects.py
+++ b/tests/modules/test_relateobjects.py
@@ -1,4 +1,5 @@
 import numpy
+import unittest
 
 import cellprofiler.image
 import cellprofiler.measurement
@@ -39,7 +40,7 @@ class TestRelateObjects(unittest.TestCase):
                     ]
 
             module = FakeModule()
-            module.module_num = 1
+            module.set_module_num(1)
             pipeline.add_module(module)
         module = cellprofiler.modules.relateobjects.Relate()
         module.x_name.value = PARENT_OBJECTS
@@ -48,56 +49,52 @@ class TestRelateObjects(unittest.TestCase):
             cellprofiler.modules.relateobjects.D_NONE
         )
         module.wants_child_objects_saved.value = False
-        module.module_num = 2 if fake_measurement else 1
+        new_module_num = 2 if fake_measurement else 1
+        module.set_module_num(new_module_num)
         pipeline.add_module(module)
-    module = cellprofiler.modules.relateobjects.Relate()
-    module.x_name.value = PARENT_OBJECTS
-    module.x_child_name.value = CHILD_OBJECTS
-    module.find_parent_child_distances.value = cellprofiler.modules.relateobjects.D_NONE
-    module.set_module_num(2) if fake_measurement else 1
-    pipeline.add_module(module)
-    object_set = cellprofiler.object.ObjectSet()
-    image_set_list = cellprofiler.image.ImageSetList()
-    image_set = image_set_list.get_image_set(0)
-    m = cellprofiler.measurement.Measurements()
-    m.add_image_measurement(cellprofiler.measurement.GROUP_NUMBER, 1)
-    m.add_image_measurement(cellprofiler.measurement.GROUP_INDEX, 1)
-    workspace = cellprofiler.workspace.Workspace(
-        pipeline, module, image_set, object_set, m, image_set_list
-    )
-    o = cellprofiler.object.Objects()
-    if parents.shape[1] == 3:
-        # IJV format
-        o.ijv = parents
-    else:
-        o.segmented = parents
-    object_set.add_objects(o, PARENT_OBJECTS)
-    o = cellprofiler.object.Objects()
-    if children.shape[1] == 3:
-        o.ijv = children
-    else:
-        o.segmented = children
-    object_set.add_objects(o, CHILD_OBJECTS)
-    return workspace, module
+        object_set = cellprofiler.object.ObjectSet()
+        image_set_list = cellprofiler.image.ImageSetList()
+        image_set = image_set_list.get_image_set(0)
+        m = cellprofiler.measurement.Measurements()
+        m.add_image_measurement(cellprofiler.measurement.GROUP_NUMBER, 1)
+        m.add_image_measurement(cellprofiler.measurement.GROUP_INDEX, 1)
+        workspace = cellprofiler.workspace.Workspace(
+            pipeline, module, image_set, object_set, m, image_set_list
+        )
+        o = cellprofiler.object.Objects()
+        if parents.shape[1] == 3:
+            # IJV format
+            o.ijv = parents
+        else:
+            o.segmented = parents
+        object_set.add_objects(o, PARENT_OBJECTS)
+        o = cellprofiler.object.Objects()
+        if children.shape[1] == 3:
+            o.ijv = children
+        else:
+            o.segmented = children
+        object_set.add_objects(o, CHILD_OBJECTS)
+        return workspace, module
 
-
-def features_and_columns_match(workspace):
-    module = workspace.module
-    pipeline = workspace.pipeline
-    measurements = workspace.measurements
-    object_names = [
-        x
-        for x in measurements.get_object_names()
-        if x != cellprofiler.measurement.IMAGE
-    ]
-    features = [
-        [
+    def features_and_columns_match(self, workspace):
+        module = workspace.module
+        pipeline = workspace.pipeline
+        measurements = workspace.measurements
+        object_names = [
+            x
+            for x in measurements.get_object_names()
+            if x != cellprofiler.measurement.IMAGE
+        ]
+        features = [
+            [
             feature
             for feature in measurements.get_feature_names(object_name)
             if feature not in (MEASUREMENT, IGNORED_MEASUREMENT)
         ]
+            for object_name in object_names
+        ]
         columns = [
-            x 
+            x
             for x in module.get_measurement_columns(pipeline)
             if x[0] != cellprofiler.measurement.IMAGE
         ]
@@ -297,242 +294,201 @@ def features_and_columns_match(workspace):
             cellprofiler.modules.relateobjects.D_BOTH
         )
         module.run(workspace)
-        features_and_columns_match(workspace)
+        self.features_and_columns_match(workspace)
         meas = workspace.measurements
-        for feature in (
-            cellprofiler.modules.relateobjects.FF_CENTROID,
-            cellprofiler.modules.relateobjects.FF_MINIMUM,
-        ):
-            m = feature % PARENT_OBJECTS
-            v = meas.get_current_measurement(CHILD_OBJECTS, m)
-            assert len(v) == n
-            if n > 0:
-                assert numpy.all(numpy.isnan(v))
-
-
-def test_distance_centroids():
-    """Check centroid-centroid distance calculation"""
-    i, j = numpy.mgrid[0:14, 0:30]
-    parent_labels = (i >= 7) * 1 + (j >= 15) * 2 + 1
-    # Centers should be at i=3 and j=7
-    parent_centers = numpy.array([[3, 7], [10, 7], [3, 22], [10, 22]], float)
-    child_labels = numpy.zeros(i.shape)
-    numpy.random.seed(0)
-    # Take 12 random points and label them
-    child_centers = numpy.random.permutation(numpy.prod(i.shape))[:12]
-    child_centers = numpy.vstack(
-        (i.flatten()[child_centers], j.flatten()[child_centers])
-    )
-    child_labels[child_centers[0], child_centers[1]] = numpy.arange(1, 13)
-    parent_indexes = parent_labels[child_centers[0], child_centers[1]] - 1
-    expected = numpy.sqrt(
-        numpy.sum(
-            (parent_centers[parent_indexes, :] - child_centers.transpose()) ** 2, 1
+        v = meas.get_current_measurement(
+            CHILD_OBJECTS, cellprofiler.modules.relateobjects.FF_CENTROID % PARENT_OBJECTS
         )
-    )
+        assert v.shape[0] == 12
+        assert numpy.all(numpy.abs(v - expected) < 0.0001)
 
-    workspace, module = make_workspace(parent_labels, child_labels)
-    assert isinstance(module, cellprofiler.modules.relateobjects.Relate)
-    module.find_parent_child_distances.value = (
-        cellprofiler.modules.relateobjects.D_CENTROID
-    )
-    module.run(workspace)
-    features_and_columns_match(workspace)
-    meas = workspace.measurements
-    v = meas.get_current_measurement(
-        CHILD_OBJECTS, cellprofiler.modules.relateobjects.FF_CENTROID % PARENT_OBJECTS
-    )
-    assert v.shape[0] == 12
-    assert numpy.all(numpy.abs(v - expected) < 0.0001)
+    def test_distance_minima(self):
+        parents = numpy.zeros((11, 11), dtype=numpy.uint8)
 
+        children = numpy.zeros_like(parents)
 
-def test_distance_minima():
-    parents = numpy.zeros((11, 11), dtype=numpy.uint8)
+        parents[1:10, 1:10] = 1
 
-    children = numpy.zeros_like(parents)
+        children[2:3, 2:3] = 1
 
-    parents[1:10, 1:10] = 1
+        children[3:8, 3:8] = 2
 
-    children[2:3, 2:3] = 1
+        workspace, module = self.make_workspace(parents, children)
 
-    children[3:8, 3:8] = 2
-
-    workspace, module = make_workspace(parents, children)
-
-    module.find_parent_child_distances.value = (
-        cellprofiler.modules.relateobjects.D_MINIMUM
-    )
-
-    module.run(workspace)
-
-    expected = [1, 4]
-
-    actual = workspace.measurements.get_current_measurement(
-        CHILD_OBJECTS, cellprofiler.modules.relateobjects.FF_MINIMUM % PARENT_OBJECTS
-    )
-
-    numpy.testing.assert_array_equal(actual, expected)
-
-
-def test_means_of_distances():
-    #
-    # Regression test of issue #1409
-    #
-    # Make sure means of minimum and mean distances of children
-    # are recorded properly
-    #
-    i, j = numpy.mgrid[0:14, 0:30]
-    #
-    # Make the objects different sizes to exercise more code
-    #
-    parent_labels = (i >= 7) * 1 + (j >= 15) * 2 + 1
-    child_labels = numpy.zeros(i.shape)
-    numpy.random.seed(0)
-    # Take 12 random points and label them
-    child_centers = numpy.random.permutation(numpy.prod(i.shape))[:12]
-    child_centers = numpy.vstack(
-        (i.flatten()[child_centers], j.flatten()[child_centers])
-    )
-    child_labels[child_centers[0], child_centers[1]] = numpy.arange(1, 13)
-    parent_centers = numpy.array([[3, 7], [10, 7], [3, 22], [10, 22]], float)
-    parent_indexes = parent_labels[child_centers[0], child_centers[1]] - 1
-    expected = numpy.sqrt(
-        numpy.sum(
-            (parent_centers[parent_indexes, :] - child_centers.transpose()) ** 2, 1
+        module.find_parent_child_distances.value = (
+            cellprofiler.modules.relateobjects.D_MINIMUM
         )
-    )
 
-    workspace, module = make_workspace(parent_labels, child_labels)
-    assert isinstance(module, cellprofiler.modules.relateobjects.Relate)
-    module.find_parent_child_distances.value = (
-        cellprofiler.modules.relateobjects.D_CENTROID
-    )
-    module.wants_per_parent_means.value = True
-    mnames = module.get_measurements(
-        workspace.pipeline,
-        PARENT_OBJECTS,
-        "_".join((cellprofiler.modules.relateobjects.C_MEAN, CHILD_OBJECTS)),
-    )
-    assert cellprofiler.modules.relateobjects.FF_CENTROID % PARENT_OBJECTS in mnames
-    feat_mean = cellprofiler.modules.relateobjects.FF_MEAN % (
-        CHILD_OBJECTS,
-        cellprofiler.modules.relateobjects.FF_CENTROID % PARENT_OBJECTS,
-    )
-    mcolumns = module.get_measurement_columns(workspace.pipeline)
-    assert any([c[0] == PARENT_OBJECTS and c[1] == feat_mean for c in mcolumns])
-    m = workspace.measurements
-    m[CHILD_OBJECTS, cellprofiler.measurement.M_LOCATION_CENTER_X, 1] = child_centers[1]
-    m[CHILD_OBJECTS, cellprofiler.measurement.M_LOCATION_CENTER_Y, 1] = child_centers[0]
-    module.run(workspace)
+        module.run(workspace)
 
-    v = m[PARENT_OBJECTS, feat_mean, 1]
+        expected = [1, 4]
 
-    plabel = m[
-        CHILD_OBJECTS, "_".join((cellprofiler.measurement.C_PARENT, PARENT_OBJECTS)), 1
-    ]
+        actual = workspace.measurements.get_current_measurement(
+            CHILD_OBJECTS, cellprofiler.modules.relateobjects.FF_MINIMUM % PARENT_OBJECTS
+        )
 
-    assert len(v) == 4
-    for idx in range(4):
-        if numpy.any(plabel == idx + 1):
-            assert round(abs(v[idx] - numpy.mean(expected[plabel == idx + 1])), 4) == 0
-
-
-def test_calculate_centroid_distances_volume():
-    parents = numpy.zeros((9, 11, 11), dtype=numpy.uint8)
-
-    children = numpy.zeros_like(parents)
-
-    k, i, j = numpy.mgrid[0:9, 0:11, 0:11]
-
-    parents[(k - 4) ** 2 + (i - 5) ** 2 + (j - 5) ** 2 <= 16] = 1
-
-    children[(k - 3) ** 2 + (i - 3) ** 2 + (j - 3) ** 2 <= 4] = 1
-
-    children[(k - 4) ** 2 + (i - 7) ** 2 + (j - 7) ** 2 <= 4] = 2
-
-    workspace, module = make_workspace(parents, children)
-
-    module.find_parent_child_distances.value = (
-        cellprofiler.modules.relateobjects.D_CENTROID
-    )
-
-    module.run(workspace)
-
-    expected = [3, numpy.sqrt(8)]
-
-    actual = workspace.measurements.get_current_measurement(
-        CHILD_OBJECTS, cellprofiler.modules.relateobjects.FF_CENTROID % PARENT_OBJECTS
-    )
-
-    numpy.testing.assert_array_equal(actual, expected)
-
-
-def test_calculate_minimum_distances_volume():
-    parents = numpy.zeros((9, 11, 11), dtype=numpy.uint8)
-
-    children = numpy.zeros_like(parents)
-
-    parents[1:8, 1:10, 1:10] = 1
-
-    children[3:6, 2:3, 2:3] = 1
-
-    children[4:7, 3:8, 3:8] = 2
-
-    workspace, module = make_workspace(parents, children)
-
-    module.find_parent_child_distances.value = (
-        cellprofiler.modules.relateobjects.D_MINIMUM
-    )
-
-    module.run(workspace)
-
-    expected = [1, 2]
-
-    actual = workspace.measurements.get_current_measurement(
-        CHILD_OBJECTS, cellprofiler.modules.relateobjects.FF_MINIMUM % PARENT_OBJECTS
-    )
-
-    numpy.testing.assert_array_equal(actual, expected)
-
-
-def test_relate_zeros_with_step_parent():
-    # https://github.com/CellProfiler/CellProfiler/issues/2441
-    parents = numpy.zeros((10, 10), dtype=numpy.uint8)
-
-    children = numpy.zeros_like(parents)
-
-    step_parents = numpy.zeros_like(parents)
-
-    step_parents_object = cellprofiler.object.Objects()
-
-    step_parents_object.segmented = step_parents
-
-    workspace, module = make_workspace(parents, children)
-
-    workspace.measurements.add_measurement(
-        "Step", cellprofiler.measurement.FF_PARENT % PARENT_OBJECTS, []
-    )
-
-    module.step_parent_names[0].step_parent_name.value = "Step"
-
-    workspace.object_set.add_objects(step_parents_object, "Step")
-
-    module.wants_step_parent_distances.value = True
-
-    module.find_parent_child_distances.value = (
-        cellprofiler.modules.relateobjects.D_MINIMUM
-    )
-
-    module.run(workspace)
-
-    expected = []
-
-    actual = workspace.measurements.get_current_measurement(
-        CHILD_OBJECTS, cellprofiler.modules.relateobjects.FF_MINIMUM % "Step"
-    )
         numpy.testing.assert_array_equal(actual, expected)
 
-     def test_relate_and_make_new_objects(self):
+
+    def test_means_of_distances(self):
+        #
+        # Regression test of issue #1409
+        #
+        # Make sure means of minimum and mean distances of children
+        # are recorded properly
+        #
+        i, j = numpy.mgrid[0:14, 0:30]
+        #
+        # Make the objects different sizes to exercise more code
+        #
+        parent_labels = (i >= 7) * 1 + (j >= 15) * 2 + 1
+        child_labels = numpy.zeros(i.shape)
+        numpy.random.seed(0)
+        # Take 12 random points and label them
+        child_centers = numpy.random.permutation(numpy.prod(i.shape))[:12]
+        child_centers = numpy.vstack(
+            (i.flatten()[child_centers], j.flatten()[child_centers])
+        )
+        child_labels[child_centers[0], child_centers[1]] = numpy.arange(1, 13)
+        parent_centers = numpy.array([[3, 7], [10, 7], [3, 22], [10, 22]], float)
+        parent_indexes = parent_labels[child_centers[0], child_centers[1]] - 1
+        expected = numpy.sqrt(
+            numpy.sum(
+                (parent_centers[parent_indexes, :] - child_centers.transpose()) ** 2, 1
+            )
+        )
+
+        workspace, module = self.make_workspace(parent_labels, child_labels)
+        assert isinstance(module, cellprofiler.modules.relateobjects.Relate)
+        module.find_parent_child_distances.value = (
+            cellprofiler.modules.relateobjects.D_CENTROID
+        )
+        module.wants_per_parent_means.value = True
+        mnames = module.get_measurements(
+            workspace.pipeline,
+            PARENT_OBJECTS,
+            "_".join((cellprofiler.modules.relateobjects.C_MEAN, CHILD_OBJECTS)),
+        )
+        assert cellprofiler.modules.relateobjects.FF_CENTROID % PARENT_OBJECTS in mnames
+        feat_mean = cellprofiler.modules.relateobjects.FF_MEAN % (
+            CHILD_OBJECTS,
+            cellprofiler.modules.relateobjects.FF_CENTROID % PARENT_OBJECTS,
+        )
+        mcolumns = module.get_measurement_columns(workspace.pipeline)
+        assert any([c[0] == PARENT_OBJECTS and c[1] == feat_mean for c in mcolumns])
+        m = workspace.measurements
+        m[CHILD_OBJECTS, cellprofiler.measurement.M_LOCATION_CENTER_X, 1] = child_centers[1]
+        m[CHILD_OBJECTS, cellprofiler.measurement.M_LOCATION_CENTER_Y, 1] = child_centers[0]
+        module.run(workspace)
+
+        v = m[PARENT_OBJECTS, feat_mean, 1]
+
+        plabel = m[
+            CHILD_OBJECTS, "_".join((cellprofiler.measurement.C_PARENT, PARENT_OBJECTS)), 1
+        ]
+
+        assert len(v) == 4
+        for idx in range(4):
+            if numpy.any(plabel == idx + 1):
+                assert round(abs(v[idx] - numpy.mean(expected[plabel == idx + 1])), 4) == 0
+
+
+    def test_calculate_centroid_distances_volume(self):
+        parents = numpy.zeros((9, 11, 11), dtype=numpy.uint8)
+
+        children = numpy.zeros_like(parents)
+
+        k, i, j = numpy.mgrid[0:9, 0:11, 0:11]
+
+        parents[(k - 4) ** 2 + (i - 5) ** 2 + (j - 5) ** 2 <= 16] = 1
+
+        children[(k - 3) ** 2 + (i - 3) ** 2 + (j - 3) ** 2 <= 4] = 1
+
+        children[(k - 4) ** 2 + (i - 7) ** 2 + (j - 7) ** 2 <= 4] = 2
+
+        workspace, module = self.make_workspace(parents, children)
+
+        module.find_parent_child_distances.value = (
+            cellprofiler.modules.relateobjects.D_CENTROID
+        )
+
+        module.run(workspace)
+
+        expected = [3, numpy.sqrt(8)]
+
+        actual = workspace.measurements.get_current_measurement(
+            CHILD_OBJECTS, cellprofiler.modules.relateobjects.FF_CENTROID % PARENT_OBJECTS
+        )
+
+        numpy.testing.assert_array_equal(actual, expected)
+
+
+    def test_calculate_minimum_distances_volume(self):
+        parents = numpy.zeros((9, 11, 11), dtype=numpy.uint8)
+
+        children = numpy.zeros_like(parents)
+
+        parents[1:8, 1:10, 1:10] = 1
+
+        children[3:6, 2:3, 2:3] = 1
+
+        children[4:7, 3:8, 3:8] = 2
+
+        workspace, module = self.make_workspace(parents, children)
+
+        module.find_parent_child_distances.value = (
+            cellprofiler.modules.relateobjects.D_MINIMUM
+        )
+
+        module.run(workspace)
+
+        expected = [1, 2]
+
+        actual = workspace.measurements.get_current_measurement(
+            CHILD_OBJECTS, cellprofiler.modules.relateobjects.FF_MINIMUM % PARENT_OBJECTS
+        )
+
+        numpy.testing.assert_array_equal(actual, expected)
+
+
+    def test_relate_zeros_with_step_parent(self):
+        # https://github.com/CellProfiler/CellProfiler/issues/2441
+        parents = numpy.zeros((10, 10), dtype=numpy.uint8)
+
+        children = numpy.zeros_like(parents)
+
+        step_parents = numpy.zeros_like(parents)
+
+        step_parents_object = cellprofiler.object.Objects()
+
+        step_parents_object.segmented = step_parents
+
+        workspace, module = self.make_workspace(parents, children)
+
+        workspace.measurements.add_measurement(
+            "Step", cellprofiler.measurement.FF_PARENT % PARENT_OBJECTS, []
+        )
+
+        module.step_parent_names[0].step_parent_name.value = "Step"
+
+        workspace.object_set.add_objects(step_parents_object, "Step")
+
+        module.wants_step_parent_distances.value = True
+
+        module.find_parent_child_distances.value = (
+            cellprofiler.modules.relateobjects.D_MINIMUM
+        )
+
+        module.run(workspace)
+
+        expected = []
+
+        actual = workspace.measurements.get_current_measurement(
+            CHILD_OBJECTS, cellprofiler.modules.relateobjects.FF_MINIMUM % "Step"
+        )
+        numpy.testing.assert_array_equal(actual, expected)
+
+    def test_relate_and_make_new_objects(self):
         '''Relate one parent to one child, but save children as a new set'''
         parent_labels = numpy.ones((10, 10), int)
         child_labels = numpy.zeros((10, 10), int)
@@ -553,3 +509,7 @@ def test_relate_zeros_with_step_parent():
         self.assertEqual(numpy.product(child_count.shape), 1)
         self.assertEqual(child_count[0], 1)
         self.features_and_columns_match(workspace)
+
+
+
+

--- a/tests/modules/test_resizeobjects.py
+++ b/tests/modules/test_resizeobjects.py
@@ -382,3 +382,77 @@ def test_resize_by_dimensions_enlarge_volume_labels(
         ),
         [1, 2, 3, 4],
     )
+
+
+def test_resize_by_image(
+    module, object_set_empty, objects_empty, image_labels, workspace_empty
+):
+    objects_empty.segmented = image_labels
+    pixel_data = numpy.zeros((10, 5))
+    workspace_empty.image_set.add("TestImage", cellprofiler.image.Image(pixel_data))
+    module.x_name.value = "InputObjects"
+    module.method.value = "Match Image"
+    module.specific_image.value = "TestImage"
+
+    module.run(workspace_empty)
+
+    expected_labels = numpy.zeros((10, 5), dtype=numpy.uint8)
+    expected_labels[1:4, 1:2] = 1
+    expected_labels[0:4, 3:4] = 2
+    expected_labels[6:9, 0:2] = 3
+    expected_labels[6:10, 3:5] = 4
+
+    numpy.testing.assert_array_equal(
+        object_set_empty.get_objects("ResizeObjects").segmented, expected_labels
+    )
+
+    numpy.testing.assert_array_equal(
+        workspace_empty.measurements.get_current_measurement(
+            "InputObjects", cellprofiler.measurement.FF_CHILDREN_COUNT % "ResizeObjects"
+        ),
+        [1, 1, 1, 1],
+    )
+
+    numpy.testing.assert_array_equal(
+        workspace_empty.measurements.get_current_measurement(
+            "ResizeObjects", cellprofiler.measurement.FF_PARENT % "InputObjects"
+        ),
+        [1, 2, 3, 4],
+    )
+
+
+def test_resize_by_image_volume(
+    module, object_set_empty, objects_empty, volume_labels, workspace_empty
+):
+    objects_empty.segmented = volume_labels
+    pixel_data = numpy.zeros((9, 10, 5))
+    workspace_empty.image_set.add("TestImage", cellprofiler.image.Image(pixel_data, dimensions=3))
+    module.x_name.value = "InputObjects"
+    module.method.value = "Match Image"
+    module.specific_image.value = "TestImage"
+
+    module.run(workspace_empty)
+
+    expected_labels = numpy.zeros((9, 10, 5), dtype=numpy.uint8)
+    expected_labels[0:9, 1:4, 1:2] = 1
+    expected_labels[0:5, 0:4, 3:4] = 2
+    expected_labels[4:9, 6:9, 0:2] = 3
+    expected_labels[1:8, 6:10, 3:5] = 4
+
+    numpy.testing.assert_array_equal(
+        object_set_empty.get_objects("ResizeObjects").segmented, expected_labels
+    )
+
+    numpy.testing.assert_array_equal(
+        workspace_empty.measurements.get_current_measurement(
+            "InputObjects", cellprofiler.measurement.FF_CHILDREN_COUNT % "ResizeObjects"
+        ),
+        [1, 1, 1, 1],
+    )
+
+    numpy.testing.assert_array_equal(
+        workspace_empty.measurements.get_current_measurement(
+            "ResizeObjects", cellprofiler.measurement.FF_PARENT % "InputObjects"
+        ),
+        [1, 2, 3, 4],
+    )

--- a/tests/test_namesubscriber.py
+++ b/tests/test_namesubscriber.py
@@ -1,0 +1,49 @@
+"""test_namesubscriber.py - test the name subscriber classes from settings"""
+
+import unittest
+
+import cellprofiler.setting
+
+
+class TestListNameSubscriber(unittest.TestCase):
+    def test_load_image_list_empty(self):
+        s = cellprofiler.setting.ListImageNameSubscriber("foo")
+        self.assertEqual(s.value_text, "")
+        self.assertEqual(s.value, [])
+
+    def test_load_image_list_single(self):
+        s = cellprofiler.setting.ListImageNameSubscriber("foo", value="SampleName")
+        self.assertEqual(s.value_text, "SampleName")
+        self.assertEqual(s.value, ["SampleName"])
+
+    def test_load_image_list_multiple(self):
+        s = cellprofiler.setting.ListImageNameSubscriber("foo", value="SampleName1, SampleName2")
+        self.assertEqual(s.value_text, "SampleName1, SampleName2")
+        self.assertEqual(s.value, ["SampleName1", "SampleName2"])
+
+    def test_set_image_list(self):
+        s = cellprofiler.setting.ListImageNameSubscriber("foo")
+        s.value = "SampleName3, SampleName4"
+        self.assertEqual(s.value_text, "SampleName3, SampleName4")
+        self.assertEqual(s.value, ["SampleName3", "SampleName4"])
+
+    def test_load_object_list_empty(self):
+        s = cellprofiler.setting.ListObjectNameSubscriber("foo")
+        self.assertEqual(s.value_text, "")
+        self.assertEqual(s.value, [])
+
+    def test_load_object_list_single(self):
+        s = cellprofiler.setting.ListObjectNameSubscriber("foo", value="SampleName")
+        self.assertEqual(s.value_text, "SampleName")
+        self.assertEqual(s.value, ["SampleName"])
+
+    def test_load_object_list_multiple(self):
+        s = cellprofiler.setting.ListObjectNameSubscriber("foo", value="SampleName1, SampleName2")
+        self.assertEqual(s.value_text, "SampleName1, SampleName2")
+        self.assertEqual(s.value, ["SampleName1", "SampleName2"])
+
+    def test_set_object_list(self):
+        s = cellprofiler.setting.ListObjectNameSubscriber("foo")
+        s.value = "SampleName3, SampleName4"
+        self.assertEqual(s.value_text, "SampleName3, SampleName4")
+        self.assertEqual(s.value, ["SampleName3", "SampleName4"])


### PR DESCRIPTION
Closes #2298.

As discussed a long time ago, a common frustration is having to use "add another image" buttons to individually specify images in the measurement modules. This becomes tedious when working with large numbers of image and object sets.

I've been working on implementing checklist boxes as an easier way to handle this. It should be appropriate wherever adding an image or object set doesn't require any additional per-group settings. I think the checklists are a bit easier for users to understand and handle than the normal multiple selection lists.

I've currently added this to the MeasureObjectIntensity module (see below). If we want to go ahead with this I can start adding it to other modules.

![NewMultiSubscriberHandling](https://user-images.githubusercontent.com/26802537/76233977-678bee80-61ff-11ea-8561-58b83ad75424.png)

Oh, you can also right click for select all/none options. Because checking a few dozen boxes is still tedious.

There are probably still bugs to be found and better solutions for some aspects, so this is a WIP for now.