### PR TITLE
Figure display fixes

### DIFF
--- a/cellprofiler/gui/figure.py
+++ b/cellprofiler/gui/figure.py
@@ -2318,7 +2318,7 @@ class Figure(wx.Frame):
         self.figure.set_facecolor((1, 1, 1))
         self.figure.set_edgecolor((1, 1, 1))
         values = numpy.array(values).flatten()
-        if xscale == LOG:
+        if xscale == "log":
             values = numpy.log(values[values > 0])
             xlabel = "Log(%s)" % (xlabel or "?")
         # hist apparently doesn't like nans, need to preen them out first
@@ -2338,7 +2338,7 @@ class Figure(wx.Frame):
             bins,
             facecolor=(0.0, 0.62, 1.0),
             edgecolor="none",
-            log=(yscale == LOG),
+            log=(yscale == "log"),
             alpha=0.75,
         )
         axes.set_xlabel(xlabel)

--- a/cellprofiler/gui/figure.py
+++ b/cellprofiler/gui/figure.py
@@ -718,6 +718,9 @@ class Figure(wx.Frame):
             xi = int(event.xdata + 0.5)
             yi = int(event.ydata + 0.5)
             fields = self.get_fields(event, yi, xi, x1)
+        else:
+            # Mouse has moved off the plot, stop updating.
+            return
 
         # Calculate the length field if mouse is down
         if self.mouse_down is not None:

--- a/cellprofiler/gui/figure.py
+++ b/cellprofiler/gui/figure.py
@@ -945,7 +945,7 @@ class Figure(wx.Frame):
         else:
             if dimensions == 2:
                 self.subplots = numpy.zeros(subplots, dtype=object)
