### PR TITLE
Fix ImageMath "Image is missing" error when loading pipelines

### DIFF
--- a/cellprofiler/modules/imagemath.py
+++ b/cellprofiler/modules/imagemath.py
@@ -273,7 +273,7 @@ use the median intensity measurement as the denominator.
             "image_name",
             cellprofiler.setting.ImageNameSubscriber(
                 "Select the image",
-                "",
+                cellprofiler.setting.NONE,
                 doc="""\
 Select the image that you want to use for this operation.""",
             ),


### PR DESCRIPTION
Fixes #3307.

When loading a pipeline, an ImageNameSubscriber inserts it's value into the list of options if it's not found in the list of possible images. When creating this class providing no setting value will default to 'None', which makes it clear to the user that no image was selected. However, ImageMath was creating subscribers with a default of "" (blank string). This makes the combobox appear blank on Windows, but it appears that on Mac this might make a combobox default to showing the first "proper" option if there is one, and this is done without internally modifying the setting value.

The result is that a pipeline would display the wrong setting as being selected when first creating the module, and if this was not changed before the user ran or saved then the pipeline would still actually have this value set to "" rather than whatever was displayed. Specifying 'None' as a default will hopefully fix this.