### PR TITLE
Relabel "OK" button in preferences GUI

### DIFF
--- a/cellprofiler/gui/preferencesdlg.py
+++ b/cellprofiler/gui/preferencesdlg.py
@@ -219,10 +219,13 @@ class PreferencesDlg(wx.Dialog):
         sizer.AddGrowableCol(3, 1)
 
         top_sizer.Add(wx.StaticLine(scrollpanel), 0, wx.EXPAND | wx.ALL, 2)
-        btnsizer = self.CreateButtonSizer(wx.OK | wx.CANCEL)
-        btnsizer.Children[1].Window.Label = "Save"
-        self.Bind(wx.EVT_BUTTON, self.save_preferences, id=wx.ID_OK)
-
+        btnsizer = wx.StdDialogButtonSizer()
+        btnSave = wx.Button(self, wx.ID_SAVE)
+        btnCancel = wx.Button(self, wx.ID_CANCEL)
+        btnsizer.SetAffirmativeButton(btnSave)
+        btnsizer.SetCancelButton(btnCancel)
+        self.Bind(wx.EVT_BUTTON, self.save_preferences, id=wx.ID_SAVE)
+        btnsizer.Realize()
         scrollpanel_sizer.Add(btnsizer, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.ALL, 5)
         scrollpanel.SetupScrolling(scrollToTop=False)
         self.Fit()
@@ -248,6 +251,7 @@ class PreferencesDlg(wx.Dialog):
                 value = control.Value
             if value != getter():
                 setter(value)
+        self.Close()
 
     def get_preferences(self):
         """Get the list of preferences.

--- a/cellprofiler/gui/preferencesdlg.py
+++ b/cellprofiler/gui/preferencesdlg.py
@@ -220,6 +220,7 @@ class PreferencesDlg(wx.Dialog):
 
         top_sizer.Add(wx.StaticLine(scrollpanel), 0, wx.EXPAND | wx.ALL, 2)
         btnsizer = self.CreateButtonSizer(wx.OK | wx.CANCEL)
+        btnsizer.Children[1].Window.Label = "Save"
         self.Bind(wx.EVT_BUTTON, self.save_preferences, id=wx.ID_OK)
 
         scrollpanel_sizer.Add(btnsizer, 0, wx.ALIGN_CENTER_HORIZONTAL | wx.ALL, 5)


### PR DESCRIPTION
Related to #3857.

I'm not sure if anyone has verified the original issue on Linux or if it's already fixed, but on Windows there are no problems with saving. However, the current GUI does not make it obvious that preferences changes will only save when exiting the dialog with the "OK" button. I know this has tripped me up in the past. To address this I've just changed the text on that button to "Save", which will hopefully be more intuitive.

Could someone check that this works fine on Mac? I believe there's a chance that the button order may be reversed with "OK" on the right, in which case I'll add a less lazy solution.