### PR TITLE
Fix loss of precision when resizing images

### DIFF
--- a/cellprofiler/modules/resize.py
+++ b/cellprofiler/modules/resize.py
@@ -338,32 +338,24 @@ resized with the same settings as the first image.""",
         new_shape = self.resized_shape(image, workspace)
 
         order = self.spline_order()
-        # Pixel values need to be between -1, 1 in order to use  skimage resize
-        # Thus determine a factor to scale by
-        img_scale_fac = numpy.abs(image_pixels).max()
 
         if image.volumetric and image.multichannel:
             output_pixels = numpy.zeros(new_shape.astype(int), dtype=image_pixels.dtype)
 
             for idx in range(int(new_shape[-1])):
                 output_pixels[:, :, :, idx] = skimage.transform.resize(
-                    image_pixels[:, :, :, idx] / img_scale_fac,
+                    image_pixels[:, :, :, idx],
                     new_shape[:-1],
                     order=order,
                     mode="symmetric",
                 )
         else:
             output_pixels = skimage.transform.resize(
-                image_pixels / img_scale_fac, new_shape, order=order, mode="symmetric"
+                image_pixels, new_shape, order=order, mode="symmetric"
             )
 
         if image.multichannel and len(new_shape) > image.dimensions:
             new_shape = new_shape[:-1]
-
-        if img_scale_fac != 1:
-            # if the image intensities were scaled,
-            # scale them back in the output
-            output_pixels = output_pixels * img_scale_fac
 
         mask = skimage.transform.resize(image.mask, new_shape, order=0, mode="constant")
 


### PR DESCRIPTION
Fixes #3831, closes #3952. Turns out you no longer need to rescale intensity to between -1 and 1 when resizing in the current version of Skimage. Yay.