### PR TITLE
Restore input/pipeline module list boundary and correct alignment.

### DIFF
--- a/cellprofiler/gui/pipelinelistview.py
+++ b/cellprofiler/gui/pipelinelistview.py
@@ -176,7 +176,7 @@ class PipelineListView(object):
     def make_list(self):
         """Make the list control with the pipeline items in it"""
         self.list_ctrl = PipelineListCtrl(self.__panel)
-        self.__sizer.Add(self.list_ctrl, 1, wx.EXPAND)
+        self.__sizer.Add(self.list_ctrl, 1, wx.EXPAND | wx.TOP, border=2)
         #
         # Bind events
         #
@@ -1494,7 +1494,7 @@ class PipelineListCtrl(wx.ScrolledWindow):
             width, height, _, _ = self.GetFullTextExtent(item.module_name)
             max_width = max(width, max_width)
         total_width = x0 + max_width + self.border * 2 + self.gap + self.text_gap
-        height = len(self.items) * self.line_height
+        height = max((len(self.items) - 1) * self.line_height, 0)
         return total_width, height
 
     def DoGetVirtualSize(self):


### PR DESCRIPTION
This pull request aims to restore the dividing line between the input and pipeline modules (as requested). This feature seems to be absent in 3.1.9 too, but I've tried to restore the visual distinction using a border on the input box sizer. Unfortunately I can't change the colour of the border so it matches the rest of the interface rather than being a black line, but it should still be a bit more obvious that the input modules are seperate.

I've also addressed the extra blank space between the input and pipeline modules which appeared in 4.0. I'm not sure why this happens, but in WX4 the widget seems to want to add space for an extra item to be added. I don't know whether this is a Windows-specific issue, so could someone check how this looks on Mac before merging?

![PipelineListView](https://user-images.githubusercontent.com/26802537/83039796-90589e80-a00c-11ea-8368-50d6624635ad.png)
