### PR TITLE
Fix pipeline failing to enter test mode properly

### DIFF
--- a/cellprofiler/gui/moduleview.py
+++ b/cellprofiler/gui/moduleview.py
@@ -4808,17 +4808,15 @@ class ValidationRequest(object):
 #     return result
 
 
-def validate_module(pipeline, module_num, test_mode, callback):
+def validate_module(pipeline, module_num, callback):
     """Validate a module and execute the callback on error on the main thread
 
     pipeline - a pipeline to be validated
     module_num - the module number of the module to be validated
-    test_mode - whether pipeline is in test mode
     callback - a callback with the signature, "fn(setting, message, pipeline_data)"
     where setting is the setting that is in error and message is the message to
     display.
     """
-    pipeline.test_mode = test_mode
     modules = [m for m in pipeline.modules() if m.module_num == module_num]
     if len(modules) != 1:
         return
@@ -4855,7 +4853,6 @@ def validation_queue_handler():
                 validate_module(
                     request.pipeline,
                     request.module_num,
-                    request.test_mode,
                     request.callback,
                 )
             except:


### PR DESCRIPTION
Fixes #3945.

As per the issue thread, test mode would sometimes fail to properly set the test mode flag, which causes problems in some pipelines (most notably the example pipeline!). This was happening on the validation thread - test mode flags were also set on this thread. This can confuse CellProfiler since I think stale validation tasks sometimes managed to change the test mode flag before being cleared. Removing the code which does this doesn't bring back the original issue it was added for (#411) - we appear to be using a different threading system now anyway. Validation still seems to work properly so hopefully this is all good now.