-                self.gridspec = matplotlib.gridspec.GridSpec(
+                self.__gridspec = matplotlib.gridspec.GridSpec(
                     subplots[1], subplots[0], figure=self.figure
                 )
             else:
@@ -965,10 +965,10 @@ class Figure(wx.Frame):
         if self.dimensions == 3:
             return None
         if not self.subplots[x, y]:
-            if self.gridspec:
+            if self.__gridspec:
                 # Add the plot to a premade subplot layout
                 plot = self.figure.add_subplot(
-                    self.gridspec[y, x], sharex=sharex, sharey=sharey,
+                    self.__gridspec[y, x], sharex=sharex, sharey=sharey,
                 )
             else:
                 rows, cols = self.subplots.shape

--- a/cellprofiler/gui/figure.py
+++ b/cellprofiler/gui/figure.py
@@ -736,16 +736,17 @@ class Figure(wx.Frame):
             diagonal = numpy.sqrt(
                 (xinterval[1] - xinterval[0]) ** 2 + (yinterval[1] - yinterval[0]) ** 2
             )
-            mutation_scale = min(int(length * 100 / diagonal), 20)
+            mutation_scale = max(min(int(length * 100 / diagonal), 20), 1)
             if self.length_arrow is not None:
                 self.length_arrow.set_positions(
                     (self.mouse_down[0], self.mouse_down[1]), (event.xdata, event.ydata)
                 )
+                self.length_arrow.set_mutation_scale(mutation_scale)
             else:
                 self.length_arrow = matplotlib.patches.FancyArrowPatch(
                     (self.mouse_down[0], self.mouse_down[1]),
                     (event.xdata, event.ydata),
-                    edgecolor="red",
+                    edgecolor="blue",
                     arrowstyle="<->",
                     mutation_scale=mutation_scale,
                 )

--- a/cellprofiler/gui/figure.py
+++ b/cellprofiler/gui/figure.py
@@ -10,6 +10,7 @@ import logging
 import os
 import sys
 import uuid
+from textwrap import fill
 
 import centrosome.cpmorphology
 import centrosome.outline
@@ -987,9 +988,8 @@ class Figure(wx.Frame):
         y - subplot's row
         """
         fontname = cellprofiler_core.preferences.get_title_font_name()
-
         self.subplot(x, y).set_title(
-            title,
+            fill(title, 30),
             fontname=fontname,
             fontsize=cellprofiler_core.preferences.get_title_font_size(),
         )

--- a/cellprofiler/gui/help/__init__.py
+++ b/cellprofiler/gui/help/__init__.py
@@ -4,6 +4,7 @@
 def make_help_menu(h, window, menu=None):
     import wx
     import cellprofiler.gui.htmldialog
+    import cellprofiler.gui.html.utils
 
     if menu is None:
         menu = wx.Menu()
@@ -14,6 +15,7 @@ def make_help_menu(h, window, menu=None):
         else:
 
             def show_dialog(event, key=key, value=value):
+                value = cellprofiler.gui.html.utils.rst_to_html_fragment(value)
                 dlg = cellprofiler.gui.htmldialog.HTMLDialog(window, key, value)
                 dlg.Show()
 

--- a/cellprofiler/modules/threshold.py
+++ b/cellprofiler/modules/threshold.py
@@ -927,7 +927,7 @@ Often a good choice is some multiple of the largest expected object size.
     def display(self, workspace, figure):
         dimensions = workspace.display_data.dimensions
 
-        figure.set_subplots((3, 1), dimensions=dimensions)
+        figure.set_subplots((2, 2), dimensions=dimensions)
 
         figure.subplot_imshow_grayscale(
             0,
@@ -945,7 +945,7 @@ Often a good choice is some multiple of the largest expected object size.
         )
 
         figure.subplot_table(
-            2, 0, workspace.display_data.statistics, workspace.display_data.col_labels
+            1, 1, workspace.display_data.statistics, workspace.display_data.col_labels
         )
 
     def get_measurement_objects_name(self):

--- a/cellprofiler/modules/unmixcolors.py
+++ b/cellprofiler/modules/unmixcolors.py
@@ -53,6 +53,7 @@ See also **ColorToGray**.
 
 .. _Colour\_Deconvolution.java: http://imagej.net/Colour_Deconvolution
 """
+import math
 
 import numpy as np
 from scipy.linalg import lstsq
@@ -417,18 +418,22 @@ blue absorbance values from the image.
             workspace.display_data.outputs[image_name] = image
 
     def display(self, workspace, figure):
-        """Display all of the images in a figure"""
-        figure.set_subplots((len(self.outputs) + 1, 1))
+        """Display all of the images in a figure, use rows of 3 subplots"""
+        numcols = min(3, len(self.outputs) + 1)
+        numrows = math.ceil((len(self.outputs) + 1) / 3)
+        figure.set_subplots((numcols, numrows))
+        coordslist = [(x, y) for y in range(numrows) for x in range(numcols)][1:]
         input_image = workspace.display_data.input_image
         figure.subplot_imshow_color(
             0, 0, input_image, title=self.input_image_name.value
         )
         ax = figure.subplot(0, 0)
         for i, output in enumerate(self.outputs):
+            x, y = coordslist[i]
             image_name = output.image_name.value
             pixel_data = workspace.display_data.outputs[image_name]
             figure.subplot_imshow_grayscale(
-                i + 1, 0, pixel_data, title=image_name, sharexy=ax
+                x, y, pixel_data, title=image_name, sharexy=ax
             )
 
     def get_absorbances(self, output):


### PR DESCRIPTION
Fixed a bunch of issues effecting the figure window which were found during RC testing:

- Wrapped excessively long figure names. Constrained layout will scale the graph to fit the whole title into the window, which made figures with titles such as file paths get too small.

- Made subplots from UnmixColors arrange themselves into rows of 3. This should make for a sensible display with any reasonable number of channels being isolated. Other modules with flexible numbers of figures already handle this.

- Moved Threshold's stats table to a second row to reduce crowding.

- Fixed a bug with constrained layout when trying to display individual subplot windows.

- Made histograms work.

- Fixed console spam when the Measure Length tool was moved off the focused subplot.

- Fixed the Measure Length tool not always drawing a line, fixed the dynamic arrow scaling and made the line blue.

- Fixed formatting of help windows launched from figure windows.