### PR TITLE
New GUI for selecting multiple image and object sets

### DIFF
--- a/cellprofiler/gui/moduleview.py
+++ b/cellprofiler/gui/moduleview.py
@@ -2267,7 +2267,7 @@ class ModuleView(object):
     def __on_checklistbox_change(self, event, setting, control):
         if not self.__handle_change:
             return
-        self.on_value_change(setting, control, control.GetChecked(), event)
+        self.on_value_change(setting, control, control.GetChecked(), event, timeout=CHECK_TIMEOUT_SEC * 1000)
 
     def __on_multichoice_change(self, event, setting, control):
         if not self.__handle_change:

--- a/cellprofiler/gui/moduleview.py
+++ b/cellprofiler/gui/moduleview.py
@@ -516,7 +516,8 @@ class ModuleView(object):
                         v, v.get_choices(), control_name, wx.CB_READONLY, control
                     )
                     flag = wx.ALIGN_LEFT
-                elif isinstance(v, cellprofiler.setting.ListImageNameSubscriber):
+                elif isinstance(v, (cellprofiler.setting.ListImageNameSubscriber,
+                                   cellprofiler.setting.ListObjectNameSubscriber)):
                     choices = v.get_choices(self.__pipeline)
                     control = self.make_list_name_subscriber_control(
                         v, choices, control_name, control
@@ -835,7 +836,7 @@ class ModuleView(object):
         return control
 
     def make_list_name_subscriber_control(self, v, choices, control_name, control):
-        """Make a read-only combobox with extra feedback about source modules,
+        """Make a read-only combnobox with extra feedback about source modules,
         and a context menu with choices navigable by module name.
 
         v            - the setting
@@ -843,13 +844,12 @@ class ModuleView(object):
         control_name - assign this name to the control
         """
         if not control:
+            namelabel = "Image" if isinstance(v, cellprofiler.setting.ListImageNameSubscriber) else "Object"
             control = namesubscriber.NameSubscriberListBox(
-                self.__module_panel, checked=v.value, choices=choices, name=control_name
+                self.__module_panel, checked=v.value, choices=choices, name=control_name, nametype=namelabel,
             )
             def callback(event, setting=v, control=control):
-                # the NameSubscriberComboBox behaves like a combobox
                 self.__on_checklistbox_change(event, setting, control)
-
             control.add_callback(callback)
         else:
             if list(choices) != list(control.Items):

--- a/cellprofiler/gui/moduleview.py
+++ b/cellprofiler/gui/moduleview.py
@@ -517,12 +517,12 @@ class ModuleView(object):
                     )
                     flag = wx.ALIGN_LEFT
                 elif isinstance(v, (cellprofiler.setting.ListImageNameSubscriber,
-                                   cellprofiler.setting.ListObjectNameSubscriber)):
+                                    cellprofiler.setting.ListObjectNameSubscriber)):
                     choices = v.get_choices(self.__pipeline)
                     control = self.make_list_name_subscriber_control(
                         v, choices, control_name, control
                     )
-                    flag = wx.ALIGN_LEFT
+                    flag = wx.EXPAND
                 elif isinstance(v, cellprofiler.setting.NameSubscriber):
                     choices = v.get_choices(self.__pipeline)
                     control = self.make_name_subscriber_control(
@@ -848,6 +848,7 @@ class ModuleView(object):
             control = namesubscriber.NameSubscriberListBox(
                 self.__module_panel, checked=v.value, choices=choices, name=control_name, nametype=namelabel,
             )
+
             def callback(event, setting=v, control=control):
                 self.__on_checklistbox_change(event, setting, control)
             control.add_callback(callback)

--- a/cellprofiler/gui/namesubscriber.py
+++ b/cellprofiler/gui/namesubscriber.py
@@ -200,6 +200,7 @@ class NameSubscriberListBox(wx.Panel):
         self.choice_names = self.get_choice_names()
         self.nametype = nametype
         self.list_dlg = wx.CheckListBox(self, style=wx.LB_NEEDED_SB | wx.LB_HSCROLL)
+        self.list_dlg.SetMinSize((200, 100))
         self.SetItems(self.choices)
         self.SetChecked(self.checked)
         sizer = wx.BoxSizer(wx.VERTICAL)

--- a/cellprofiler/gui/namesubscriber.py
+++ b/cellprofiler/gui/namesubscriber.py
@@ -196,13 +196,11 @@ class NameSubscriberListBox(wx.Panel):
         self.list_dlg = wx.CheckListBox(
             self,
             choices=[self.get_choice_label(choice) for choice in choices],
-            style=wx.LB_MULTIPLE,
         )
         self.SetChecked(self.checked)
         sizer = wx.BoxSizer(wx.HORIZONTAL)
         sizer.AddStretchSpacer()
-        sizer.Add(self.list_dlg, flag=wx.ALL | wx.EXPAND | wx.ALIGN_CENTER, border=3)
-        sizer.Add((5, 5))
+        sizer.Add(self.list_dlg, flag=wx.ALL | wx.EXPAND, border=3)
         sizer.AddStretchSpacer()
         self.SetSizer(sizer)
         self.callbacks = []

--- a/cellprofiler/gui/namesubscriber.py
+++ b/cellprofiler/gui/namesubscriber.py
@@ -188,15 +188,14 @@ class NameSubscriberListBox(wx.Panel):
 
     def __init__(self, annotation, choices=None, checked=[], name="", nametype="Image"):
         wx.Panel.__init__(self, annotation, name=name)
-        if choices is None:
-            choices = []
+        self.choices = choices
+        if self.choices is None:
+            self.choices = []
         self.checked = checked
-        self.choice_names = self.get_choice_names(choices)
+        self.choice_names = self.get_choice_names()
         self.nametype = nametype
-        self.list_dlg = wx.CheckListBox(
-            self,
-            choices=[self.get_choice_label(choice) for choice in choices],
-        )
+        self.list_dlg = wx.CheckListBox(self)
+        self.SetItems(self.choices)
         self.SetChecked(self.checked)
         sizer = wx.BoxSizer(wx.HORIZONTAL)
         sizer.AddStretchSpacer()
@@ -264,21 +263,27 @@ class NameSubscriberListBox(wx.Panel):
         whitespace = " "*max(10, (90 - len(name) - len(end)))
         return "".join((name, whitespace, end))
 
-    def get_choice_names(self, choices):
-        choice_names = [choice[0] for choice in choices]
+    def get_choice_names(self):
+        choice_names = [choice[0] for choice in self.choices]
         if self.checked != 'None':
             for item in self.checked:
                 if item not in choice_names:
-                    choice_names.append(item)
-                    choices.append((item, None, 0, True))
+                    choice_names.insert(0, item)
+                    self.choices.insert(0, (item, None, 0, True))
         return choice_names
 
     def GetItems(self):
         return self.list_dlg.GetItems()
 
     def SetItems(self, choices):
-        self.choice_names = self.get_choice_names(choices)
+        self.choices = choices
+        self.choice_names = self.get_choice_names()
         self.list_dlg.SetItems([self.get_choice_label(choice) for choice in choices])
+        for i in range(len(self.choices)):
+            choice = self.choices[i]
+            if choice[1] is None:
+                # Tag missing items
+                self.list_dlg.SetItemBackgroundColour(i, "pink")
         # on Mac, changing the items clears the current selection
         self.SetChecked(self.checked)
         self.Refresh()

--- a/cellprofiler/gui/namesubscriber.py
+++ b/cellprofiler/gui/namesubscriber.py
@@ -178,6 +178,7 @@ class NameSubscriberComboBox(wx.Panel):
 
     Value = property(GetValue, SetValue)
 
+
 class NameSubscriberListBox(wx.Panel):
     """A list of checkboxes with extra annotation, and a context menu.
 
@@ -185,13 +186,13 @@ class NameSubscriberListBox(wx.Panel):
     multiple items.
     """
 
-    def __init__(self, annotation, choices=None, checked=[], name=""):
+    def __init__(self, annotation, choices=None, checked=[], name="", nametype="Image"):
         wx.Panel.__init__(self, annotation, name=name)
         if choices is None:
             choices = []
         self.checked = checked
         self.choice_names = self.get_choice_names(choices)
-
+        self.nametype = nametype
         self.list_dlg = wx.CheckListBox(
             self,
             choices=[self.get_choice_label(choice) for choice in choices],
@@ -224,7 +225,6 @@ class NameSubscriberListBox(wx.Panel):
         menu.Destroy()
 
     def select_all(self, evt):
-        print("Selecting all")
         self.SetChecked(self.choice_names)
         self.checked = self.GetChecked()
         for cb in self.callbacks:
@@ -237,7 +237,6 @@ class NameSubscriberListBox(wx.Panel):
             cb(evt)
 
     def item_selected(self, evt):
-        print("Selected item")
         selected = self.choice_names[evt.Selection]
         if self.list_dlg.IsChecked(evt.Selection):
             self.checked.remove(selected)
@@ -248,7 +247,6 @@ class NameSubscriberListBox(wx.Panel):
         for cb in self.callbacks:
             cb(evt)
         self.list_dlg.Deselect(evt.Selection)
-
 
     def choice_made(self, evt):
         for cb in self.callbacks:
@@ -264,11 +262,9 @@ class NameSubscriberListBox(wx.Panel):
             else:
                 end = "(from %s #%02d)" % (module_name, module_num)
         else:
-            end = "(Module Missing!)"
+            end = "(%s Missing!)" % self.nametype
         whitespace = " "*max(10, (90 - len(name) - len(end)))
         return "".join((name, whitespace, end))
-
-
 
     def get_choice_names(self, choices):
         choice_names = [choice[0] for choice in choices]

--- a/cellprofiler/gui/namesubscriber.py
+++ b/cellprofiler/gui/namesubscriber.py
@@ -2,6 +2,7 @@
 """namesubscriber.py - implements a combobox with extra information
 """
 
+import platform
 import wx
 
 
@@ -191,16 +192,18 @@ class NameSubscriberListBox(wx.Panel):
         self.choices = choices
         if self.choices is None:
             self.choices = []
+        if platform.system() == "darwin":
+            self.text_width = 50
+        else:
+            self.text_width = 90
         self.checked = checked
         self.choice_names = self.get_choice_names()
         self.nametype = nametype
-        self.list_dlg = wx.CheckListBox(self)
+        self.list_dlg = wx.CheckListBox(self, style=wx.LB_NEEDED_SB | wx.LB_HSCROLL)
         self.SetItems(self.choices)
         self.SetChecked(self.checked)
-        sizer = wx.BoxSizer(wx.HORIZONTAL)
-        sizer.AddStretchSpacer()
-        sizer.Add(self.list_dlg, flag=wx.ALL | wx.EXPAND, border=3)
-        sizer.AddStretchSpacer()
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        sizer.Add(self.list_dlg, 0, flag=wx.ALL | wx.EXPAND, border=3)
         self.SetSizer(sizer)
         self.callbacks = []
         self.list_dlg.Bind(wx.EVT_CHECKLISTBOX, self.choice_made)
@@ -260,7 +263,7 @@ class NameSubscriberListBox(wx.Panel):
                 end = "(from %s #%02d)" % (module_name, module_num)
         else:
             end = "(%s Missing!)" % self.nametype
-        whitespace = " "*max(10, (90 - len(name) - len(end)))
+        whitespace = " "*max(10, (self.text_width - len(name) - len(end)))
         return "".join((name, whitespace, end))
 
     def get_choice_names(self):

--- a/cellprofiler/modules/measurecolocalization.py
+++ b/cellprofiler/modules/measurecolocalization.py
@@ -112,20 +112,27 @@ F_COSTES_FORMAT = "Correlation_Costes_%s_%s"
 class MeasureColocalization(cellprofiler.module.Module):
     module_name = "MeasureColocalization"
     category = "Measurement"
-    variable_revision_number = 3
+    variable_revision_number = 4
 
     def create_settings(self):
         """Create the initial settings for the module"""
-        self.image_groups = []
-        self.add_image(can_delete=False)
-        self.spacer_1 = cellprofiler.setting.Divider()
-        self.add_image(can_delete=False)
-        self.image_count = cellprofiler.setting.HiddenCount(self.image_groups)
 
-        self.add_image_button = cellprofiler.setting.DoSomething(
-            "", "Add another image", self.add_image
+        self.images_list = cellprofiler.setting.ListImageNameSubscriber(
+            "Select images to measure",
+            [],
+            doc="""Select images to measure the correlation/colocalization in.""",
         )
-        self.spacer_2 = cellprofiler.setting.Divider()
+
+        self.objects_list = cellprofiler.setting.ListObjectNameSubscriber(
+            "Select objects to measure",
+            [],
+            doc="""\
+*(Used only when "Within objects" or "Both" are selected)*
+
+Select the objects to be measured.""",
+        )
+
+
         self.thr = cellprofiler.setting.Float(
             "Set threshold as percentage of maximum intensity for the images",
             15,
@@ -152,15 +159,8 @@ All methods measure correlation on a pixel by pixel basis.
             % globals(),
         )
 
-        self.object_groups = []
-        self.add_object(can_delete=False)
-        self.object_count = cellprofiler.setting.HiddenCount(self.object_groups)
+        self.spacer = cellprofiler.setting.Divider(line=True)
 
-        self.spacer_2 = cellprofiler.setting.Divider(line=True)
-
-        self.add_object_button = cellprofiler.setting.DoSomething(
-            "", "Add another object", self.add_object
-        )
         self.do_all = cellprofiler.setting.Binary(
             "Run all metrics?",
             True,
@@ -224,115 +224,30 @@ Select *{YES}* to run the Manders coefficients using Costes auto threshold.
             ),
         )
 
-    def add_image(self, can_delete=True):
-        """Add an image to the image_groups collection
-
-        can_delete - set this to False to keep from showing the "remove"
-                     button for images that must be present.
-        """
-        group = cellprofiler.setting.SettingsGroup()
-        if can_delete:
-            group.append("divider", cellprofiler.setting.Divider(line=False))
-        group.append(
-            "image_name",
-            cellprofiler.setting.ImageNameSubscriber(
-                "Select an image to measure",
-                cellprofiler.setting.NONE,
-                doc="Select an image to measure the correlation/colocalization in.",
-            ),
-        )
-
-        if (
-            len(self.image_groups) == 0
-        ):  # Insert space between 1st two images for aesthetics
-            group.append("extra_divider", cellprofiler.setting.Divider(line=False))
-
-        if can_delete:
-            group.append(
-                "remover",
-                cellprofiler.setting.RemoveSettingButton(
-                    "", "Remove this image", self.image_groups, group
-                ),
-            )
-
-        self.image_groups.append(group)
-
-    def add_object(self, can_delete=True):
-        """Add an object to the object_groups collection"""
-        group = cellprofiler.setting.SettingsGroup()
-        if can_delete:
-            group.append("divider", cellprofiler.setting.Divider(line=False))
-
-        group.append(
-            "object_name",
-            cellprofiler.setting.ObjectNameSubscriber(
-                "Select an object to measure",
-                cellprofiler.setting.NONE,
-                doc="""\
-*(Used only when "Within objects" or "Both" are selected)*
-
-Select the objects to be measured.""",
-            ),
-        )
-
-        if can_delete:
-            group.append(
-                "remover",
-                cellprofiler.setting.RemoveSettingButton(
-                    "", "Remove this object", self.object_groups, group
-                ),
-            )
-        self.object_groups.append(group)
 
     def settings(self):
         """Return the settings to be saved in the pipeline"""
-        result = [self.image_count, self.object_count]
-        result += [image_group.image_name for image_group in self.image_groups]
-        result += [self.thr]
-        result += [self.images_or_objects]
-        result += [object_group.object_name for object_group in self.object_groups]
-        result += [
-            self.do_all,
-            self.do_corr_and_slope,
-            self.do_manders,
-            self.do_rwc,
-            self.do_overlap,
-            self.do_costes,
+        result = [self.images_list,
+                  self.thr,
+                  self.images_or_objects,
+                  self.objects_list,
+                  self.do_all,
+                  self.do_corr_and_slope,
+                  self.do_manders,
+                  self.do_rwc,
+                  self.do_overlap,
+                  self.do_costes,
         ]
         return result
 
-    def prepare_settings(self, setting_values):
-        """Make sure there are the right number of image and object slots for the incoming settings"""
-        image_count = int(setting_values[0])
-        object_count = int(setting_values[1])
-        if image_count < 2:
-            raise ValueError(
-                "The MeasureColocalization module must have at least two input images. %d found in pipeline file"
-                % image_count
-            )
-
-        del self.image_groups[image_count:]
-        while len(self.image_groups) < image_count:
-            self.add_image()
-
-        del self.object_groups[object_count:]
-        while len(self.object_groups) < object_count:
-            self.add_object()
-
     def visible_settings(self):
-        result = []
-        for image_group in self.image_groups:
-            result += image_group.visible_settings()
-        result += [
-            self.add_image_button,
-            self.spacer_2,
-            self.thr,
-            self.images_or_objects,
+        result = [self.images_list,
+                  self.spacer,
+                  self.thr,
+                  self.images_or_objects,
         ]
         if self.wants_objects():
-            for object_group in self.object_groups:
-                result += object_group.visible_settings()
-            result += [self.add_object_button]
+            result += [self.objects_list]
         result += [self.do_all]
         if not self.do_all:
             result += [
@@ -349,8 +264,8 @@ Select the objects to be measured.""",
         help_settings = [
             self.images_or_objects,
             self.thr,
-            self.image_groups[0].image_name,
-            self.object_groups[0].object_name,
+            self.images_list,
+            self.objects_list,
             self.do_all,
         ]
         return help_settings
@@ -360,11 +275,11 @@ Select the objects to be measured.""",
 
         Yields the pairs of images in a canonical order.
         """
-        for i in range(self.image_count.value - 1):
-            for j in range(i + 1, self.image_count.value):
+        for i in range(len(self.images_list.value) - 1):
+            for j in range(i + 1, len(self.images_list.value)):
                 yield (
-                    self.image_groups[i].image_name.value,
-                    self.image_groups[j].image_name.value,
+                    self.images_list.value[i],
+                    self.images_list.value[j],
                 )
 
     def wants_images(self):
@@ -385,9 +300,7 @@ Select the objects to be measured.""",
                     workspace, first_image_name, second_image_name
                 )
             if self.wants_objects():
-                for object_name in [
-                    group.object_name.value for group in self.object_groups
-                ]:
+                for object_name in self.objects_list.value:
                     statistics += self.run_image_pair_objects(
                         workspace, first_image_name, second_image_name, object_name
                     )
@@ -1405,8 +1318,8 @@ Select the objects to be measured.""",
                     ]
 
             if self.wants_objects():
