### PR TITLE
Fix console spam in EditObjectsDialog

### DIFF
--- a/cellprofiler/gui/editobjectsdlg.py
+++ b/cellprofiler/gui/editobjectsdlg.py
@@ -286,6 +286,7 @@ class EditObjectsDialog(wx.Dialog):
 
         self.panel = CanvasPatch(self, -1, self.figure)
         self.toolbar = cellprofiler.gui.figure.NavigationToolbar(self.panel)
+        self.toolbar.set_message = self.discard_message
         self.sash_parent = wx.Panel(self)
         #
         # Need to reparent the canvas after instantiating the toolbar so
@@ -2168,3 +2169,8 @@ class EditObjectsDialog(wx.Dialog):
                 del self.artists[artist]
             if display:
                 self.display()
+
+    def discard_message(self, message):
+        # Matplotlib wants to update the status bar, but this window lacks one.
+        # So we ignore it. Matplotlib plan to remove this behaviour eventually.
+        return


### PR DESCRIPTION
Matplotlib are in the process of moving away from creating a wx statusbar (see matplotlib/matplotlib#17092). For the time being the current version attempts to update whatever wx statusbar is present on a plot window. I'd fixed this for the normal figure windows, but on the edit object dialogs there is no statusbar at all which upsets matplotlib.

As a fix for this version, I've added a dud function to chuck out the update commands sent by matplotlib.