### PR TITLE
Fix loading of CP3 workspaces

### DIFF
--- a/cellprofiler/gui/imagesetctrl.py
+++ b/cellprofiler/gui/imagesetctrl.py
@@ -251,7 +251,7 @@ class ImageSetGridTable(wx.grid.GridTableBase):
         column = self.columns[col]
         if (
             column.channel_type
-            == cellprofiler_core.pipeline.Pipeline.ImageSetChannelDescriptor.CT_OBJECTS
+            == cellprofiler_core.pipeline.ImageSetChannelDescriptor.CT_OBJECTS
         ):
             feature = cellprofiler_core.measurement.C_OBJECTS_URL + "_" + column.channel
         else:
@@ -377,7 +377,10 @@ class ImageSetCache:
             entry = self.cache[key]
             entry[1] = self.access_time
         self.access_time += 1
-        return entry[0][index]
+        result = entry[0][index]
+        if isinstance(result, bytes):
+            result = result.decode("utf-8")
+        return result
 
     def decimate(self):
         """Reduce the cache size by 1/2"""

--- a/cellprofiler/gui/imagesetctrl.py
+++ b/cellprofiler/gui/imagesetctrl.py
@@ -234,7 +234,8 @@ class ImageSetGridTable(wx.grid.GridTableBase):
         image_set = self.image_numbers[row]
         column = self.columns[col]
         value = self.cache[column.feature, image_set]
-        value = value.decode('unicode_escape')
+        if isinstance(value, bytes):
+            value = value.decode('unicode_escape')
         if (
             column.column_type == COL_URL
             and self.display_mode == DISPLAY_MODE_SIMPLE

--- a/cellprofiler/gui/imagesetctrl.py
+++ b/cellprofiler/gui/imagesetctrl.py
@@ -234,6 +234,7 @@ class ImageSetGridTable(wx.grid.GridTableBase):
         image_set = self.image_numbers[row]
         column = self.columns[col]
         value = self.cache[column.feature, image_set]
+        value = value.decode('unicode_escape')
         if (
             column.column_type == COL_URL
             and self.display_mode == DISPLAY_MODE_SIMPLE


### PR DESCRIPTION
A problem we have is that CP3 .cpproj files have their measurements, particularly filenames, encoded as bytes rather than strings when the HDF5 data is imported in Python 3. I'm still trying to figure out how best to address this, but for now these changes decode elements needed by the GUI as necessary.

Posting this as a draft in case anyone has a better idea, I'm still trying to figure out how to deal with this in analysis mode.