-                for i in range(self.object_count.value):
-                    object_name = self.object_groups[i].object_name.value
+                for i in range(len(self.objects_list.value)):
+                    object_name = self.objects_list.value[i]
                     if self.do_corr_and_slope:
                         columns += [
                             (
@@ -1482,7 +1395,7 @@ Select the objects to be measured.""",
         if (object_name == cellprofiler.measurement.IMAGE and self.wants_images()) or (
             (object_name != cellprofiler.measurement.IMAGE)
             and self.wants_objects()
-            and (object_name in [x.object_name.value for x in self.object_groups])
+            and (object_name in self.objects_list.value)
         ):
             return ["Correlation"]
         return []
@@ -1539,6 +1452,23 @@ Select the objects to be measured.""",
             )
             variable_revision_number = 3
 
+        if variable_revision_number == 3:
+            num_images = int(setting_values[0])
+            num_objects = int(setting_values[1])
+            div_img = 2 + num_images
+            div_obj = div_img + 2 + num_objects
+            images_set = set(setting_values[2:div_img])
+            thr_mode = setting_values[div_img:div_img + 2]
+            objects_set = set(setting_values[div_img + 2:div_obj])
+            other_settings = setting_values[div_obj:]
+            if "None" in images_set:
+                images_set.remove("None")
+            if "None" in objects_set:
+                objects_set.remove("None")
+            images_string = ", ".join(map(str, images_set))
+            objects_string = ", ".join(map(str, objects_set))
+            setting_values = [images_string] + thr_mode + [objects_string] + other_settings
+            variable_revision_number = 4
         return setting_values, variable_revision_number, from_matlab
 
     def volumetric(self):

--- a/cellprofiler/modules/measurecolocalization.py
+++ b/cellprofiler/modules/measurecolocalization.py
@@ -1430,6 +1430,19 @@ Select *{YES}* to run the Manders coefficients using Costes auto threshold.
                     result.append("%s_%s" % (i2, i1))
         return result
 
+    def validate_module(self, pipeline):
+        """Make sure chosen objects are selected only once"""
+        if len(self.images_list.value) == 0:
+            raise cellprofiler.setting.ValidationError(
+                "No images selected", self.images_list
+            )
+
+        if self.wants_objects():
+            if len(self.objects_list.value) == 0:
+                raise cellprofiler.setting.ValidationError(
+                    "No object sets selected", self.objects_list
+                )
+
     def upgrade_settings(
         self, setting_values, variable_revision_number, module_name, from_matlab
     ):

--- a/cellprofiler/modules/measuregranularity.py
+++ b/cellprofiler/modules/measuregranularity.py
@@ -13,6 +13,14 @@ Granularity is measured as described by Ilya Ravkin (references below).
 The size of the starting structure element as well as the range of the
 spectrum is given as input.
 
+As of **CellProfiler 4.0** the settings for this module have been changed to simplify
+configuration. A single set of parameters is now applied to all images and objects within the module,
+rather than each image needing individual configuration.
+Pipelines from older versions will be converted to match this format. If multiple sets of parameters
+were defined CellProfiler will apply the first set from the older pipeline version.
+Specifying multiple sets of parameters can still be achieved by running multiple copies of this module.
+
+
 |
 
 ============ ============ ===============

--- a/cellprofiler/modules/measuregranularity.py
+++ b/cellprofiler/modules/measuregranularity.py
@@ -44,6 +44,7 @@ References
    processing”, *Applied Informatics*, v.14, pp. 41-90, Finances and
    Statistics, Moskow, (in Russian)
 """
+import logging
 
 import numpy as np
 import scipy.ndimage as scind
@@ -64,6 +65,8 @@ IMAGE_SETTING_COUNT = IMAGE_SETTING_COUNT_V3
 
 OBJECTS_SETTING_COUNT_V3 = 1
 OBJECTS_SETTING_COUNT = OBJECTS_SETTING_COUNT_V3
+
+logger = logging.getLogger(__name__)
 
 
 class MeasureGranularity(cellprofiler.module.Module):
@@ -254,7 +257,7 @@ class MeasureGranularity(cellprofiler.module.Module):
         # Remove background pixels using a greyscale tophat filter
         #
         if self.image_sample_size.value < 1:
-            back_shape = new_shape * scale.image_sample_size.value
+            back_shape = new_shape * self.image_sample_size.value
             if im.dimensions is 2:
                 i, j = (
                     np.mgrid[0 : back_shape[0], 0 : back_shape[1]].astype(float)
@@ -501,7 +504,7 @@ class MeasureGranularity(cellprofiler.module.Module):
             variable_revision_number = 3
         if variable_revision_number == 3:
             n_images = int(setting_values[0])
-            grouplist = setting_values[1:6*n_images+1]
+            grouplist = setting_values[1:]
             images_list = []
             objects_list = []
             setting_groups = []
@@ -521,32 +524,25 @@ class MeasureGranularity(cellprofiler.module.Module):
             if "None" in images_set:
                 images_set.remove("None")
             if len(settings_set) > 1:
-                import wx
-                wx.MessageBox(
+                logger.warning(
                     "The pipeline you loaded was converted from an older version of CellProfiler.\n"
                     "The MeasureGranularity module no longer supports different settings for each image.\n"
                     "Instead, all selected images and objects will be analysed together with the same settings.\n"
                     "If you want to perform analysis with additional settings, please use a second "
-                    "copy of the module.",
-                    "Compatibility Warning - MeasureGranularity",
-                    wx.ICON_INFORMATION,
+                    "copy of the module."
                 )
             if len(objects_set) > len(objects_list):
-                import wx
-                wx.MessageBox(
+                logger.warning(
                     "The pipeline you loaded was converted from an older version of CellProfiler.\n"
                     "The MeasureGranularity module now analyses all images and object sets together.\n"
                     "Specific pairs of images and objects are no longer supported.\n"
                     "If you want to restrict analysis to specific image/object sets, please use a second "
-                    "copy of the module.",
-                    "Compatibility Warning - MeasureGranularity",
-                    wx.ICON_INFORMATION,
+                    "copy of the module."
                 )
             if len(objects_set) > 0:
                 wants_objects = True
             else:
                 wants_objects = False
-
             images_string = ", ".join(map(str, images_set))
             objects_string = ", ".join(map(str, objects_set))
             setting_values = [images_string, wants_objects, objects_string] + list(setting_groups[0])

--- a/cellprofiler/modules/measuregranularity.py
+++ b/cellprofiler/modules/measuregranularity.py
@@ -181,6 +181,18 @@ class MeasureGranularity(cellprofiler.module.Module):
 
     def validate_module(self, pipeline):
         """Make sure settings are compatible. In particular, we make sure that no measurements are duplicated"""
+        if len(self.images_list.value) == 0:
+            raise cellprofiler.setting.ValidationError(
+                "No images selected", self.images_list
+            )
+
+        if self.wants_objects.value:
+            if len(self.objects_list.value) == 0:
+                raise cellprofiler.setting.ValidationError(
+                    "No object sets selected", self.objects_list
+                )
+
+
         measurements, sources = self.get_measurement_columns(
             pipeline, return_sources=True
         )

--- a/cellprofiler/modules/measuregranularity.py
+++ b/cellprofiler/modules/measuregranularity.py
@@ -50,10 +50,10 @@ import scipy.ndimage as scind
 import skimage.morphology
 from centrosome.cpmorphology import fixup_scipy_ndimage_result as fix
 
-import cellprofiler.measurement as cpmeas
-import cellprofiler.module as cpm
-import cellprofiler.setting as cps
-import cellprofiler.workspace as cpw
+import cellprofiler.measurement
+import cellprofiler.module
+import cellprofiler.setting
+import cellprofiler.workspace
 
 "Granularity category"
 C_GRANULARITY = "Granularity_%s_%s"
@@ -66,139 +66,107 @@ OBJECTS_SETTING_COUNT_V3 = 1
 OBJECTS_SETTING_COUNT = OBJECTS_SETTING_COUNT_V3
 
 
-class MeasureGranularity(cpm.Module):
+class MeasureGranularity(cellprofiler.module.Module):
     module_name = "MeasureGranularity"
     category = "Measurement"
-    variable_revision_number = 3
+    variable_revision_number = 4
 
     def create_settings(self):
-        self.divider_top = cps.Divider(line=False)
-        self.images = []
-        self.image_count = cps.HiddenCount(self.images, "Image count")
-        self.add_image(can_remove=False)
-        self.add_button = cps.DoSomething("", "Add another image", self.add_image)
-        self.divider_bottom = cps.Divider(line=False)
-
-    def add_image(self, can_remove=True):
-        group = GranularitySettingsGroup()
-        group.can_remove = can_remove
-        if can_remove:
-            group.append("divider", cps.Divider(line=True))
-
-        group.append(
-            "image_name",
-            cps.ImageNameSubscriber(
-                "Select an image to measure",
-                cps.NONE,
-                doc="Select the grayscale images whose granularity you want to measure.",
-            ),
+        self.images_list = cellprofiler.setting.ListImageNameSubscriber(
+            "Select images to measure",
+            [],
+            doc="""Select images in which to measure the granularity.""",
         )
 
-        group.append(
-            "subsample_size",
-            cps.Float(
+        self.divider_top = cellprofiler.setting.Divider(line=True)
+
+        self.wants_objects = cellprofiler.setting.Binary(
+            "Measure within objects?",
+            False,
+            doc="""\
+        Press this button to capture granularity measurements for objects, such as
+        those identified by a prior **IdentifyPrimaryObjects** module.
+        **MeasureGranularity** will measure the image’s granularity within each
+        object at the requested scales."""
+        )
+
+        self.objects_list = cellprofiler.setting.ListObjectNameSubscriber(
+            "Select objects to measure",
+            [],
+            doc="""\
+        *(Used only when "Measure within objects" is enabled)*
+
+        Select the objects within which granularity will be measured.""",
+        )
+
+        self.divider_bottom = cellprofiler.setting.Divider(line=True)
+        self.subsample_size = cellprofiler.setting.Float(
                 "Subsampling factor for granularity measurements",
                 0.25,
                 minval=np.finfo(float).eps,
                 maxval=1,
                 doc="""\
-If the textures of interest are larger than a few pixels, we recommend
-you subsample the image with a factor <1 to speed up the processing.
-Down sampling the image will let you detect larger structures with a
-smaller sized structure element. A factor >1 might increase the accuracy
-but also require more processing time. Images are typically of higher
-resolution than is required for granularity measurements, so the default
-value is 0.25. For low-resolution images, increase the subsampling
-fraction; for high-resolution images, decrease the subsampling fraction.
-Subsampling by 1/4 reduces computation time by (1/4) :sup:`3` because the
-size of the image is (1/4) :sup:`2` of original and the range of granular
-spectrum can be 1/4 of original. Moreover, the results are sometimes
-actually a little better with subsampling, which is probably because
-with subsampling the individual granular spectrum components can be used
-as features, whereas without subsampling a feature should be a sum of
-several adjacent granular spectrum components. The recommendation on the
-numerical value cannot be determined in advance; an analysis as in this
-reference may be required before running the whole set. See this `pdf`_,
-slides 27-31, 49-50.
+        If the textures of interest are larger than a few pixels, we recommend
+        you subsample the image with a factor <1 to speed up the processing.
+        Down sampling the image will let you detect larger structures with a
+        smaller sized structure element. A factor >1 might increase the accuracy
+        but also require more processing time. Images are typically of higher
+        resolution than is required for granularity measurements, so the default
+        value is 0.25. For low-resolution images, increase the subsampling
+        fraction; for high-resolution images, decrease the subsampling fraction.
+        Subsampling by 1/4 reduces computation time by (1/4) :sup:`3` because the
+        size of the image is (1/4) :sup:`2` of original and the range of granular
+        spectrum can be 1/4 of original. Moreover, the results are sometimes
+        actually a little better with subsampling, which is probably because
+        with subsampling the individual granular spectrum components can be used
+        as features, whereas without subsampling a feature should be a sum of
+        several adjacent granular spectrum components. The recommendation on the
+        numerical value cannot be determined in advance; an analysis as in this
+        reference may be required before running the whole set. See this `pdf`_,
+        slides 27-31, 49-50.
 
-.. _pdf: http://www.ravkin.net/presentations/Statistical%20properties%20of%20algorithms%20for%20analysis%20of%20cell%20images.pdf""",
-            ),
-        )
+        .. _pdf: http://www.ravkin.net/presentations/Statistical%20properties%20of%20algorithms%20for%20analysis%20of%20cell%20images.pdf""",
+            )
 
-        group.append(
-            "image_sample_size",
-            cps.Float(
+        self.image_sample_size = cellprofiler.setting.Float(
                 "Subsampling factor for background reduction",
                 0.25,
                 minval=np.finfo(float).eps,
                 maxval=1,
                 doc="""\
-It is important to remove low frequency image background variations as
-they will affect the final granularity measurement. Any method can be
-used as a pre-processing step prior to this module; we have chosen to
-simply subtract a highly open image. To do it quickly, we subsample the
-image first. The subsampling factor for background reduction is usually
-[0.125 – 0.25]. This is highly empirical, but a small factor should be
-used if the structures of interest are large. The significance of
-background removal in the context of granulometry is that image volume
-at certain granular size is normalized by total image volume, which
-depends on how the background was removed.""",
-            ),
-        )
+        It is important to remove low frequency image background variations as
+        they will affect the final granularity measurement. Any method can be
+        used as a pre-processing step prior to this module; we have chosen to
+        simply subtract a highly open image. To do it quickly, we subsample the
+        image first. The subsampling factor for background reduction is usually
+        [0.125 – 0.25]. This is highly empirical, but a small factor should be
+        used if the structures of interest are large. The significance of
+        background removal in the context of granulometry is that image volume
+        at certain granular size is normalized by total image volume, which
+        depends on how the background was removed.""",
+            )
 
-        group.append(
-            "element_size",
-            cps.Integer(
+        self.element_size = cellprofiler.setting.Integer(
                 "Radius of structuring element",
                 10,
                 minval=1,
                 doc="""\
-This radius should correspond to the radius of the textures of interest
-*after* subsampling; i.e., if textures in the original image scale have
-a radius of 40 pixels, and a subsampling factor of 0.25 is used, the
-structuring element size should be 10 or slightly smaller, and the range
-of the spectrum defined below will cover more sizes.""",
-            ),
-        )
+        This radius should correspond to the radius of the textures of interest
+        *after* subsampling; i.e., if textures in the original image scale have
+        a radius of 40 pixels, and a subsampling factor of 0.25 is used, the
+        structuring element size should be 10 or slightly smaller, and the range
+        of the spectrum defined below will cover more sizes.""",
+            )
 
