### PR TITLE
Add more descriptive errors to modules requiring matched image dimensions

### DIFF
--- a/cellprofiler/modules/correctilluminationapply.py
+++ b/cellprofiler/modules/correctilluminationapply.py
@@ -240,7 +240,7 @@ somewhat empirical.
             raise ValueError(
                 "This module requires that the image and illumination function have equal dimensions.\n"
                 "The %s image and %s illumination function do not (%s vs %s).\n"
-                "If they are paired correctly you may want to use the Resize or Crop module to make them the same size.
+                "If they are paired correctly you may want to use the Resize or Crop module to make them the same size."
                 % (
                     image_name,
                     illum_correct_name,

--- a/cellprofiler/modules/correctilluminationapply.py
+++ b/cellprofiler/modules/correctilluminationapply.py
@@ -239,7 +239,8 @@ somewhat empirical.
         if orig_image.pixel_data.shape != illum_function_pixel_data.shape:
             raise ValueError(
                 "This module requires that the image and illumination function have equal dimensions.\n"
-                "The %s image and %s illumination function do not (%s vs %s)"
+                "The %s image and %s illumination function do not (%s vs %s).\n"
+                "If they are paired correctly you may want to use the Resize or Crop module to make them the same size.
                 % (
                     image_name,
                     illum_correct_name,

--- a/cellprofiler/modules/correctilluminationapply.py
+++ b/cellprofiler/modules/correctilluminationapply.py
@@ -235,6 +235,18 @@ somewhat empirical.
         else:
             if illum_function_pixel_data.ndim == 2:
                 illum_function_pixel_data = illum_function_pixel_data[:, :, np.newaxis]
+        # Throw an error if image and illum data are incompatible
+        if orig_image.pixel_data.shape != illum_function_pixel_data.shape:
+            raise ValueError(
+                "This module requires that the image and illumination function have equal dimensions.\n"
+                "The %s image and %s illumination function do not (%s vs %s)"
+                % (
+                    image_name,
+                    illum_correct_name,
+                    orig_image.pixel_data.shape,
+                    illum_function_pixel_data.shape,
+                )
+            )
         #
         # Either divide or subtract the illumination image from the original
         #

--- a/cellprofiler/modules/identifysecondaryobjects.py
+++ b/cellprofiler/modules/identifysecondaryobjects.py
@@ -527,7 +527,9 @@ segmentation.""",
         if img.shape != objects.shape:
             raise ValueError(
                 "This module requires that the input image and object sets are the same size.\n"
-                "The %s image and %s objects are not (%s vs %s)"
+                "The %s image and %s objects are not (%s vs %s).\n"
+                "If they are paired correctly you may want to use the Resize, ResizeObjects or "
+                "Crop module(s) to make them the same size."
                 % (
                     image_name,
                     self.x_name.value,

--- a/cellprofiler/modules/identifysecondaryobjects.py
+++ b/cellprofiler/modules/identifysecondaryobjects.py
@@ -524,6 +524,17 @@ segmentation.""",
         img = image.pixel_data
         mask = image.mask
         objects = workspace.object_set.get_objects(self.x_name.value)
+        if img.shape != objects.shape:
+            raise ValueError(
+                "This module requires that the input image and object sets are the same size.\n"
+                "The %s image and %s objects are not (%s vs %s)"
+                % (
+                    image_name,
+                    self.x_name.value,
+                    img.shape,
+                    objects.shape,
+                )
+            )
         global_threshold = None
         if self.method == M_DISTANCE_N:
             has_threshold = False

--- a/cellprofiler/modules/identifytertiaryobjects.py
+++ b/cellprofiler/modules/identifytertiaryobjects.py
@@ -256,7 +256,8 @@ but the results will be zero or not-a-number (NaN).
         # If size/shape differences were too extreme, raise an error.
         if primary_labels.shape != secondary_labels.shape:
             raise ValueError(
-                "The first object set (%s) cannot come from a bigger image than the second object set (%s) - %s vs %s"
+                "This module requires that the object sets have matching widths and matching heights.\n"
+                "The %s and %s objects do not (%s vs %s)"
                 % (
                     self.secondary_objects_name,
                     self.primary_objects_name,

--- a/cellprofiler/modules/identifytertiaryobjects.py
+++ b/cellprofiler/modules/identifytertiaryobjects.py
@@ -257,7 +257,9 @@ but the results will be zero or not-a-number (NaN).
         if primary_labels.shape != secondary_labels.shape:
             raise ValueError(
                 "This module requires that the object sets have matching widths and matching heights.\n"
-                "The %s and %s objects do not (%s vs %s)"
+                "The %s and %s objects do not (%s vs %s).\n"
+                "If they are paired correctly you may want to use the ResizeObjects module "
+                "to make them the same size."
                 % (
                     self.secondary_objects_name,
                     self.primary_objects_name,

--- a/cellprofiler/modules/identifytertiaryobjects.py
+++ b/cellprofiler/modules/identifytertiaryobjects.py
@@ -253,6 +253,18 @@ but the results will be zero or not-a-number (NaN).
                     tertiary_image, _ = cpo.size_similarly(
                         secondary_labels, tertiary_image
                     )
+        # If size/shape differences were too extreme, raise an error.
+        if primary_labels.shape != secondary_labels.shape:
+            raise ValueError(
+                "The first object set (%s) cannot come from a bigger image than the second object set (%s) - %s vs %s"
+                % (
+                    self.secondary_objects_name,
+                    self.primary_objects_name,
+                    secondary_labels.shape,
+                    primary_labels.shape,
+                )
+            )
+
         #
         # Find the outlines of the primary image and use this to shrink the
         # primary image by one. This guarantees that there is something left


### PR DESCRIPTION
Closes #1977.

I've gone through and added checks for whether image dimensions are compatible to modules where this wasn't already handled elsewhere.

In the case of IDTertiary, the module actually has some methods for handling when initial object sets are larger than the smaller objects, but this isn't something the user should be doing intentionally. I've therefore made the error simply ask that the dimensions be matched if this process was unsuccessful.