### PR TITLE
Fixes for export modules

### DIFF
--- a/cellprofiler/modules/exporttodatabase.py
+++ b/cellprofiler/modules/exporttodatabase.py
@@ -2557,7 +2557,7 @@ available:
                     or pixels.dtype == numpy.bool
                 ):
                     factor = 255
-                    if self.auto_scale_thumbnail_intensities:
+                    if self.auto_scale_thumbnail_intensities and pixels.dtype != numpy.bool:
                         pixels = (pixels - pixels.min()) / pixels.max()
                 else:
                     raise Exception(

--- a/cellprofiler/modules/exporttospreadsheet.py
+++ b/cellprofiler/modules/exporttospreadsheet.py
@@ -135,7 +135,7 @@ SETTING_OG_OFFSET_V9 = 15
 SETTING_OG_OFFSET_V10 = 17
 SETTING_OG_OFFSET_V11 = 18
 """Offset of the first object group in the settings"""
-SETTING_OG_OFFSET = 17
+SETTING_OG_OFFSET = 18
 
 """Offset of the object name setting within an object group"""
 SETTING_OBJECT_NAME_IDX = 0
@@ -178,7 +178,7 @@ NANS_AS_NANS = "NaN"
 class ExportToSpreadsheet(cpm.Module):
     module_name = "ExportToSpreadsheet"
     category = ["File Processing", "Data Tools"]
-    variable_revision_number = 12
+    variable_revision_number = 13
 
     def create_settings(self):
         self.delimiter = cps.CustomChoice(
@@ -254,6 +254,16 @@ GUI and to fail when running headless."""
 “Image\_Metadata\_” columns are normally exported in the Image data
 file, but if you select *"Yes"*, they will also be exported with the
 Object data file(s)."""
+            % globals(),
+        )
+
+        self.add_filepath = cps.Binary(
+            "Add image file and folder names to your object data file?",
+            False,
+            doc="""\
+“Image\_PathName\_” and “Image\_FileName\_” columns are normally
+exported in the Image data file, but if you select *"Yes"*, they will also
+be exported with the Object data file(s)."""
             % globals(),
         )
 
@@ -544,6 +554,7 @@ desired.
         result = [
             self.delimiter,
             self.add_metadata,
+            self.add_filepath,
             self.pick_columns,
             self.wants_aggregate_means,
             self.wants_aggregate_medians,
@@ -577,6 +588,7 @@ desired.
         result += [
             self.wants_overwrite_without_warning,
             self.add_metadata,
+            self.add_filepath,
             self.nan_representation,
             self.pick_columns,
         ]
@@ -1276,6 +1288,14 @@ desired.
             ]
             mdfeatures.sort()
             features += mdfeatures
+        if self.add_filepath.value:
+            filefeatures = [
+                (IMAGE, name)
+                for object_name, name in columns
+                if name.startswith("PathName_", "FileName_") and object_name == IMAGE
+            ]
+            filefeatures.sort()
+            features += filefeatures
         for object_name in object_names:
             ofeatures = [
                 feature for col_object, feature in columns if col_object == object_name
@@ -1583,9 +1603,13 @@ desired.
             setting_values = setting_values[:2] + setting_values[3:]
 
             variable_revision_number = 12
+        if variable_revision_number == 12:
+            # Add "add file path" setting.
+            setting_values = setting_values[:2] + [cps.NO] + setting_values[2:]
+            variable_revision_number = 13
 
         # Standardize input/output directory name references
-        SLOT_DIRCHOICE = 6
+        SLOT_DIRCHOICE = 7
         directory = setting_values[SLOT_DIRCHOICE]
         directory = cps.DirectoryPath.upgrade_setting(directory)
         setting_values = (

--- a/cellprofiler/modules/exporttospreadsheet.py
+++ b/cellprofiler/modules/exporttospreadsheet.py
@@ -1258,6 +1258,9 @@ desired.
 
             columns = set(columns)
             features = [x for x in features if x in columns]
+        elif object_name == cpmeas.IMAGE:
+            # Exclude any thumbnails if they've been created for ExportToDatabase
+            features = [x for x in features if not x.startswith("Thumbnail_")]
         return features
 
     def make_object_file(


### PR DESCRIPTION
I've made it so that ExportToDatabase will no longer try (and fail) to rescale boolean thumbnails. Fixes #3976

On the subject of thumbnails, I've made ExportToSpreadsheet exclude thumbnails generated by ExportToDatabase, unless the user is in 'choose columns' mode - in which case they can have them if they so wish. Fixes #3973

I've also added the requested 'add file folder and name in objects table' option to ExportToSpreadsheet. Closes #3739

These are a bit tricky to test on the part of Master's analyse mode being broken, but I've got them working on 3.1.9 and hopefully the port should be fine.