-        group.append(
-            "granular_spectrum_length",
-            cps.Integer(
+        self.granular_spectrum_length = cellprofiler.setting.Integer(
                 "Range of the granular spectrum",
                 16,
                 minval=1,
                 doc="""\
-You may need a trial run to see which granular
-spectrum range yields informative measurements. Start by using a wide spectrum and
-narrow it down to the informative range to save time.""",
-            ),
-        )
-
-        group.append(
-            "add_objects_button",
-            cps.DoSomething(
-                "",
-                "Add another object",
-                group.add_objects,
-                doc="""\
-Press this button to add granularity measurements for objects, such as
-those identified by a prior **IdentifyPrimaryObjects** module.
-**MeasureGranularity** will measure the image’s granularity within each
-object at the requested scales.""",
-            ),
-        )
-
-        group.objects = []
-
-        group.object_count = cps.HiddenCount(group.objects, "Object count")
-
-        if can_remove:
-            group.append(
-                "remover",
-                cps.RemoveSettingButton("", "Remove this image", self.images, group),
+        You may need a trial run to see which granular
+        spectrum range yields informative measurements. Start by using a wide spectrum and
+        narrow it down to the informative range to save time.""",
             )
-        self.images.append(group)
-        return group
 
     def validate_module(self, pipeline):
         """Make sure settings are compatible. In particular, we make sure that no measurements are duplicated"""
@@ -208,52 +176,37 @@ object at the requested scales.""",
         d = {}
         for m, s in zip(measurements, sources):
             if m in d:
-                raise cps.ValidationError("Measurement %s made twice." % (m[1]), s[0])
+                raise cellprofiler.setting.ValidationError("Measurement %s made twice." % (m[1]), s[0])
             d[m] = True
 
     def settings(self):
-        result = [self.image_count]
-        for image in self.images:
-            result += [
-                image.object_count,
-                image.image_name,
-                image.subsample_size,
-                image.image_sample_size,
-                image.element_size,
-                image.granular_spectrum_length,
-            ]
-            result += [ob.objects_name for ob in image.objects]
+        result = [self.images_list,
+                  self.wants_objects,
+                  self.objects_list,
+                  self.subsample_size,
+                  self.image_sample_size,
+                  self.element_size,
+                  self.granular_spectrum_length,
+                  ]
         return result
 
-    def prepare_settings(self, setting_values):
-        """Adjust self.images to account for the expected # of images"""
-        image_count = int(setting_values[0])
-        idx = 1
-        del self.images[:]
-        while len(self.images) < image_count:
-            image = self.add_image(len(self.images) > 0)
-            object_count = int(setting_values[idx])
-            idx += IMAGE_SETTING_COUNT
-            for i in range(object_count):
-                image.add_objects()
-                idx += OBJECTS_SETTING_COUNT
-
     def visible_settings(self):
-        result = []
-        for index, image in enumerate(self.images):
-            result += image.visible_settings()
-        result += [self.add_button]
+        result = [self.images_list, self.divider_top, self.wants_objects]
+        if self.wants_objects.value:
+            result += [self.objects_list]
+        result += [self.divider_bottom,
+                   self.subsample_size,
+                   self.image_sample_size,
+                   self.element_size,
+                   self.granular_spectrum_length
+                   ]
         return result
 
     def run(self, workspace):
-        max_scale = np.max(
-            [image.granular_spectrum_length.value for image in self.images]
-        )
-        col_labels = ["Image name"] + ["GS%d" % n for n in range(1, max_scale + 1)]
+        col_labels = ["Image name"] + ["GS%d" % n for n in range(1, self.granular_spectrum_length.value + 1)]
         statistics = []
-        for image in self.images:
-            statistic = self.run_on_image_setting(workspace, image)
-            statistic += ["-"] * (max_scale - image.granular_spectrum_length.value)
+        for image_name in self.images_list.value:
+            statistic = self.run_on_image_setting(workspace, image_name)
             statistics.append(statistic)
         if self.show_window:
             workspace.display_data.statistics = statistics
@@ -267,21 +220,21 @@ object at the requested scales.""",
                              title="If individual objects were measured, use an Export module to view their results"
                              )
 
-    def run_on_image_setting(self, workspace, image):
-        assert isinstance(workspace, cpw.Workspace)
+    def run_on_image_setting(self, workspace, image_name):
+        assert isinstance(workspace, cellprofiler.workspace.Workspace)
         image_set = workspace.image_set
         measurements = workspace.measurements
-        im = image_set.get_image(image.image_name.value, must_be_grayscale=True)
+        im = image_set.get_image(image_name, must_be_grayscale=True)
         #
         # Downsample the image and mask
         #
         new_shape = np.array(im.pixel_data.shape)
-        if image.subsample_size.value < 1:
-            new_shape = new_shape * image.subsample_size.value
+        if self.subsample_size.value < 1:
+            new_shape = new_shape * self.subsample_size.value
             if im.dimensions is 2:
                 i, j = (
                     np.mgrid[0 : new_shape[0], 0 : new_shape[1]].astype(float)
-                    / image.subsample_size.value
+                    / self.subsample_size.value
                 )
                 pixels = scind.map_coordinates(im.pixel_data, (i, j), order=1)
                 mask = scind.map_coordinates(im.mask.astype(float), (i, j)) > 0.9
@@ -290,7 +243,7 @@ object at the requested scales.""",
                     np.mgrid[
                         0 : new_shape[0], 0 : new_shape[1], 0 : new_shape[2]
                     ].astype(float)
-                    / image.subsample_size.value
+                    / self.subsample_size.value
                 )
                 pixels = scind.map_coordinates(im.pixel_data, (k, i, j), order=1)
                 mask = scind.map_coordinates(im.mask.astype(float), (k, i, j)) > 0.9
@@ -300,12 +253,12 @@ object at the requested scales.""",
         #
         # Remove background pixels using a greyscale tophat filter
         #
-        if image.image_sample_size.value < 1:
-            back_shape = new_shape * image.image_sample_size.value
+        if self.image_sample_size.value < 1:
+            back_shape = new_shape * scale.image_sample_size.value
             if im.dimensions is 2:
                 i, j = (
                     np.mgrid[0 : back_shape[0], 0 : back_shape[1]].astype(float)
-                    / image.image_sample_size.value
+                    / self.image_sample_size.value
                 )
                 back_pixels = scind.map_coordinates(pixels, (i, j), order=1)
                 back_mask = scind.map_coordinates(mask.astype(float), (i, j)) > 0.9
@@ -314,7 +267,7 @@ object at the requested scales.""",
                     np.mgrid[
                         0 : new_shape[0], 0 : new_shape[1], 0 : new_shape[2]
                     ].astype(float)
-                    / image.subsample_size.value
+                    / self.subsample_size.value
                 )
                 back_pixels = scind.map_coordinates(pixels, (k, i, j), order=1)
                 back_mask = scind.map_coordinates(mask.astype(float), (k, i, j)) > 0.9
@@ -322,7 +275,7 @@ object at the requested scales.""",
             back_pixels = pixels
             back_mask = mask
             back_shape = new_shape
-        radius = image.element_size.value
+        radius = self.element_size.value
         if im.dimensions is 2:
             selem = skimage.morphology.disk(radius, dtype=bool)
         else:
@@ -333,7 +286,7 @@ object at the requested scales.""",
         back_pixels_mask = np.zeros_like(back_pixels)
         back_pixels_mask[back_mask == True] = back_pixels[back_mask == True]
         back_pixels = skimage.morphology.dilation(back_pixels_mask, selem=selem)
-        if image.image_sample_size.value < 1:
+        if self.image_sample_size.value < 1:
             if im.dimensions is 2:
                 i, j = np.mgrid[0 : new_shape[0], 0 : new_shape[1]].astype(float)
                 #
@@ -371,7 +324,7 @@ object at the requested scales.""",
                     )
                     self.start_mean = np.maximum(self.current_mean, np.finfo(float).eps)
 
-        object_records = [ObjectRecord(ob.objects_name.value) for ob in image.objects]
+        object_records = [ObjectRecord(objects_name) for objects_name in self.objects_list.value]
         #
         # Transcribed from the Matlab module: granspectr function
         #
@@ -384,7 +337,7 @@ object at the requested scales.""",
         # I.Ravkin, V.Temov "Bit representation techniques and image processing", Applied Informatics, v.14, pp. 41-90, Finances and Statistics, Moskow, 1988 (in Russian)
         # THIS IMPLEMENTATION INSTEAD OF OPENING USES EROSION FOLLOWED BY RECONSTRUCTION
         #
-        ng = image.granular_spectrum_length.value
+        ng = self.granular_spectrum_length.value
         startmean = np.mean(pixels[mask])
         ero = pixels.copy()
         # Mask the test image so that masked pixels will have no effect
@@ -398,7 +351,7 @@ object at the requested scales.""",
             footprint = skimage.morphology.disk(1, dtype=bool)
         else:
             footprint = skimage.morphology.ball(1, dtype=bool)
-        statistics = [image.image_name.value]
+        statistics = [image_name]
         for i in range(1, ng + 1):
             prevmean = currentmean
             ero_mask = np.zeros_like(ero)
@@ -408,7 +361,7 @@ object at the requested scales.""",
             currentmean = np.mean(rec[mask])
             gs = (prevmean - currentmean) * 100 / startmean
             statistics += ["%.2f" % gs]
-            feature = image.granularity_feature(i)
+            feature = self.granularity_feature(i, image_name)
             measurements.add_image_measurement(feature, gs)
             #
             # Restore the reconstructed image to the shape of the
@@ -455,23 +408,23 @@ object at the requested scales.""",
     def get_measurement_columns(self, pipeline, return_sources=False):
         result = []
         sources = []
-        for image in self.images:
-            gslength = image.granular_spectrum_length.value
+        for image_name in self.images_list.value:
+            gslength = self.granular_spectrum_length.value
             for i in range(1, gslength + 1):
                 result += [
-                    (cpmeas.IMAGE, image.granularity_feature(i), cpmeas.COLTYPE_FLOAT)
+                    (cellprofiler.measurement.IMAGE, self.granularity_feature(i, image_name), cellprofiler.measurement.COLTYPE_FLOAT)
                 ]
-                sources += [(image.image_name, image.granularity_feature(i))]
-            for ob in image.objects:
+                sources += [(image_name, self.granularity_feature(i, image_name))]
+            for object_name in self.objects_list.value:
                 for i in range(1, gslength + 1):
                     result += [
                         (
-                            ob.objects_name.value,
-                            image.granularity_feature(i),
-                            cpmeas.COLTYPE_FLOAT,
+                            object_name,
+                            self.granularity_feature(i, image_name),
+                            cellprofiler.measurement.COLTYPE_FLOAT,
                         )
                     ]
-                    sources += [(ob.objects_name.value, image.granularity_feature(i))]
+                    sources += [(object_name, self.granularity_feature(i, image_name))]
 
         if return_sources:
             return result, sources
@@ -483,16 +436,20 @@ object at the requested scales.""",
 
         object_name - name of an object or IMAGE to match all
         """
-        if object_name == cpmeas.IMAGE:
-            return self.images
+        if object_name == cellprofiler.measurement.IMAGE:
+            return self.images_list.value
         return [
-            image
-            for image in self.images
-            if object_name in [ob.objects_name.value for ob in image.objects]
+            image_name
+            for image_name in self.images_list.value
+            if object_name in self.objects_list.value
         ]
 
     def get_categories(self, pipeline, object_name):
-        if len(self.get_matching_images(object_name)) > 0:
+        """Return the categories supported by this module for the given object
+
+        object_name - name of the measured object or cellprofiler.measurement.IMAGE
+        """
+        if object_name in self.objects_list.value and self.wants_objects.value:
             return ["Granularity"]
         else:
             return []
@@ -500,8 +457,7 @@ object at the requested scales.""",
     def get_measurements(self, pipeline, object_name, category):
         max_length = 0
         if category == "Granularity":
-            for image in self.get_matching_images(object_name):
-                max_length = max(max_length, image.granular_spectrum_length.value)
+                max_length = max(max_length, self.granular_spectrum_length.value)
         return [str(i) for i in range(1, max_length + 1)]
 
     def get_measurement_images(self, pipeline, object_name, category, measurement):
@@ -513,10 +469,13 @@ object at the requested scales.""",
                     return []
             except ValueError:
                 return []
-            for image in self.get_matching_images(object_name):
-                if image.granular_spectrum_length.value >= length:
-                    result.append(image.image_name.value)
+            if self.granular_spectrum_length.value >= length:
+                for image_name in self.images_list.value:
+                    result.append(image_name)
         return result
+
+    def granularity_feature(self, length, image_name):
+        return C_GRANULARITY % (length, image_name)
 
     def upgrade_settings(
         self, setting_values, variable_revision_number, module_name, from_matlab
@@ -526,7 +485,7 @@ object at the requested scales.""",
             from_matlab = False
             variable_revision_number = 1
         if variable_revision_number == 1:
-            # changed to use cps.SettingsGroup() but did not change the
+            # changed to use cellprofiler.setting.SettingsGroup() but did not change the
             # ordering of any of the settings
             variable_revision_number = 2
         if variable_revision_number == 2:
@@ -540,51 +499,61 @@ object at the requested scales.""",
                 setting_values = setting_values[IMAGE_SETTING_COUNT_V2:]
             setting_values = new_setting_values
             variable_revision_number = 3
+        if variable_revision_number == 3:
+            n_images = int(setting_values[0])
+            grouplist = setting_values[1:6*n_images+1]
+            images_list = []
+            objects_list = []
+            setting_groups = []
+            while grouplist:
+                n_objects = int(grouplist[0])
+                images_list += [grouplist[1]]
+                setting_groups.append(tuple(grouplist[2:6]))
+                if grouplist[6:6+n_objects] != "None":
+                    objects_list += grouplist[6:6+n_objects]
+                if len(grouplist) > 6+n_objects:
+                    grouplist = grouplist[6+n_objects:]
+                else:
+                    grouplist = False
+            images_set = set(images_list)
+            objects_set = set(objects_list)
+            settings_set = set(setting_groups)
+            if "None" in images_set:
+                images_set.remove("None")
+            if len(settings_set) > 1:
+                import wx
+                wx.MessageBox(
+                    "The pipeline you loaded was converted from an older version of CellProfiler.\n"
+                    "The MeasureGranularity module no longer supports different settings for each image.\n"
+                    "Instead, all selected images and objects will be analysed together with the same settings.\n"
+                    "If you want to perform analysis with additional settings, please use a second "
+                    "copy of the module.",
+                    "Compatibility Warning - MeasureGranularity",
+                    wx.ICON_INFORMATION,
+                )
+            if len(objects_set) > len(objects_list):
+                import wx
+                wx.MessageBox(
+                    "The pipeline you loaded was converted from an older version of CellProfiler.\n"
+                    "The MeasureGranularity module now analyses all images and object sets together.\n"
+                    "Specific pairs of images and objects are no longer supported.\n"
+                    "If you want to restrict analysis to specific image/object sets, please use a second "
+                    "copy of the module.",
+                    "Compatibility Warning - MeasureGranularity",
+                    wx.ICON_INFORMATION,
+                )
+            if len(objects_set) > 0:
+                wants_objects = True
+            else:
+                wants_objects = False
+
+            images_string = ", ".join(map(str, images_set))
+            objects_string = ", ".join(map(str, objects_set))
+            setting_values = [images_string, wants_objects, objects_string] + list(setting_groups[0])
+
+            variable_revision_number = 4
+
         return setting_values, variable_revision_number, from_matlab
 
     def volumetric(self):
         return True
-
-
-class GranularitySettingsGroup(cps.SettingsGroup):
-    def granularity_feature(self, length):
-        return C_GRANULARITY % (length, self.image_name.value)
-
-    def add_objects(self):
-        og = cps.SettingsGroup()
-        og.append(
-            "objects_name",
-            cps.ObjectNameSubscriber(
-                "Select objects to measure",
-                cps.NONE,
-                doc="""\
-Select the objects whose granularity will be measured. You can select
-objects from prior modules that identify objects, such as
-**IdentifyPrimaryObjects**. If you only want to measure the granularity
-for the image overall, you can remove all objects using the “Remove this
-object” button.""",
-            ),
-        )
-        og.append(
-            "remover",
-            cps.RemoveSettingButton("", "Remove this object", self.objects, og),
-        )
-        self.objects.append(og)
-
-    def visible_settings(self):
-        result = []
-        if self.can_remove:
-            result += [self.divider]
-        result += [
-            self.image_name,
-            self.subsample_size,
-            self.image_sample_size,
-            self.element_size,
-            self.granular_spectrum_length,
-        ]
-        for ob in self.objects:
-            result += [ob.objects_name, ob.remover]
-        result += [self.add_objects_button]
-        if self.can_remove:
-            result += [self.remover]
-        return result

--- a/cellprofiler/modules/measureimageareaoccupied.py
+++ b/cellprofiler/modules/measureimageareaoccupied.py
@@ -103,7 +103,7 @@ Area occupied can be measured in two ways:
             [],
             doc="""*(Used only if ‘{O_BINARY_IMAGE}’ is to be measured)*
 
-This is a binary image created earlier in the pipeline, where you would
+These should be binary images created earlier in the pipeline, where you would
 like to measure the area occupied by the foreground in the image.
                     """.format(
                         **{"O_BINARY_IMAGE": O_BINARY_IMAGE}

--- a/cellprofiler/modules/measureimageareaoccupied.py
+++ b/cellprofiler/modules/measureimageareaoccupied.py
@@ -69,6 +69,7 @@ F_TOTAL_VOLUME = "TotalVolume"
 
 O_BINARY_IMAGE = "Binary Image"
 O_OBJECTS = "Objects"
+O_BOTH = "Both"
 
 # The number of settings per image or object group
 IMAGE_SETTING_COUNT = 1
@@ -79,163 +80,79 @@ OBJECT_SETTING_COUNT = 3
 class MeasureImageAreaOccupied(cellprofiler.module.Module):
     module_name = "MeasureImageAreaOccupied"
     category = "Measurement"
-    variable_revision_number = 4
+    variable_revision_number = 5
 
     def create_settings(self):
-        self.operands = []
-
-        self.count = cellprofiler.setting.HiddenCount(self.operands)
-
-        self.add_operand(can_remove=False)
-
-        self.add_operand_button = cellprofiler.setting.DoSomething(
-            "", "Add another area", self.add_operand
-        )
-
-        self.remover = cellprofiler.setting.DoSomething(
-            "", "Remove this area", self.remove
-        )
-
-    def add_operand(self, can_remove=True):
-        class Operand(object):
-            def __init__(self):
-                self.__spacer = cellprofiler.setting.Divider(line=True)
-
-                self.__operand_choice = cellprofiler.setting.Choice(
-                    "Measure the area occupied in a binary image, or in objects?",
-                    [O_BINARY_IMAGE, O_OBJECTS],
-                    doc="""\
-The area can be measured in two ways:
+        self.operand_choice = cellprofiler.setting.Choice(
+            "Measure the area occupied by",
+            [O_BINARY_IMAGE, O_OBJECTS, O_BOTH],
+            doc="""\
+Area occupied can be measured in two ways:
 
 -  *{O_BINARY_IMAGE}:* The area occupied by the foreground in a binary (black and white) image.
 -  *{O_OBJECTS}:* The area occupied by previously-identified objects.
                     """.format(
                         **{"O_BINARY_IMAGE": O_BINARY_IMAGE, "O_OBJECTS": O_OBJECTS}
                     ),
-                )
+        )
 
-                self.__operand_objects = cellprofiler.setting.ObjectNameSubscriber(
-                    "Select objects to measure",
-                    cellprofiler.setting.NONE,
-                    doc="""\
-*(Used only if ‘{O_OBJECTS}’ are to be measured)*
+        self.divider = cellprofiler.setting.Divider()
 
-Select the previously identified objects you would like to measure.
-                    """.format(
-                        **{"O_OBJECTS": O_OBJECTS}
-                    ),
-                )
-
-                self.__binary_name = cellprofiler.setting.ImageNameSubscriber(
-                    "Select a binary image to measure",
-                    cellprofiler.setting.NONE,
-                    doc="""\
-*(Used only if ‘{O_BINARY_IMAGE}’ is to be measured)*
+        self.images_list = cellprofiler.setting.ListImageNameSubscriber(
+            "Select binary images to measure",
+            [],
+            doc="""*(Used only if ‘{O_BINARY_IMAGE}’ is to be measured)*
 
 This is a binary image created earlier in the pipeline, where you would
 like to measure the area occupied by the foreground in the image.
                     """.format(
                         **{"O_BINARY_IMAGE": O_BINARY_IMAGE}
                     ),
-                )
+        )
 
-            @property
-            def spacer(self):
-                return self.__spacer
+        self.objects_list = cellprofiler.setting.ListObjectNameSubscriber(
+            "Select object sets to measure",
+            [],
+            doc="""*(Used only if ‘{O_OBJECTS}’ are to be measured)*
 
-            @property
-            def operand_choice(self):
-                return self.__operand_choice
-
-            @property
-            def operand_objects(self):
-                return self.__operand_objects
-
-            @property
-            def binary_name(self):
-                return self.__binary_name
-
-            @property
-            def remover(self):
-                return self.__remover
-
-            @property
-            def object(self):
-                if self.operand_choice == O_BINARY_IMAGE:
-                    return self.binary_name.value
-                else:
-                    return self.operand_objects.value
-
-        self.operands += [Operand()]
-
-    def remove(self):
-        del self.operands[-1]
-
-        return self.operands
+Select the previously identified objects you would like to measure.""".format(
+                        **{"O_OBJECTS": O_OBJECTS}
+                    ),
+        )
 
     def validate_module(self, pipeline):
         """Make sure chosen objects and images are selected only once"""
-        settings = {}
-        for group in self.operands:
-            if (group.operand_choice.value, group.operand_objects.value) in settings:
-                if group.operand_choice.value == O_OBJECTS:
+        if self.operand_choice in (O_BINARY_IMAGE, O_BOTH):
+            images = set()
+            if len(self.images_list.value) == 0:
+                raise cellprofiler.setting.ValidationError("No images selected", self.images_list)
+            for image_name in self.images_list.value:
+                if image_name in images:
                     raise cellprofiler.setting.ValidationError(
-                        "{} has already been selected".format(
-                            group.operand_objects.value
-                        ),
-                        group.operand_objects,
+                        "%s has already been selected" % image_name, image_name
                     )
-
-            settings[(group.operand_choice.value, group.operand_objects.value)] = True
-
-        settings = {}
-        for group in self.operands:
-            if (group.operand_choice.value, group.binary_name.value) in settings:
-                if group.operand_choice.value == O_BINARY_IMAGE:
+                images.add(image_name)
+        if self.operand_choice in (O_OBJECTS, O_BOTH):
+            objects = set()
+            if len(self.objects_list.value) == 0:
+                raise cellprofiler.setting.ValidationError("No objects selected", self.objects_list)
+            for object_name in self.objects_list.value:
+                if object_name in objects:
                     raise cellprofiler.setting.ValidationError(
-                        "%s has already been selected" % group.binary_name.value,
-                        group.binary_name,
+                        "%s has already been selected" % object_name, object_name
                     )
-            settings[(group.operand_choice.value, group.binary_name.value)] = True
+                objects.add(object_name)
 
     def settings(self):
-        result = [self.count]
-
-        for op in self.operands:
-            result += [op.operand_choice, op.operand_objects, op.binary_name]
-
+        result = [self.operand_choice, self.images_list, self.objects_list]
         return result
 
-    def prepare_settings(self, setting_values):
-        count = int(setting_values[0])
-
-        sequence = self.operands
-
-        del sequence[count:]
-
-        while len(sequence) < count:
-            self.add_operand()
-
-            sequence = self.operands
-
     def visible_settings(self):
-        result = []
-
-        for op in self.operands:
-            result += [op.spacer]
-
-            result += [op.operand_choice]
-
-            result += (
-                [op.operand_objects]
-                if op.operand_choice == O_OBJECTS
-                else [op.binary_name]
-            )
-
-        result.append(self.add_operand_button)
-
-        result.append(self.remover)
-
+        result = [self.operand_choice, self.divider]
+        if self.operand_choice in (O_BOTH, O_BINARY_IMAGE):
+            result.append(self.images_list)
+        if self.operand_choice in (O_BOTH, O_OBJECTS):
+            result.append(self.objects_list)
         return result
 
     def run(self, workspace):
@@ -243,12 +160,16 @@ like to measure the area occupied by the foreground in the image.
 
         statistics = []
 
-        for op in self.operands:
-            if op.operand_choice == O_OBJECTS:
-                statistics += self.measure_objects(op, workspace)
-
-            if op.operand_choice == O_BINARY_IMAGE:
-                statistics += self.measure_images(op, workspace)
+        if self.operand_choice in (O_BOTH, O_BINARY_IMAGE):
+            if len(self.images_list.value) == 0:
+                raise ValueError("No images were selected for analysis.")
+            for binary_image in self.images_list.value:
+                statistics += self.measure_images(binary_image, workspace)
+        if self.operand_choice in (O_BOTH, O_OBJECTS):
+            if len(self.objects_list.value) == 0:
+                raise ValueError("No object sets were selected for analysis.")
+            for object_set in self.objects_list.value:
+                statistics += self.measure_objects(object_set, workspace)
 
         if self.show_window:
             workspace.display_data.statistics = statistics
@@ -276,8 +197,8 @@ like to measure the area occupied by the foreground in the image.
             numpy.array([features], dtype=float),
         )
 
-    def measure_objects(self, operand, workspace):
-        objects = workspace.get_objects(operand.operand_objects.value)
+    def measure_objects(self, object_set, workspace):
+        objects = workspace.get_objects(object_set)
 
         label_image = objects.segmented
 
@@ -315,21 +236,21 @@ like to measure the area occupied by the foreground in the image.
         pipeline = workspace.pipeline
 
         self._add_image_measurement(
-            operand.operand_objects.value,
+            object_set,
             F_VOLUME_OCCUPIED if pipeline.volumetric() else F_AREA_OCCUPIED,
             area_occupied,
             measurements,
         )
 
         self._add_image_measurement(
-            operand.operand_objects.value,
+            object_set,
             F_SURFACE_AREA if pipeline.volumetric() else F_PERIMETER,
             perimeter,
             measurements,
         )
 
         self._add_image_measurement(
-            operand.operand_objects.value,
+            object_set,
             F_TOTAL_VOLUME if pipeline.volumetric() else F_TOTAL_AREA,
             total_area,
             measurements,
@@ -337,16 +258,16 @@ like to measure the area occupied by the foreground in the image.
 
         return [
             [
-                operand.operand_objects.value,
+                object_set,
                 str(area_occupied),
                 str(perimeter),
                 str(total_area),
             ]
         ]
 
-    def measure_images(self, operand, workspace):
+    def measure_images(self, image_set, workspace):
         image = workspace.image_set.get_image(
-            operand.binary_name.value, must_be_binary=True
+            image_set, must_be_binary=True
         )
 
         area_occupied = numpy.sum(image.pixel_data > 0)
@@ -362,21 +283,21 @@ like to measure the area occupied by the foreground in the image.
         pipeline = workspace.pipeline
 
         self._add_image_measurement(
-            operand.binary_name.value,
+            image_set,
             F_VOLUME_OCCUPIED if pipeline.volumetric() else F_AREA_OCCUPIED,
             area_occupied,
             measurements,
         )
 
         self._add_image_measurement(
-            operand.binary_name.value,
+            image_set,
             F_SURFACE_AREA if pipeline.volumetric() else F_PERIMETER,
             perimeter,
             measurements,
         )
 
         self._add_image_measurement(
-            operand.binary_name.value,
+            image_set,
             F_TOTAL_VOLUME if pipeline.volumetric() else F_TOTAL_AREA,
             total_area,
             measurements,
@@ -384,7 +305,7 @@ like to measure the area occupied by the foreground in the image.
 
         return [
             [
-                operand.binary_name.value,
+                image_set,
                 str(area_occupied),
                 str(perimeter),
                 str(total_area),
@@ -401,28 +322,40 @@ like to measure the area occupied by the foreground in the image.
         """Return column definitions for measurements made by this module"""
         columns = []
 
-        for op in self.operands:
-            for feature in self._get_feature_names(pipeline):
-                columns.append(
-                    (
-                        cellprofiler.measurement.IMAGE,
-                        "{:s}_{:s}_{:s}".format(
-                            C_AREA_OCCUPIED,
-                            feature,
-                            op.operand_objects.value
-                            if op.operand_choice == O_OBJECTS
-                            else op.binary_name.value,
-                        ),
-                        cellprofiler.measurement.COLTYPE_FLOAT,
+        if self.operand_choice in (O_BOTH, O_OBJECTS):
+            for object_set in self.objects_list.value:
+                for feature in self._get_feature_names(pipeline):
+                    columns.append(
+                        (
+                            cellprofiler.measurement.IMAGE,
+                            "{:s}_{:s}_{:s}".format(
+                                C_AREA_OCCUPIED,
+                                feature,
+                                object_set,
+                            ),
+                            cellprofiler.measurement.COLTYPE_FLOAT,
+                        )
                     )
-                )
+        if self.operand_choice in (O_BOTH, O_BINARY_IMAGE):
+            for image_set in self.images_list.value:
+                for feature in self._get_feature_names(pipeline):
+                    columns.append(
+                        (
+                            cellprofiler.measurement.IMAGE,
+                            "{:s}_{:s}_{:s}".format(
+                                C_AREA_OCCUPIED,
+                                feature,
+                                image_set,
+                            ),
+                            cellprofiler.measurement.COLTYPE_FLOAT,
+                        )
+                    )
 
         return columns
 
     def get_categories(self, pipeline, object_name):
         if object_name == cellprofiler.measurement.IMAGE:
             return [C_AREA_OCCUPIED]
-
         return []
 
     def get_measurements(self, pipeline, object_name, category):
@@ -431,7 +364,6 @@ like to measure the area occupied by the foreground in the image.
             and category == C_AREA_OCCUPIED
         ):
             return self._get_feature_names(pipeline)
-
         return []
 
     def get_measurement_objects(self, pipeline, object_name, category, measurement):
@@ -441,11 +373,10 @@ like to measure the area occupied by the foreground in the image.
             and measurement in self._get_feature_names(pipeline)
         ):
             return [
-                op.operand_objects.value
-                for op in self.operands
-                if op.operand_choice == O_OBJECTS
+                object_name
+                for object_name in self.objects_list.value
+                if self.operand_choice in (O_OBJECTS, O_BOTH)
             ]
-
         return []
 
     def get_measurement_images(self, pipeline, object_name, category, measurement):
@@ -455,11 +386,10 @@ like to measure the area occupied by the foreground in the image.
             and measurement in self._get_feature_names(pipeline)
         ):
             return [
-                op.binary_name.value
-                for op in self.operands
-                if op.operand_choice == O_BINARY_IMAGE
+                image_name
+                for image_name in self.images_list.value
+                if self.operand_choice in (O_BINARY_IMAGE, O_BOTH)
             ]
-
         return []
 
     def upgrade_settings(
@@ -516,7 +446,31 @@ like to measure the area occupied by the foreground in the image.
             setting_values = [setting_values[0]] + object_settings
 
             variable_revision_number = 4
-
+        if variable_revision_number == 4:
+            num_sets = setting_values[0]
+            setting_values = setting_values[1:]
+            images_set = set()
+            objects_set = set()
+            conditions, names1, names2 = [(setting_values[i::3]) for i in range(3)]
+            for condition, name1, name2 in zip(conditions, names1, names2):
+                if condition == O_BINARY_IMAGE:
+                    images_set.add(name2)
+                elif condition == O_OBJECTS:
+                    objects_set.add(name1)
+            if "None" in images_set:
+                images_set.remove("None")
+            if "None" in objects_set:
+                objects_set.remove("None")
+            if len(images_set) > 0 and len(objects_set) > 0:
+                mode = O_BOTH
+            elif len(images_set) == 0:
+                mode = O_OBJECTS
+            else:
+                mode = O_BINARY_IMAGE
+            images_string = ", ".join(map(str, images_set))
+            objects_string = ", ".join(map(str, objects_set))
+            setting_values = [mode, images_string, objects_string]
+            variable_revision_number = 5
         return setting_values, variable_revision_number, from_matlab
 
     def volumetric(self):

--- a/cellprofiler/modules/measureimageintensity.py
+++ b/cellprofiler/modules/measureimageintensity.py
@@ -2,9 +2,9 @@
 
 import numpy as np
 
-import cellprofiler.measurement as cpmeas
-import cellprofiler.module as cpm
-import cellprofiler.setting as cps
+import cellprofiler.measurement
+import cellprofiler.module
+import cellprofiler.setting
 from cellprofiler.modules import _help
 
 __doc__ = """
@@ -102,21 +102,21 @@ ALL_MEASUREMENTS = [
 ]
 
 
-class MeasureImageIntensity(cpm.Module):
+class MeasureImageIntensity(cellprofiler.module.Module):
     module_name = "MeasureImageIntensity"
     category = "Measurement"
     variable_revision_number = 3
 
     def create_settings(self):
         """Create the settings & name the module"""
-        self.images_list = cps.ListImageNameSubscriber(
+        self.images_list = cellprofiler.setting.ListImageNameSubscriber(
             "Select images to measure",
             [],
             doc="""Select the grayscale images whose intensity you want to measure.""",
         )
 
-        self.divider = cps.Divider(line=False)
-        self.wants_objects = cps.Binary(
+        self.divider = cellprofiler.setting.Divider(line=False)
+        self.wants_objects = cellprofiler.setting.Binary(
             "Measure the intensity only from areas enclosed by objects?",
             False,
             doc="""\
@@ -127,7 +127,7 @@ class MeasureImageIntensity(cpm.Module):
         """
         )
 
-        self.objects_list = cps.ListObjectNameSubscriber(
+        self.objects_list = cellprofiler.setting.ListObjectNameSubscriber(
             "Select input object sets",
             [],
             doc="""Select the object sets whose intensity you want to measure.""",
@@ -295,41 +295,41 @@ class MeasureImageIntensity(cpm.Module):
         columns = []
         for im in self.images_list.value:
             for feature, coltype in (
-                (F_TOTAL_INTENSITY, cpmeas.COLTYPE_FLOAT),
-                (F_MEAN_INTENSITY, cpmeas.COLTYPE_FLOAT),
-                (F_MEDIAN_INTENSITY, cpmeas.COLTYPE_FLOAT),
-                (F_STD_INTENSITY, cpmeas.COLTYPE_FLOAT),
-                (F_MAD_INTENSITY, cpmeas.COLTYPE_FLOAT),
-                (F_MIN_INTENSITY, cpmeas.COLTYPE_FLOAT),
-                (F_MAX_INTENSITY, cpmeas.COLTYPE_FLOAT),
-                (F_TOTAL_AREA, cpmeas.COLTYPE_INTEGER),
-                (F_PERCENT_MAXIMAL, cpmeas.COLTYPE_FLOAT),
-                (F_LOWER_QUARTILE, cpmeas.COLTYPE_FLOAT),
-                (F_UPPER_QUARTILE, cpmeas.COLTYPE_FLOAT),
+                (F_TOTAL_INTENSITY, cellprofiler.measurement.COLTYPE_FLOAT),
+                (F_MEAN_INTENSITY, cellprofiler.measurement.COLTYPE_FLOAT),
+                (F_MEDIAN_INTENSITY, cellprofiler.measurement.COLTYPE_FLOAT),
+                (F_STD_INTENSITY, cellprofiler.measurement.COLTYPE_FLOAT),
+                (F_MAD_INTENSITY, cellprofiler.measurement.COLTYPE_FLOAT),
+                (F_MIN_INTENSITY, cellprofiler.measurement.COLTYPE_FLOAT),
+                (F_MAX_INTENSITY, cellprofiler.measurement.COLTYPE_FLOAT),
+                (F_TOTAL_AREA, cellprofiler.measurement.COLTYPE_INTEGER),
+                (F_PERCENT_MAXIMAL, cellprofiler.measurement.COLTYPE_FLOAT),
+                (F_LOWER_QUARTILE, cellprofiler.measurement.COLTYPE_FLOAT),
+                (F_UPPER_QUARTILE, cellprofiler.measurement.COLTYPE_FLOAT),
             ):
                 if self.wants_objects:
                     for object_set in self.objects_list.value:
                         measurement_name = im + "_" + object_set
-                        columns.append((cpmeas.IMAGE, feature % measurement_name, coltype))
+                        columns.append((cellprofiler.measurement.IMAGE, feature % measurement_name, coltype))
                 else:
                     measurement_name = im
-                    columns.append((cpmeas.IMAGE, feature % measurement_name, coltype))
+                    columns.append((cellprofiler.measurement.IMAGE, feature % measurement_name, coltype))
         return columns
 
     def get_categories(self, pipeline, object_name):
-        if object_name == cpmeas.IMAGE:
+        if object_name == cellprofiler.measurement.IMAGE:
             return ["Intensity"]
         else:
             return []
 
     def get_measurements(self, pipeline, object_name, category):
-        if object_name == cpmeas.IMAGE and category == "Intensity":
+        if object_name == cellprofiler.measurement.IMAGE and category == "Intensity":
             return ALL_MEASUREMENTS
         return []
 
     def get_measurement_images(self, pipeline, object_name, category, measurement):
         if (
-            object_name == cpmeas.IMAGE
+            object_name == cellprofiler.measurement.IMAGE
             and category == "Intensity"
             and measurement in ALL_MEASUREMENTS
         ):
@@ -356,8 +356,8 @@ class MeasureImageIntensity(cpm.Module):
         if from_matlab and variable_revision_number == 2:
             setting_values = [
                 setting_values[0],  # image name
-                cps.NO,  # wants objects
-                cps.NONE,
+                cellprofiler.setting.NO,  # wants objects
+                cellprofiler.setting.NONE,
             ]  # object name
             variable_revision_number = 1
             from_matlab = False

--- a/cellprofiler/modules/measureimageintensity.py
+++ b/cellprofiler/modules/measureimageintensity.py
@@ -202,6 +202,8 @@ class MeasureImageIntensity(cpm.Module):
             else:
                 if image.has_mask:
                     pixels = input_pixels[image.mask]
+                else:
+                    pixels = input_pixels
                 statistics += self.measure(pixels, im, None, measurement_name, workspace)
         workspace.display_data.statistics = statistics
         workspace.display_data.col_labels = col_labels
@@ -307,10 +309,10 @@ class MeasureImageIntensity(cpm.Module):
             ):
                 if self.wants_objects:
                     for object_set in self.objects_list.value:
-                        measurement_name = im.image_name.value + "_" + object_set
+                        measurement_name = im + "_" + object_set
                         columns.append((cpmeas.IMAGE, feature % measurement_name, coltype))
                 else:
-                    measurement_name = im.image_name.value
+                    measurement_name = im
                     columns.append((cpmeas.IMAGE, feature % measurement_name, coltype))
         return columns
 

--- a/cellprofiler/modules/measureimageintensity.py
+++ b/cellprofiler/modules/measureimageintensity.py
@@ -179,9 +179,21 @@ class MeasureImageIntensity(cpm.Module):
             measurement_name = im
             if self.wants_objects.value:
                 for object_set in self.objects_list.value:
-
                     measurement_name += "_" + object_set
                     objects = workspace.get_objects(object_set)
+                    if objects.shape != input_pixels.shape:
+                        raise ValueError(
+                            "This module requires that the image and object sets have matching dimensions.\n"
+                            "The %s image and %s objects do not (%s vs %s).\n"
+                            "If they are paired correctly you may want to use the Resize, ResizeObjects or "
+                            "Crop module(s) to make them the same size."
+                            % (
+                                im,
+                                object_set,
+                                input_pixels.shape,
+                                objects.shape,
+                            )
+                        )
                     if image.has_mask:
                         pixels = input_pixels[np.logical_and(objects.segmented != 0, image.mask)]
                     else:

--- a/cellprofiler/modules/measureimageintensity.py
+++ b/cellprofiler/modules/measureimageintensity.py
@@ -23,6 +23,13 @@ module. If the image has a mask, only unmasked pixels will be measured.
 
 {HELP_ON_MEASURING_INTENSITIES}
 
+As of **CellProfiler 4.0** the settings for this module have been changed to simplify
+configuration. All selected images and objects are now analysed together rather
+than needing to be matched in pairs.
+Pipelines from older versions will be converted to match this format, which may
+create extra computational work. Specific pairing can still be achieved by running
+multiple copies of this module.
+
 |
 
 ============ ============ ===============

--- a/cellprofiler/modules/measureimageintensity.py
+++ b/cellprofiler/modules/measureimageintensity.py
@@ -394,7 +394,6 @@ class MeasureImageIntensity(cellprofiler.module.Module):
                     "copy of the module.",
                 )
             variable_revision_number = 3
-            print(setting_values)
         return setting_values, variable_revision_number, from_matlab
 
     def volumetric(self):

--- a/cellprofiler/modules/measureimageintensity.py
+++ b/cellprofiler/modules/measureimageintensity.py
@@ -1,5 +1,7 @@
 # coding=utf-8
 
+import logging
+
 import numpy as np
 
 import cellprofiler.measurement
@@ -100,6 +102,7 @@ ALL_MEASUREMENTS = [
     "LowerQuartileIntensity",
     "UpperQuartileIntensity",
 ]
+logger = logging.getLogger(__name__)
 
 
 class MeasureImageIntensity(cellprofiler.module.Module):
@@ -375,16 +378,13 @@ class MeasureImageIntensity(cellprofiler.module.Module):
             objects_string = ", ".join(map(str, objects_set))
             setting_values = [images_string, wants_objects, objects_string]
             if len(use_objects) > 1 or len(objects_set) > 1:
-                import wx
-                wx.MessageBox(
+                logger.warning(
                     "The pipeline you loaded was converted from an older version of CellProfiler.\n"
                     "The MeasureImageIntensity module no longer uses pairs of images and objects.\n"
                     "Instead, all selected images and objects will be analysed together.\n"
                     "If you want to limit analysis of particular objects or perform both "
                     "whole image and object-restricted analysis you should use a second "
                     "copy of the module.",
-                    "Compatibility Warning - MeasureImageIntensity",
-                    wx.ICON_INFORMATION,
                 )
             variable_revision_number = 3
             print(setting_values)

--- a/cellprofiler/modules/measureimagequality.py
+++ b/cellprofiler/modules/measureimagequality.py
@@ -1617,9 +1617,6 @@ to the foreground pixels or the background pixels.
     def images_to_process(self, image_group, workspace, pipeline=None):
         """Return a list of input image names appropriate to the setting choice """
         if self.images_choice.value == O_SELECT:
-            print("Images list")
-            print(image_group.image_names.value)
-            #if len(image_group.image_names.value) > 1:
             return image_group.image_names.value
         elif self.images_choice.value == O_ALL_LOADED:
             # Grab all loaded images

--- a/cellprofiler/modules/measureimagequality.py
+++ b/cellprofiler/modules/measureimagequality.py
@@ -207,7 +207,7 @@ IMAGE_GROUP_SETTING_OFFSET = 2
 class MeasureImageQuality(cellprofiler.module.Module):
     module_name = "MeasureImageQuality"
     category = "Measurement"
-    variable_revision_number = 5
+    variable_revision_number = 6
 
     def create_settings(self):
         self.images_choice = cellprofiler.setting.Choice(
@@ -247,13 +247,12 @@ calculated.
 
         group.append(
             "image_names",
-            cellprofiler.setting.ImageNameSubscriberMultiChoice(
+            cellprofiler.setting.ListImageNameSubscriber(
                 text="Select the images to measure",
                 doc="""\
 *(Used only if “{O_SELECT}” is chosen for selecting images)*
 
-Choose one or more images from this list. You can select multiple images
-by clicking using the shift or command keys. In addition to loaded
+Choose one or more images from this list. In addition to loaded
 images, the list includes the images that were created by prior modules.
 """.format(
                     **{"O_SELECT": O_SELECT}
@@ -722,7 +721,7 @@ to the foreground pixels or the background pixels.
         """Make sure a measurement is selected in image_names"""
         if self.images_choice.value == O_SELECT:
             for image_group in self.image_groups:
-                if not image_group.image_names.get_selections():
+                if len(image_group.image_names.value) == 0:
                     raise cellprofiler.setting.ValidationError(
                         "Please choose at least one image", image_group.image_names
                     )
@@ -1618,7 +1617,10 @@ to the foreground pixels or the background pixels.
     def images_to_process(self, image_group, workspace, pipeline=None):
         """Return a list of input image names appropriate to the setting choice """
         if self.images_choice.value == O_SELECT:
-            return image_group.image_names.get_selections()
+            print("Images list")
+            print(image_group.image_names.value)
+            #if len(image_group.image_names.value) > 1:
+            return image_group.image_names.value
         elif self.images_choice.value == O_ALL_LOADED:
             # Grab all loaded images
             accepted_image_list = []
@@ -1897,6 +1899,25 @@ to the foreground pixels or the background pixels.
                 for x in setting_values
             ]
             variable_revision_number = 5
+        if (not from_matlab) and variable_revision_number == 5:
+            if setting_values[0] == "Select...":
+                num_images = setting_values[1]
+                metadata_end = int(num_images)*2
+                num_settings = [int(setting_values[i+2]) + int(setting_values[i+3]*5) for i in range(0, metadata_end, 2)]
+
+                to_unpack = setting_values[2+metadata_end:]
+                new_setting_values = setting_values[:2+metadata_end]
+                while to_unpack:
+                    image_names = to_unpack[0]
+                    split_image_names = image_names.split(',')
+                    new_image_names = ", ".join(map(str, split_image_names))
+                    num_moresettings = num_settings.pop(0)
+                    new_setting_values.append(new_image_names)
+                    new_setting_values += to_unpack[1:2+num_moresettings]
+                    to_unpack = to_unpack[2+num_moresettings:]
+                setting_values = new_setting_values
+
+            variable_revision_number == 6
 
         return setting_values, variable_revision_number, from_matlab
 

--- a/cellprofiler/modules/measureobjectintensity.py
+++ b/cellprofiler/modules/measureobjectintensity.py
@@ -206,16 +206,8 @@ class MeasureObjectIntensity(cellprofiler.module.Module):
             num_imgs = int(setting_values[0])
             images_list = setting_values[1:num_imgs+1]
             objects_list = setting_values[num_imgs+1:]
-            setting_values = [images_list, objects_list]
+            setting_values = [", ".join(map(str, images_list)), ", ".join(map(str, objects_list))]
             variable_revision_number = 4
-        else:
-            # Convert saved image and object lists back into python lists
-            for i in (0, 1):
-                to_convert = setting_values[i]
-                if to_convert == '[]':
-                    setting_values[i] = []
-                else:
-                    setting_values[i] = to_convert.replace('\'', '').strip('][').split(', ')
         return setting_values, variable_revision_number, from_matlab
 
     def validate_module(self, pipeline):

--- a/cellprofiler/modules/measureobjectsizeshape.py
+++ b/cellprofiler/modules/measureobjectsizeshape.py
@@ -217,7 +217,7 @@ F_STANDARD = [
 
 class MeasureObjectSizeShape(cellprofiler.module.Module):
     module_name = "MeasureObjectSizeShape"
-    variable_revision_number = 1
+    variable_revision_number = 2
     category = "Measurement"
 
     def create_settings(self):
@@ -226,13 +226,12 @@ class MeasureObjectSizeShape(cellprofiler.module.Module):
         The module allows for an unlimited number of measured objects, each
         of which has an entry in self.object_groups.
         """
-        self.object_groups = []
-        self.add_object(can_remove=False)
-        self.spacer = cellprofiler.setting.Divider(line=True)
-        self.add_objects = cellprofiler.setting.DoSomething(
-            "", "Add another object", self.add_object
+        self.objects_list = cellprofiler.setting.ListObjectNameSubscriber(
+            "Select object sets to measure",
+            [],
+            doc="""Select the object sets whose size and shape you want to measure.""",
         )
-
+        self.spacer = cellprofiler.setting.Divider(line=True)
         self.calculate_zernikes = cellprofiler.setting.Binary(
             text="Calculate the Zernike features?",
             value=True,
@@ -246,63 +245,25 @@ module.""".format(
             ),
         )
 
-    def add_object(self, can_remove=True):
-        """Add a slot for another object"""
-        group = cellprofiler.setting.SettingsGroup()
-        if can_remove:
-            group.append("divider", cellprofiler.setting.Divider(line=False))
-
-        group.append(
-            "name",
-            cellprofiler.setting.ObjectNameSubscriber(
-                "Select objects to measure",
-                cellprofiler.setting.NONE,
-                doc="""Select the objects that you want to measure.""",
-            ),
-        )
-
-        if can_remove:
-            group.append(
-                "remove",
-                cellprofiler.setting.RemoveSettingButton(
-                    "", "Remove this object", self.object_groups, group
-                ),
-            )
-
-        self.object_groups.append(group)
-
     def settings(self):
         """The settings as they appear in the save file"""
-        result = [og.name for og in self.object_groups]
-        result.append(self.calculate_zernikes)
+        result = [self.objects_list, self.calculate_zernikes]
         return result
-
-    def prepare_settings(self, setting_values):
-        """Adjust the number of object groups based on the number of setting_values"""
-        object_group_count = len(setting_values) - 1
-        while len(self.object_groups) > object_group_count:
-            self.remove_object(object_group_count)
-
-        while len(self.object_groups) < object_group_count:
-            self.add_object()
 
     def visible_settings(self):
         """The settings as they appear in the module viewer"""
-        result = []
-        for og in self.object_groups:
-            result += og.visible_settings()
-        result.extend([self.add_objects, self.spacer, self.calculate_zernikes])
+        result = [self.objects_list, self.spacer, self.calculate_zernikes]
         return result
 
     def validate_module(self, pipeline):
         """Make sure chosen objects are selected only once"""
         objects = set()
-        for group in self.object_groups:
-            if group.name.value in objects:
+        for object_name in self.objects_list.value:
+            if object_name in objects:
                 raise cellprofiler.setting.ValidationError(
-                    "%s has already been selected" % group.name.value, group.name
+                    "%s has already been selected" % object_name, object_name
                 )
-            objects.add(group.name.value)
+            objects.add(object_name)
 
     def get_categories(self, pipeline, object_name):
         """Get the categories of measurements supplied for the given object name
@@ -311,8 +272,9 @@ module.""".format(
         object_name - name of labels in question (or 'Images')
         returns a list of category names
         """
-        if object_name in [og.name for og in self.object_groups]:
-            return [AREA_SHAPE]
+        for object_set in self.objects_list.value:
+            if object_set == object_name:
+                return [AREA_SHAPE]
         else:
             return []
 
@@ -370,8 +332,8 @@ module.""".format(
 
             workspace.display_data.statistics = []
 
-        for object_group in self.object_groups:
-            self.run_on_objects(object_group.name.value, workspace)
+        for object_name in self.objects_list.value:
+            self.run_on_objects(object_name, workspace)
 
     def run_on_objects(self, object_name, workspace):
         """Run, computing the area measurements for a single map of objects"""
@@ -652,10 +614,9 @@ module.""".format(
     def get_measurement_columns(self, pipeline):
         """Return measurement column definitions.
         All cols returned as float even though "Area" will only ever be int"""
-        object_names = [s.value for s in self.settings()][:-1]
         measurement_names = self.get_feature_names(pipeline)
         cols = []
-        for oname in object_names:
+        for oname in self.objects_list.value:
             for mname in measurement_names:
                 cols += [
                     (
@@ -694,6 +655,10 @@ module.""".format(
             )
             variable_revision_number = 1
             from_matlab = False
+        if not from_matlab and variable_revision_number == 1:
+            objects_list = setting_values[:-1]
+            setting_values = [", ".join(map(str, objects_list)), setting_values[-1]]
+            variable_revision_number = 2
         return setting_values, variable_revision_number, from_matlab
 
     def volumetric(self):

--- a/cellprofiler/modules/measureobjectsizeshape.py
+++ b/cellprofiler/modules/measureobjectsizeshape.py
@@ -258,6 +258,11 @@ module.""".format(
     def validate_module(self, pipeline):
         """Make sure chosen objects are selected only once"""
         objects = set()
+        if len(self.objects_list.value) == 0:
+            raise cellprofiler.setting.ValidationError(
+                "No object sets selected", self.objects_list
+            )
+
         for object_name in self.objects_list.value:
             if object_name in objects:
                 raise cellprofiler.setting.ValidationError(

--- a/cellprofiler/setting.py
+++ b/cellprofiler/setting.py
@@ -1591,6 +1591,7 @@ class ImageNameSubscriber(NameSubscriber):
             text, IMAGE_GROUP, value, can_be_blank, blank_text, *args, **kwargs
         )
 
+
 class ListImageNameSubscriber(NameSubscriber):
     """A setting that provides an image name
     """
@@ -1606,6 +1607,24 @@ class ListImageNameSubscriber(NameSubscriber):
     ):
         super(ListImageNameSubscriber, self).__init__(
             text, IMAGE_GROUP, value, can_be_blank, blank_text, *args, **kwargs
+        )
+
+
+class ListObjectNameSubscriber(NameSubscriber):
+    """A setting that provides an image name
+    """
+
+    def __init__(
+        self,
+        text,
+        value=None,
+        can_be_blank=False,
+        blank_text=LEAVE_BLANK,
+        *args,
+        **kwargs,
+    ):
+        super(ListObjectNameSubscriber, self).__init__(
+            text, OBJECT_GROUP, value, can_be_blank, blank_text, *args, **kwargs
         )
 
 

--- a/cellprofiler/setting.py
+++ b/cellprofiler/setting.py
@@ -1535,7 +1535,6 @@ class ListNameSubscriber(NameSubscriber):
         else:
             value = value.split(", ")
         self._Setting__value = value
-        print("Internally setting ", self._Setting__value)
 
     def __internal_get_value(self):
         return self.get_value()

--- a/cellprofiler/setting.py
+++ b/cellprofiler/setting.py
@@ -1521,7 +1521,6 @@ class ListNameSubscriber(NameSubscriber):
             text, group, value, can_be_blank, blank_text, *args, **kwargs
         )
         self.value = value
-        self.value_text = value
 
     def get_value_text(self):
         """Convert the underlying list to a string"""
@@ -1531,7 +1530,7 @@ class ListNameSubscriber(NameSubscriber):
         self.set_value_text(value)
 
     def set_value_text(self, value):
-        self.value = value
+        self._Setting__value = value
 
     value_text = property(get_value_text, __internal_set_value_text)
 

--- a/cellprofiler/setting.py
+++ b/cellprofiler/setting.py
@@ -1502,6 +1502,47 @@ class NameSubscriber(Setting):
             )
 
 
+class ListNameSubscriber(NameSubscriber):
+    """Stores name provider names as a list"""
+
+    def __init__(
+        self,
+        text,
+        group,
+        value=None,
+        can_be_blank=False,
+        blank_text=LEAVE_BLANK,
+        *args,
+        **kwargs,
+    ):
+        super(ListNameSubscriber, self).__init__(
+            text, group, value, can_be_blank, blank_text, *args, **kwargs
+        )
+
+    def get_value_text(self):
+        """Convert the underlying list to a string"""
+        return ", ".join(map(str, self._Setting__value))
+
+    def __internal_set_value_text(self, value):
+        self.set_value_text(value)
+
+    value_text = property(get_value_text, __internal_set_value_text)
+
+    def __internal_set_value(self, value):
+        """Convert a saved string into a list"""
+        if len(value) == 0:
+            value = []
+        else:
+            value = value.split(", ")
+        self._Setting__value = value
+        print("Internally setting ", self._Setting__value)
+
+    def __internal_get_value(self):
+        return self.get_value()
+
+    value = property(__internal_get_value, __internal_set_value)
+
+
 def filter_duplicate_names(name_list):
     """remove any repeated names from a list of (name, ...) keeping the last occurrence."""
     name_dict = dict(list(zip((n[0] for n in name_list), name_list)))
@@ -1592,7 +1633,7 @@ class ImageNameSubscriber(NameSubscriber):
         )
 
 
-class ListImageNameSubscriber(NameSubscriber):
+class ListImageNameSubscriber(ListNameSubscriber):
     """A setting that provides an image name
     """
 
@@ -1607,24 +1648,6 @@ class ListImageNameSubscriber(NameSubscriber):
     ):
         super(ListImageNameSubscriber, self).__init__(
             text, IMAGE_GROUP, value, can_be_blank, blank_text, *args, **kwargs
-        )
-
-
-class ListObjectNameSubscriber(NameSubscriber):
-    """A setting that provides an image name
-    """
-
-    def __init__(
-        self,
-        text,
-        value=None,
-        can_be_blank=False,
-        blank_text=LEAVE_BLANK,
-        *args,
-        **kwargs,
-    ):
-        super(ListObjectNameSubscriber, self).__init__(
-            text, OBJECT_GROUP, value, can_be_blank, blank_text, *args, **kwargs
         )
 
 
@@ -1701,6 +1724,24 @@ class ObjectNameSubscriber(NameSubscriber):
         **kwargs,
     ):
         super(ObjectNameSubscriber, self).__init__(
+            text, OBJECT_GROUP, value, can_be_blank, blank_text, *args, **kwargs
+        )
+
+
+class ListObjectNameSubscriber(ListNameSubscriber):
+    """A setting that provides an image name
+    """
+
+    def __init__(
+        self,
+        text,
+        value=None,
+        can_be_blank=False,
+        blank_text=LEAVE_BLANK,
+        *args,
+        **kwargs,
+    ):
+        super(ListObjectNameSubscriber, self).__init__(
             text, OBJECT_GROUP, value, can_be_blank, blank_text, *args, **kwargs
         )
 

--- a/cellprofiler/setting.py
+++ b/cellprofiler/setting.py
@@ -1591,6 +1591,23 @@ class ImageNameSubscriber(NameSubscriber):
             text, IMAGE_GROUP, value, can_be_blank, blank_text, *args, **kwargs
         )
 
+class ListImageNameSubscriber(NameSubscriber):
+    """A setting that provides an image name
+    """
+
+    def __init__(
+        self,
+        text,
+        value=None,
+        can_be_blank=False,
+        blank_text=LEAVE_BLANK,
+        *args,
+        **kwargs,
+    ):
+        super(ListImageNameSubscriber, self).__init__(
+            text, IMAGE_GROUP, value, can_be_blank, blank_text, *args, **kwargs
+        )
+
 
 class FileImageNameSubscriber(ImageNameSubscriber):
     """A setting that provides image names loaded from files"""

--- a/cellprofiler/setting.py
+++ b/cellprofiler/setting.py
@@ -1547,6 +1547,20 @@ class ListNameSubscriber(NameSubscriber):
 
     value = property(__internal_get_value, __internal_set_value)
 
+    def test_valid(self, pipeline):
+        choices = self.get_choices(pipeline)
+        if len(choices) == 0:
+            raise ValidationError(
+                "No prior instances of %s were defined" % self.group, self
+            )
+        for name in self.value:
+            if name not in [c[0] for c in choices]:
+                raise ValidationError(
+                    "%s not in %s"
+                    % (name, ", ".join(c[0] for c in self.get_choices(pipeline))),
+                    self,
+                )
+
 
 def filter_duplicate_names(name_list):
     """remove any repeated names from a list of (name, ...) keeping the last occurrence."""

--- a/cellprofiler/setting.py
+++ b/cellprofiler/setting.py
@@ -1515,9 +1515,13 @@ class ListNameSubscriber(NameSubscriber):
         *args,
         **kwargs,
     ):
+        if value is None:
+            value = ""
         super(ListNameSubscriber, self).__init__(
             text, group, value, can_be_blank, blank_text, *args, **kwargs
         )
+        self.value = value
+        self.value_text = value
 
     def get_value_text(self):
         """Convert the underlying list to a string"""
@@ -1525,6 +1529,9 @@ class ListNameSubscriber(NameSubscriber):
 
     def __internal_set_value_text(self, value):
         self.set_value_text(value)
+
+    def set_value_text(self, value):
+        self.value = value
 
     value_text = property(get_value_text, __internal_set_value_text)
 

--- a/tests/modules/test_measurecolocalization.py
+++ b/tests/modules/test_measurecolocalization.py
@@ -18,10 +18,10 @@ def make_workspace(image1, image2, objects=None):
     module = cellprofiler.modules.measurecolocalization.MeasureColocalization()
     image_set_list = cellprofiler.image.ImageSetList()
     image_set = image_set_list.get_image_set(0)
-    for image_group, name, image in zip(
-        module.image_groups, (IMAGE1_NAME, IMAGE2_NAME), (image1, image2)
+    module.images_list.value = ', '.join((IMAGE1_NAME, IMAGE2_NAME))
+    for image_name, name, image in zip(
+        module.images_list.value, (IMAGE1_NAME, IMAGE2_NAME), (image1, image2)
     ):
-        image_group.image_name.value = name
         image_set.add(name, image)
     object_set = cellprofiler.object.ObjectSet()
     if objects is None:
@@ -32,7 +32,7 @@ def make_workspace(image1, image2, objects=None):
         module.images_or_objects.value = (
             cellprofiler.modules.measurecolocalization.M_IMAGES_AND_OBJECTS
         )
-        module.object_groups[0].object_name.value = OBJECTS_NAME
+        module.objects_list.value = OBJECTS_NAME
         object_set.add_objects(objects, OBJECTS_NAME)
     pipeline = cellprofiler.pipeline.Pipeline()
     workspace = cellprofiler.workspace.Workspace(
@@ -64,13 +64,13 @@ def test_load_v2():
         module.images_or_objects.value
         == cellprofiler.modules.measurecolocalization.M_IMAGES_AND_OBJECTS
     )
-    assert module.image_count.value == 2
+    assert len(module.images_list.value) == 2
     assert module.thr == 15.0
-    for name in [x.image_name.value for x in module.image_groups]:
+    for name in module.images_list.value:
         assert name in ["DNA", "Cytoplasm"]
 
-    assert module.object_count.value == 2
-    for name in [x.object_name.value for x in module.object_groups]:
+    assert len(module.objects_list.value) == 2
+    for name in module.objects_list.value:
         assert name in ["Nuclei", "Cells"]
 
 
@@ -92,13 +92,13 @@ def test_load_v3():
         module.images_or_objects.value
         == cellprofiler.modules.measurecolocalization.M_IMAGES_AND_OBJECTS
     )
-    assert module.image_count.value == 2
+    assert len(module.images_list.value) == 2
     assert module.thr == 25.0
-    for name in [x.image_name.value for x in module.image_groups]:
+    for name in module.images_list.value:
         assert name in ["DNA", "Cytoplasm"]
 
-    assert module.object_count.value == 2
-    for name in [x.object_name.value for x in module.object_groups]:
+    assert len(module.objects_list.value) == 2
+    for name in module.objects_list.value:
         assert name in ["Nuclei", "Cells"]
 
 
@@ -124,9 +124,8 @@ asymmetrical_measurement_formats = [
 def test_get_categories():
     """Test the get_categories function for some different cases"""
     module = cellprofiler.modules.measurecolocalization.MeasureColocalization()
-    module.image_groups[0].image_name.value = IMAGE1_NAME
-    module.image_groups[1].image_name.value = IMAGE2_NAME
-    module.object_groups[0].object_name.value = OBJECTS_NAME
+    module.images_list.value = ', '.join((IMAGE1_NAME, IMAGE2_NAME))
+    module.objects_list.value = OBJECTS_NAME
     module.images_or_objects.value = cellprofiler.modules.measurecolocalization.M_IMAGES
 
     def cat(name):
@@ -149,9 +148,8 @@ def test_get_categories():
 def test_get_measurements():
     """Test the get_measurements function for some different cases"""
     module = cellprofiler.modules.measurecolocalization.MeasureColocalization()
-    module.image_groups[0].image_name.value = IMAGE1_NAME
-    module.image_groups[1].image_name.value = IMAGE2_NAME
-    module.object_groups[0].object_name.value = OBJECTS_NAME
+    module.images_list.value = ', '.join((IMAGE1_NAME, IMAGE2_NAME))
+    module.objects_list.value = OBJECTS_NAME
     module.images_or_objects.value = cellprofiler.modules.measurecolocalization.M_IMAGES
 
     def meas(name):
@@ -192,9 +190,8 @@ def test_get_measurement_images():
         ),
     ):
         module = cellprofiler.modules.measurecolocalization.MeasureColocalization()
-        module.image_groups[0].image_name.value = IMAGE1_NAME
-        module.image_groups[1].image_name.value = IMAGE2_NAME
-        module.object_groups[0].object_name.value = OBJECTS_NAME
+        module.images_list.value = ', '.join((IMAGE1_NAME, IMAGE2_NAME))
+        module.objects_list.value = OBJECTS_NAME
         module.images_or_objects.value = iocase
         for name, mfs in (
             (cellprofiler.measurement.IMAGE, all_image_measurement_formats),
@@ -220,9 +217,8 @@ def test_get_measurement_images():
 
 def test_01_get_measurement_columns_images():
     module = cellprofiler.modules.measurecolocalization.MeasureColocalization()
-    module.image_groups[0].image_name.value = IMAGE1_NAME
-    module.image_groups[1].image_name.value = IMAGE2_NAME
-    module.object_groups[0].object_name.value = OBJECTS_NAME
+    module.images_list.value = ', '.join((IMAGE1_NAME, IMAGE2_NAME))
+    module.objects_list.value = OBJECTS_NAME
     module.images_or_objects.value = cellprofiler.modules.measurecolocalization.M_IMAGES
     columns = module.get_measurement_columns(None)
     expected = [
@@ -247,9 +243,8 @@ def test_01_get_measurement_columns_images():
 
 def test_02_get_measurement_columns_objects():
     module = cellprofiler.modules.measurecolocalization.MeasureColocalization()
-    module.image_groups[0].image_name.value = IMAGE1_NAME
-    module.image_groups[1].image_name.value = IMAGE2_NAME
-    module.object_groups[0].object_name.value = OBJECTS_NAME
+    module.images_list.value = ', '.join((IMAGE1_NAME, IMAGE2_NAME))
+    module.objects_list.value = OBJECTS_NAME
     module.images_or_objects.value = (
         cellprofiler.modules.measurecolocalization.M_OBJECTS
     )
@@ -276,9 +271,8 @@ def test_02_get_measurement_columns_objects():
 
 def test_03_get_measurement_columns_both():
     module = cellprofiler.modules.measurecolocalization.MeasureColocalization()
-    module.image_groups[0].image_name.value = IMAGE1_NAME
-    module.image_groups[1].image_name.value = IMAGE2_NAME
-    module.object_groups[0].object_name.value = OBJECTS_NAME
+    module.images_list.value = ', '.join((IMAGE1_NAME, IMAGE2_NAME))
+    module.objects_list.value = OBJECTS_NAME
     module.images_or_objects.value = (
         cellprofiler.modules.measurecolocalization.M_IMAGES_AND_OBJECTS
     )

--- a/tests/modules/test_measureimageareaoccupied.py
+++ b/tests/modules/test_measureimageareaoccupied.py
@@ -206,7 +206,7 @@ def test_image_volume():
 
 def test_load_v3():
     with open(
-        "./resources/modules/measureimageareaoccupied/v3.pipeline", "r"
+        "./tests/resources/modules/measureimageareaoccupied/v3.pipeline", "r"
     ) as fd:
         data = fd.read()
 

--- a/tests/modules/test_measureimageintensity.py
+++ b/tests/modules/test_measureimageintensity.py
@@ -38,9 +38,9 @@ def measurements():
 def module():
     module = cellprofiler.modules.measureimageintensity.MeasureImageIntensity()
 
-    module.images[0].image_name.value = "image"
+    module.images_list.value = "image"
 
-    module.images[0].object_name.value = "objects"
+    module.objects_list.value = "objects"
 
     return module
 
@@ -167,7 +167,7 @@ def test_volume_and_objects(image, measurements, module, objects, workspace):
 
     objects.segmented = object_data
 
-    module.images[0].wants_objects.value = True
+    module.wants_objects.value = True
 
     module.run(workspace)
 
@@ -206,7 +206,7 @@ def test_volume_and_objects_and_mask(image, measurements, module, objects, works
 
     objects.segmented = object_data
 
-    module.images[0].wants_objects.value = True
+    module.wants_objects.value = True
 
     module.run(workspace)
 
@@ -367,7 +367,7 @@ def test_image_and_objects(image, measurements, module, objects, workspace):
 
     objects.segmented = labels
 
-    module.images[0].wants_objects.value = True
+    module.wants_objects.value = True
 
     module.run(workspace)
 
@@ -432,7 +432,7 @@ def test_image_and_objects_and_mask(image, measurements, module, objects, worksp
 
     objects.segmented = labels
 
-    module.images[0].wants_objects.value = True
+    module.wants_objects.value = True
 
     module.run(workspace)
 
@@ -455,39 +455,87 @@ def test_image_and_objects_and_mask(image, measurements, module, objects, worksp
     )
 
 
-def test_get_measurement_columns(module):
+def test_get_measurement_columns_whole_image_mode(module):
     image_names = ["image%d" % i for i in range(3)]
 
-    object_names = ["object%d" % i for i in range(3)]
-
-    first = True
+    module.wants_objects.value = False
 
     expected_suffixes = []
 
     for image_name in image_names:
-        if first:
-            first = False
-        else:
-            module.add_image_measurement()
+        im = module.images_list.value[-1]
 
-        im = module.images[-1]
-
-        im.image_name.value = image_name
-
-        im.wants_objects.value = False
+        module.images_list.value.append(image_name)
 
         expected_suffixes.append(image_name)
 
+    columns = module.get_measurement_columns(None)
+
+    assert all([column[0] == cellprofiler.measurement.IMAGE for column in columns])
+
+    for expected_suffix in expected_suffixes:
+        for feature, coltype in (
+            (
+                cellprofiler.modules.measureimageintensity.F_TOTAL_INTENSITY,
+                cellprofiler.measurement.COLTYPE_FLOAT,
+            ),
+            (
+                cellprofiler.modules.measureimageintensity.F_MEAN_INTENSITY,
+                cellprofiler.measurement.COLTYPE_FLOAT,
+            ),
+            (
+                cellprofiler.modules.measureimageintensity.F_MIN_INTENSITY,
+                cellprofiler.measurement.COLTYPE_FLOAT,
+            ),
+            (
+                cellprofiler.modules.measureimageintensity.F_MAX_INTENSITY,
+                cellprofiler.measurement.COLTYPE_FLOAT,
+            ),
+            (
+                cellprofiler.modules.measureimageintensity.F_TOTAL_AREA,
+                cellprofiler.measurement.COLTYPE_INTEGER,
+            ),
+            (
+                cellprofiler.modules.measureimageintensity.F_PERCENT_MAXIMAL,
+                cellprofiler.measurement.COLTYPE_FLOAT,
+            ),
+            (
+                cellprofiler.modules.measureimageintensity.F_MAD_INTENSITY,
+                cellprofiler.measurement.COLTYPE_FLOAT,
+            ),
+            (
+                cellprofiler.modules.measureimageintensity.F_LOWER_QUARTILE,
+                cellprofiler.measurement.COLTYPE_FLOAT,
+            ),
+            (
+                cellprofiler.modules.measureimageintensity.F_UPPER_QUARTILE,
+                cellprofiler.measurement.COLTYPE_FLOAT,
+            ),
+        ):
+            # feature names are now formatting strings
+            feature_name = feature % expected_suffix
+
+            assert any(
+                [
+                    (column[1] == feature_name and column[2] == coltype)
+                    for column in columns
+                ]
+            )
+
+def test_get_measurement_columns_object_mode(module):
+    image_names = ["image%d" % i for i in range(3)]
+
+    object_names = ["object%d" % i for i in range(3)]
+
+    module.wants_objects.value = True
+
+    expected_suffixes = []
+
+    for image_name in image_names:
+        module.images_list.value.append(image_name)
+
         for object_name in object_names:
-            module.add_image_measurement()
-
-            im = module.images[-1]
-
-            im.image_name.value = image_name
-
-            im.wants_objects.value = True
-
-            im.object_name.value = object_name
+            module.objects_list.value.append(object_name)
 
             expected_suffixes.append("%s_%s" % (image_name, object_name))
 
@@ -536,7 +584,6 @@ def test_get_measurement_columns(module):
         ):
             # feature names are now formatting strings
             feature_name = feature % expected_suffix
-
             assert any(
                 [
                     (column[1] == feature_name and column[2] == coltype)

--- a/tests/modules/test_measureimagequality.py
+++ b/tests/modules/test_measureimagequality.py
@@ -494,7 +494,7 @@ def test_experiment_threshold():
     )
     m = workspace.measurements
     assert isinstance(m, cellprofiler.measurement.Measurements)
-    image_name = module.image_groups[0].image_names.get_selections()[0]
+    image_name = module.image_groups[0].image_names.value[0]
     feature = (
         module.image_groups[0].threshold_groups[0].threshold_feature_name(image_name)
     )
@@ -536,7 +536,7 @@ def test_experiment_threshold_cycle_skipping():
     )
     m = workspace.measurements
     assert isinstance(m, cellprofiler.measurement.Measurements)
-    image_name = module.image_groups[0].image_names.get_selections()[0]
+    image_name = module.image_groups[0].image_names.value[0]
     feature = (
         module.image_groups[0].threshold_groups[0].threshold_feature_name(image_name)
     )
@@ -560,7 +560,7 @@ def test_experiment_threshold_cycle_skipping():
     # Check threshold algorithms
     threshold_group = module.image_groups[0].threshold_groups[0]
     threshold_algorithm = threshold_group.threshold_algorithm
-    image_name = module.image_groups[0].image_names.value
+    image_name = module.image_groups[0].image_names.value_text
     f_mean, f_median, f_std = [
         threshold_group.threshold_feature_name(image_name, agg)
         for agg in (
@@ -634,7 +634,7 @@ def test_load_v3():
 
     group = module.image_groups[0]
     thr = group.threshold_groups[0]
-    assert group.image_names == "Alpha"
+    assert group.image_names.value_text == "Alpha"
     assert group.check_blur
     assert group.scale_groups[0].scale == 25
     assert group.check_saturation
@@ -649,7 +649,7 @@ def test_load_v3():
 
     group = module.image_groups[1]
     thr = group.threshold_groups[0]
-    assert group.image_names == "Beta"
+    assert group.image_names.value_text == "Beta"
     assert not group.check_blur
     assert group.scale_groups[0].scale == 15
     assert not group.check_saturation
@@ -694,19 +694,21 @@ def test_load_v4():
     assert len(module.image_groups) == 1
     group = module.image_groups[0]
     assert module.images_choice == cellprofiler.modules.measureimagequality.O_SELECT
-    assert group.image_names == "Alpha"
+    assert group.image_names.value_text == "Alpha"
 
     module = pipeline.modules()[2]
     assert len(module.image_groups) == 1
     group = module.image_groups[0]
     assert module.images_choice == cellprofiler.modules.measureimagequality.O_SELECT
-    assert group.image_names == "Delta,Beta"
+    assert "Delta" in group.image_names.value
+    assert "Beta" in group.image_names.value
+    assert len(group.image_names.value) == 2
 
     module = pipeline.modules()[3]
     assert len(module.image_groups) == 2
     group = module.image_groups[0]
     assert module.images_choice == cellprofiler.modules.measureimagequality.O_SELECT
-    assert group.image_names == "Delta"
+    assert group.image_names.value_text == "Delta"
     assert group.check_intensity
     assert not group.use_all_threshold_methods
     thr = group.threshold_groups[0]
@@ -716,13 +718,13 @@ def test_load_v4():
     )
     assert thr.two_class_otsu == cellprofiler.modules.identify.O_TWO_CLASS
     group = module.image_groups[1]
-    assert group.image_names == "Epsilon"
+    assert group.image_names.value_text == "Epsilon"
 
     module = pipeline.modules()[4]
     assert len(module.image_groups) == 1
     group = module.image_groups[0]
     assert module.images_choice == cellprofiler.modules.measureimagequality.O_SELECT
-    assert group.image_names == "Zeta"
+    assert group.image_names.value_text == "Zeta"
     assert not group.use_all_threshold_methods
     thr = group.threshold_groups[0]
     assert thr.threshold_method == centrosome.threshold.TM_OTSU
@@ -780,7 +782,7 @@ def test_check_image_groups():
 
     q = workspace.module
     # Set my_image1 and my_image2 settings: Saturation only
-    q.image_groups[0].image_names.value = "my_image1,my_image2"
+    q.image_groups[0].image_names.value = "my_image1, my_image2"
     q.image_groups[0].include_image_scalings.value = False
     q.image_groups[0].check_blur.value = False
     q.image_groups[0].check_saturation.value = True
@@ -789,7 +791,7 @@ def test_check_image_groups():
 
     # Set my_image3 and my_image4's settings: Blur only
     q.add_image_group()
-    q.image_groups[1].image_names.value = "my_image3,my_image4"
+    q.image_groups[1].image_names.value = "my_image3, my_image4"
     q.image_groups[1].include_image_scalings.value = False
     q.image_groups[1].check_blur.value = True
     q.image_groups[1].check_saturation.value = False

--- a/tests/modules/test_measureobjectintensity.py
+++ b/tests/modules/test_measureobjectintensity.py
@@ -36,9 +36,9 @@ def measurements():
 def module():
     module = cellprofiler.modules.measureobjectintensity.MeasureObjectIntensity()
 
-    module.images_list.value = [IMAGE_NAME]
+    module.images_list.value = IMAGE_NAME
 
-    module.objects_list.value = [OBJECT_NAME]
+    module.objects_list.value = OBJECT_NAME
 
     return module
 
@@ -122,9 +122,9 @@ def assert_features_and_columns_match(measurements, module):
 
 def test_supplied_measurements(module):
     """Test the get_category / get_measurements, get_measurement_images functions"""
-    module.images_list.value = ["MyImage"]
+    module.images_list.value = "MyImage"
 
-    module.objects_list.value = ["MyObjects1", "MyObjects2"]
+    module.objects_list.value = "MyObjects1, MyObjects2"
 
     expected_categories = tuple(
         sorted(
@@ -174,9 +174,9 @@ def test_supplied_measurements(module):
 
 def test_get_measurement_columns(module):
     """test the get_measurement_columns method"""
-    module.images_list.value = ["MyImage"]
+    module.images_list.value = "MyImage"
 
-    module.objects_list.value = ["MyObjects1", "MyObjects2"]
+    module.objects_list.value = "MyObjects1, MyObjects2"
 
     columns = module.get_measurement_columns(None)
 

--- a/tests/modules/test_measureobjectintensity.py
+++ b/tests/modules/test_measureobjectintensity.py
@@ -36,9 +36,9 @@ def measurements():
 def module():
     module = cellprofiler.modules.measureobjectintensity.MeasureObjectIntensity()
 
-    module.images[0].name.value = IMAGE_NAME
+    module.images_list.value = [IMAGE_NAME]
 
-    module.objects[0].name.value = OBJECT_NAME
+    module.objects_list.value = [OBJECT_NAME]
 
     return module
 
@@ -122,13 +122,9 @@ def assert_features_and_columns_match(measurements, module):
 
 def test_supplied_measurements(module):
     """Test the get_category / get_measurements, get_measurement_images functions"""
-    module.images[0].name.value = "MyImage"
+    module.images_list.value = ["MyImage"]
 
-    module.add_object()
-
-    module.objects[0].name.value = "MyObjects1"
-
-    module.objects[1].name.value = "MyObjects2"
+    module.objects_list.value = ["MyObjects1", "MyObjects2"]
 
     expected_categories = tuple(
         sorted(
@@ -178,13 +174,9 @@ def test_supplied_measurements(module):
 
 def test_get_measurement_columns(module):
     """test the get_measurement_columns method"""
-    module.images[0].name.value = "MyImage"
+    module.images_list.value = ["MyImage"]
 
-    module.add_object()
-
-    module.objects[0].name.value = "MyObjects1"
-
-    module.objects[1].name.value = "MyObjects2"
+    module.objects_list.value = ["MyObjects1", "MyObjects2"]
 
     columns = module.get_measurement_columns(None)
 

--- a/tests/modules/test_measureobjectintensitydistribution.py
+++ b/tests/modules/test_measureobjectintensitydistribution.py
@@ -125,7 +125,7 @@ Maximum radius:50
     )
     assert module.object_count.value == 2
     assert module.bin_counts_count.value == 2
-    assert module.images_list.value_text == "OrigBlue, EnhancedGreen"
+    assert {'OrigBlue', 'EnhancedGreen'}.issubset(module.images_list.value)
     assert module.objects[0].object_name == "Nuclei"
     assert (
         module.objects[0].center_choice
@@ -166,7 +166,7 @@ def test_load_v3():
     )
     assert module.object_count.value == 3
     assert module.bin_counts_count.value == 2
-    assert module.images_list.value_text == "OrigBlue, EnhancedGreen"
+    assert {'OrigBlue', 'EnhancedGreen'}.issubset(module.images_list.value)
     assert module.objects[0].object_name == "Nuclei"
     assert (
         module.objects[0].center_choice
@@ -217,7 +217,7 @@ def test_load_v4():
     )
     assert module.zernike_degree == 9
     assert len(module.images_list.value) == 2
-    assert module.images_list.value_text == "CropGreen, CropRed"
+    assert {'CropGreen', 'CropRed'}.issubset(module.images_list.value)
     assert len(module.objects) == 2
     for group, (object_name, center_choice, center_object_name) in zip(
         module.objects,
@@ -321,7 +321,7 @@ def test_load_v5():
     )
     assert module.zernike_degree == 7
     assert len(module.images_list.value) == 2
-    assert module.images_list.value_text == "CropGreen, CropRed"
+    assert {'CropGreen', 'CropRed'}.issubset(module.images_list.value)
     assert len(module.objects) == 2
     for group, (object_name, center_choice, center_object_name) in zip(
         module.objects,

--- a/tests/modules/test_measureobjectintensitydistribution.py
+++ b/tests/modules/test_measureobjectintensitydistribution.py
@@ -82,7 +82,7 @@ def feature_radial_cv(bin, bin_count, image_name=IMAGE_NAME):
 def test_please_implement_a_test_of_the_new_version():
     assert (
         cellprofiler.modules.measureobjectintensitydistribution.MeasureObjectIntensityDistribution.variable_revision_number
-        == 5
+        == 6
     )
 
 
@@ -123,11 +123,9 @@ Maximum radius:50
         module,
         cellprofiler.modules.measureobjectintensitydistribution.MeasureObjectIntensityDistribution,
     )
-    assert module.image_count.value == 2
     assert module.object_count.value == 2
     assert module.bin_counts_count.value == 2
-    assert module.images[0].image_name == "EnhancedGreen"
-    assert module.images[1].image_name == "OrigBlue"
+    assert module.images_list.value_text == "OrigBlue, EnhancedGreen"
     assert module.objects[0].object_name == "Nuclei"
     assert (
         module.objects[0].center_choice
@@ -166,11 +164,9 @@ def test_load_v3():
         module,
         cellprofiler.modules.measureobjectintensitydistribution.MeasureObjectIntensityDistribution,
     )
-    assert module.image_count.value == 2
     assert module.object_count.value == 3
     assert module.bin_counts_count.value == 2
-    assert module.images[0].image_name == "EnhancedGreen"
-    assert module.images[1].image_name == "OrigBlue"
+    assert module.images_list.value_text == "OrigBlue, EnhancedGreen"
     assert module.objects[0].object_name == "Nuclei"
     assert (
         module.objects[0].center_choice
@@ -220,9 +216,8 @@ def test_load_v4():
         == cellprofiler.modules.measureobjectintensitydistribution.Z_NONE
     )
     assert module.zernike_degree == 9
-    assert len(module.images) == 2
-    for group, image_name in zip(module.images, ("CropGreen", "CropRed")):
-        assert group.image_name.value == image_name
+    assert len(module.images_list.value) == 2
+    assert module.images_list.value_text == "CropGreen, CropRed"
     assert len(module.objects) == 2
     for group, (object_name, center_choice, center_object_name) in zip(
         module.objects,
@@ -325,9 +320,8 @@ def test_load_v5():
         == cellprofiler.modules.measureobjectintensitydistribution.Z_MAGNITUDES
     )
     assert module.zernike_degree == 7
-    assert len(module.images) == 2
-    for group, image_name in zip(module.images, ("CropGreen", "CropRed")):
-        assert group.image_name.value == image_name
+    assert len(module.images_list.value) == 2
+    assert module.images_list.value_text == "CropGreen, CropRed"
     assert len(module.objects) == 2
     for group, (object_name, center_choice, center_object_name) in zip(
         module.objects,
@@ -416,10 +410,7 @@ def test_01_get_measurement_columns():
     module = (
         cellprofiler.modules.measureobjectintensitydistribution.MeasureObjectIntensityDistribution()
     )
-    for i, image_name in ((0, "DNA"), (1, "Cytoplasm"), (2, "Actin")):
-        if i:
-            module.add_image()
-        module.images[i].image_name.value = image_name
+    module.images_list.value = "DNA, Cytoplasm, Actin"
     for i, object_name, center_name in (
         (0, "Nucleii", None),
         (1, "Cells", "Nucleii"),
@@ -456,7 +447,7 @@ def test_01_get_measurement_columns():
         column_dictionary[key] = (object_name, feature, coltype)
 
     for object_name in [x.object_name.value for x in module.objects]:
-        for image_name in [x.image_name.value for x in module.images]:
+        for image_name in module.images_list.value:
             for bin_count, wants_scaled in [
                 (x.bin_count.value, x.wants_scaled.value) for x in module.bin_counts
             ]:
@@ -494,10 +485,7 @@ def test_02_get_zernike_columns():
     ):
         module.wants_zernikes.value = wants_zernikes
         module.zernike_degree.value = 2
-        for i, image_name in ((0, "DNA"), (1, "Cytoplasm"), (2, "Actin")):
-            if i:
-                module.add_image()
-            module.images[i].image_name.value = image_name
+        module.images_list.value = "DNA, Cytoplasm, Actin"
         for i, object_name, center_name in (
             (0, "Nucleii", None),
             (1, "Cells", "Nucleii"),
@@ -532,10 +520,7 @@ def test_01_get_measurements():
     module = (
         cellprofiler.modules.measureobjectintensitydistribution.MeasureObjectIntensityDistribution()
     )
-    for i, image_name in ((0, "DNA"), (1, "Cytoplasm"), (2, "Actin")):
-        if i:
-            module.add_image()
-        module.images[i].image_name.value = image_name
+    module.images_list.value = "DNA, Cytoplasm, Actin"
     for i, object_name, center_name in (
         (0, "Nucleii", None),
         (1, "Cells", "Nucleii"),
@@ -572,7 +557,7 @@ def test_01_get_measurements():
                 object_name,
                 cellprofiler.modules.measureobjectintensitydistribution.M_CATEGORY,
             )
-        for image_name in [x.image_name.value for x in module.images]:
+        for image_name in module.images_list.value:
             for (
                 feature
             ) in cellprofiler.modules.measureobjectintensitydistribution.F_ALL:
@@ -621,10 +606,7 @@ def test_02_get_zernike_measurements():
         module.wants_zernikes.value = wants_zernikes
         module.zernike_degree.value = 2
 
-        for i, image_name in ((0, "DNA"), (1, "Cytoplasm"), (2, "Actin")):
-            if i:
-                module.add_image()
-            module.images[i].image_name.value = image_name
+        module.images_list.value = "DNA, Cytoplasm, Actin"
         for i, object_name, center_name in (
             (0, "Nucleii", None),
             (1, "Cells", "Nucleii"),
@@ -682,7 +664,7 @@ def test_default_heatmap_values():
     module.heatmaps[0].image_name.value = IMAGE_NAME
     module.heatmaps[0].object_name.value = OBJECT_NAME
     module.heatmaps[0].bin_count.value = 10
-    module.images[0].image_name.value = "Bar"
+    module.images_list.value = "Bar"
     module.objects[0].object_name.value = "Foo"
     module.bin_counts[0].bin_count.value = 2
     assert module.heatmaps[0].image_name.get_image_name() == "Bar"
@@ -690,7 +672,7 @@ def test_default_heatmap_values():
     assert module.heatmaps[0].object_name.get_objects_name() == "Foo"
     assert not module.heatmaps[0].object_name.is_visible()
     assert module.heatmaps[0].get_number_of_bins() == 2
-    module.add_image()
+    module.images_list.value = "Bar, MoreBar"
     assert module.heatmaps[0].image_name.is_visible()
     assert module.heatmaps[0].image_name.get_image_name() == IMAGE_NAME
     module.add_object()
@@ -725,7 +707,7 @@ def run_module(
     )
     module.wants_zernikes.value = wants_zernikes
     module.zernike_degree.value = zernike_degree
-    module.images[0].image_name.value = IMAGE_NAME
+    module.images_list.value = IMAGE_NAME
     module.objects[0].object_name.value = OBJECT_NAME
     object_set = cellprofiler.object.ObjectSet()
     main_objects = cellprofiler.object.Objects()

--- a/tests/modules/test_measureobjectsizeshape.py
+++ b/tests/modules/test_measureobjectsizeshape.py
@@ -28,7 +28,7 @@ def make_workspace(labels):
     m = cellprofiler.measurement.Measurements()
     module = cellprofiler.modules.measureobjectsizeshape.MeasureObjectAreaShape()
     module.set_module_num(1)
-    module.object_groups[0].name.value = OBJECTS_NAME
+    module.objects_list.value = OBJECTS_NAME
     pipeline = cellprofiler.pipeline.Pipeline()
 
     def callback(caller, event):
@@ -60,8 +60,8 @@ def test_01_load_v1():
     assert isinstance(
         module, cellprofiler.modules.measureobjectsizeshape.MeasureObjectSizeShape
     )
-    assert len(module.object_groups) == 2
-    for og, expected in zip(module.object_groups, ("Nuclei", "Cells")):
+    assert len(module.objects_list.value) == 2
+    for og, expected in zip(module.objects_list.value, ("Nuclei", "Cells")):
         assert og.name == expected
     assert module.calculate_zernikes
 
@@ -226,7 +226,7 @@ def test_measurements_no_zernike():
 def test_non_contiguous():
     """make sure MeasureObjectAreaShape doesn't crash if fed non-contiguous objects"""
     module = cellprofiler.modules.measureobjectsizeshape.MeasureObjectAreaShape()
-    module.object_groups[0].name.value = "SomeObjects"
+    module.objects_list.value.append("SomeObjects")
     module.calculate_zernikes.value = True
     object_set = cellprofiler.object.ObjectSet()
     labels = numpy.zeros((10, 20), int)
@@ -274,7 +274,7 @@ def test_zernikes_are_different():
     object_set = cellprofiler.object.ObjectSet()
     object_set.add_objects(objects, "SomeObjects")
     module = cellprofiler.modules.measureobjectsizeshape.MeasureObjectAreaShape()
-    module.object_groups[0].name.value = "SomeObjects"
+    module.objects_list.value.append("SomeObjects")
     module.calculate_zernikes.value = True
     module.set_module_num(1)
     image_set_list = cellprofiler.image.ImageSetList()
@@ -308,7 +308,7 @@ def test_zernikes_are_different():
 
 def test_extent():
     module = cellprofiler.modules.measureobjectsizeshape.MeasureObjectAreaShape()
-    module.object_groups[0].name.value = "SomeObjects"
+    module.objects_list.value.append("SomeObjects")
     module.calculate_zernikes.value = True
     object_set = cellprofiler.object.ObjectSet()
     labels = numpy.zeros((10, 20), int)
@@ -375,7 +375,7 @@ def test_overlapping():
     olist.append(objects)
     for objects in olist:
         module = cellprofiler.modules.measureobjectsizeshape.MeasureObjectAreaShape()
-        module.object_groups[0].name.value = "SomeObjects"
+        module.objects_list.value.append("SomeObjects")
         module.calculate_zernikes.value = True
         object_set = cellprofiler.object.ObjectSet()
         object_set.add_objects(objects, "SomeObjects")

--- a/tests/modules/test_measuretexture.py
+++ b/tests/modules/test_measuretexture.py
@@ -16,8 +16,8 @@ INPUT_OBJECTS_NAME = "inputobjects"
 def make_workspace(image, labels, convert=True, mask=None):
     """Make a workspace for testing MeasureTexture"""
     module = cellprofiler.modules.measuretexture.MeasureTexture()
-    module.image_groups[0].image_name.value = INPUT_IMAGE_NAME
-    module.object_groups[0].object_name.value = INPUT_OBJECTS_NAME
+    module.images_list.value = INPUT_IMAGE_NAME
+    module.objects_list.value = INPUT_OBJECTS_NAME
     pipeline = cellprofiler.pipeline.Pipeline()
     object_set = cellprofiler.object.ObjectSet()
     image_set_list = cellprofiler.image.ImageSetList()
@@ -84,12 +84,10 @@ Number of angles to compute for Gabor:6
     for i, wants_gabor in enumerate((True, False)):
         module = pipeline.modules()[i]
         assert isinstance(module, cellprofiler.modules.measuretexture.MeasureTexture)
-        assert len(module.image_groups) == 2
-        assert module.image_groups[0].image_name.value == "rawDNA"
-        assert module.image_groups[1].image_name.value == "rawGFP"
-        assert len(module.object_groups) == 2
-        assert module.object_groups[0].object_name.value == "Cells"
-        assert module.object_groups[1].object_name.value == "Nuclei"
+        assert len(module.images_list.value) == 2
+        assert {'rawDNA', 'rawGFP'}.issubset(module.images_list.value)
+        assert len(module.objects_list.value) == 2
+        assert {'Cells', 'Nuclei'}.issubset(module.objects_list.value)
         assert len(module.scale_groups) == 2
         assert module.scale_groups[0].scale == 3
         assert module.scale_groups[1].scale == 5
@@ -141,12 +139,10 @@ Number of angles to compute for Gabor:6
     for i, wants_gabor in enumerate((True, False)):
         module = pipeline.modules()[i]
         assert isinstance(module, cellprofiler.modules.measuretexture.MeasureTexture)
-        assert len(module.image_groups) == 2
-        assert module.image_groups[0].image_name.value == "rawDNA"
-        assert module.image_groups[1].image_name.value == "rawGFP"
-        assert len(module.object_groups) == 2
-        assert module.object_groups[0].object_name.value == "Cells"
-        assert module.object_groups[1].object_name.value == "Nuclei"
+        assert len(module.images_list.value) == 2
+        assert {'rawDNA', 'rawGFP'}.issubset(module.images_list.value)
+        assert len(module.objects_list.value) == 2
+        assert {'Cells', 'Nuclei'}.issubset(module.objects_list.value)
         assert len(module.scale_groups) == 2
         assert module.scale_groups[0].scale == 3
         assert module.scale_groups[1].scale == 5
@@ -226,12 +222,10 @@ Measure images or objects?:Both
     ):
         module = pipeline.modules()[i]
         assert isinstance(module, cellprofiler.modules.measuretexture.MeasureTexture)
-        assert len(module.image_groups) == 2
-        assert module.image_groups[0].image_name.value == "rawDNA"
-        assert module.image_groups[1].image_name.value == "rawGFP"
-        assert len(module.object_groups) == 2
-        assert module.object_groups[0].object_name.value == "Cells"
-        assert module.object_groups[1].object_name.value == "Nuclei"
+        assert len(module.images_list.value) == 2
+        assert {'rawDNA', 'rawGFP'}.issubset(module.images_list.value)
+        assert len(module.objects_list.value) == 2
+        assert {'Cells', 'Nuclei'}.issubset(module.objects_list.value)
         assert len(module.scale_groups) == 2
         assert module.scale_groups[0].scale == 3
         assert module.scale_groups[1].scale == 5

--- a/tests/test_namesubscriber.py
+++ b/tests/test_namesubscriber.py
@@ -1,0 +1,49 @@
+"""test_namesubscriber.py - test the name subscriber classes from settings"""
+
+import unittest
+
+import cellprofiler.setting
+
+
+class TestListNameSubscriber(unittest.TestCase):
+    def test_load_image_list_empty(self):
+        s = cellprofiler.setting.ListImageNameSubscriber("foo")
+        self.assertEqual(s.value_text, "")
+        self.assertEqual(s.value, [])
+
+    def test_load_image_list_single(self):
+        s = cellprofiler.setting.ListImageNameSubscriber("foo", value="SampleName")
+        self.assertEqual(s.value_text, "SampleName")
+        self.assertEqual(s.value, ["SampleName"])
+
+    def test_load_image_list_multiple(self):
+        s = cellprofiler.setting.ListImageNameSubscriber("foo", value="SampleName1, SampleName2")
+        self.assertEqual(s.value_text, "SampleName1, SampleName2")
+        self.assertEqual(s.value, ["SampleName1", "SampleName2"])
+
+    def test_set_image_list(self):
+        s = cellprofiler.setting.ListImageNameSubscriber("foo")
+        s.value = "SampleName3, SampleName4"
+        self.assertEqual(s.value_text, "SampleName3, SampleName4")
+        self.assertEqual(s.value, ["SampleName3", "SampleName4"])
+
+    def test_load_object_list_empty(self):
+        s = cellprofiler.setting.ListObjectNameSubscriber("foo")
+        self.assertEqual(s.value_text, "")
+        self.assertEqual(s.value, [])
+
+    def test_load_object_list_single(self):
+        s = cellprofiler.setting.ListObjectNameSubscriber("foo", value="SampleName")
+        self.assertEqual(s.value_text, "SampleName")
+        self.assertEqual(s.value, ["SampleName"])
+
+    def test_load_object_list_multiple(self):
+        s = cellprofiler.setting.ListObjectNameSubscriber("foo", value="SampleName1, SampleName2")
+        self.assertEqual(s.value_text, "SampleName1, SampleName2")
+        self.assertEqual(s.value, ["SampleName1", "SampleName2"])
+
+    def test_set_object_list(self):
+        s = cellprofiler.setting.ListObjectNameSubscriber("foo")
+        s.value = "SampleName3, SampleName4"
+        self.assertEqual(s.value_text, "SampleName3, SampleName4")
+        self.assertEqual(s.value, ["SampleName3", "SampleName4"])


### PR DESCRIPTION
Continuing from #3938 but with a cleaner branch. Closes #2298.

This pull request will replace the interface for selecting multiple image or object sets in the measurement modules. Previously multiple objects were typically added using groups, with an 'Add an image' button allowing the user to choose an additional image from a dropdown box. This was slow and tedious when working with many images. The new implementation uses checklist boxes. I've also added a right-click menu for 'select all/none' functionality. To preserve functionality items are also labelled with their source module, and annotated appropriately if they're missing from the pipeline (screenshot below).

![NewMultiSubscriberHandling](https://user-images.githubusercontent.com/26802537/76233977-678bee80-61ff-11ea-8561-58b83ad75424.png)

Per Anne's comments, I've tried to make as much use of this as possible to keep things consistent between modules. Changed modules are as follows:

- MeasureColocalization
- MeasureGranularity
- MeasureImageAreaOccupied
- MeasureImageIntensity
- MeasureImageQuality
- MeasureObjectIntensity
- MeasureObjectIntensityDistribution
- MeasureObjectSizeShape
- MeasureTexture

MeasureObjectIntensityDistribution still uses groups for object sets since each needs an individually defined center point.

**Compatibility notes**:

I've made it so that selected image and object sets are converted when importing older pipelines. However, with MeasureGranularity we decided to move from having detection parameters configured per-image to having a single set of parameters shared between all images. In practice most users did this anyway, but when importing old pipelines where multiple sets of parameters were defined CellProfiler will now carry forward the first set and log a warning about the upgrade. Multiple copies of a module can be used to specify multiple sets of analysis parameters. 

Likewise, MeasureImageIntensity now no longer operates on pairs of images and objects, instead all possible image/object pairings will be processed together. Upgrading an old pipeline will build a list featuring all images and objects and log a warning about this change. This could create more computational work, but again a user could duplicate the module to do specific pairwise comparisons.


**Other notes**:

This implementation adds the ListImageNameSubscriber and ListObjectNameSubscriber setting classes to setting.py. This is basically a wx listbox but with checkboxes next to each name to aid selection, which seems to be much easier to use than SubscriberMultiChoice (which has existed for a long time but is rarely utilised, and needed ctrl+clicking to select multiple options). SubscriberMultiChoice is still used in ExportToDatabase but has otherwise been replaced, if we want to remove that class entirely then we could update ExportToDatabase too with a bit of effort.

It's worth mentioning that the large boxes introduced by this change will make the text wrapping bug described in #3962 more noticeable. We might want to try to fix that.