### PR TITLE
Remove deprecated can_overwrite measurements parameter

### DIFF
--- a/cellprofiler/gui/datatoolframe.py
+++ b/cellprofiler/gui/datatoolframe.py
@@ -237,7 +237,7 @@ class DataToolFrame(wx.Frame):
 
     def load_measurements(self, measurements_file_name):
         self.measurements = cellprofiler_core.measurement.load_measurements(
-            measurements_file_name, can_overwrite=True
+            measurements_file_name
         )
         # Start on the first image
         self.measurements.next_image_set(1)

--- a/cellprofiler/gui/parametersampleframe.py
+++ b/cellprofiler/gui/parametersampleframe.py
@@ -638,9 +638,7 @@ class ParameterSampleFrame(wx.Frame):
         better understanding of what exactly this does, but I'm pretty much
         using it as a black box for the time being.
         """
-        self.__measurements = cellprofiler_core.measurement.Measurements(
-            can_overwrite=True
-        )
+        self.__measurements = cellprofiler_core.measurement.Measurements()
         self.__object_set = cellprofiler_core.object.ObjectSet(can_overwrite=True)
         self.__image_set_list = cellprofiler_core.image.ImageSetList()
         workspace = cellprofiler.gui.workspace.Workspace(

--- a/cellprofiler/modules/saveimages.py
+++ b/cellprofiler/modules/saveimages.py
@@ -764,19 +764,16 @@ store images in the subfolder, "*date*\/*plate-name*".""",
                 cellprofiler_core.measurement.IMAGE,
                 self.file_name_feature,
                 fn,
-                can_overwrite=True,
             )
             workspace.measurements.add_measurement(
                 cellprofiler_core.measurement.IMAGE,
                 self.path_name_feature,
                 pn,
-                can_overwrite=True,
             )
             workspace.measurements.add_measurement(
                 cellprofiler_core.measurement.IMAGE,
                 self.url_feature,
                 url,
-                can_overwrite=True,
             )
 
     @property

--- a/cellprofiler/modules/trackobjects.py
+++ b/cellprofiler/modules/trackobjects.py
@@ -2727,21 +2727,18 @@ Enter a name to give the color-coded image of tracked labels.""",
                 object_name,
                 self.measurement_name(F_LABEL),
                 newlabel[i],
-                can_overwrite=True,
                 image_set_number=image_number,
             )
             m.add_measurement(
                 object_name,
                 self.measurement_name(F_PARENT_IMAGE_NUMBER),
                 parent_image_numbers[i],
-                can_overwrite=True,
                 image_set_number=image_number,
             )
             m.add_measurement(
                 object_name,
                 self.measurement_name(F_PARENT_OBJECT_NUMBER),
                 parent_object_numbers[i],
-                can_overwrite=True,
                 image_set_number=image_number,
             )
             is_fixups = fixups.get(image_number, None)
@@ -3045,7 +3042,6 @@ Enter a name to give the color-coded image of tracked labels.""",
                     self.feature_name,
                     val,
                     image_set_number=image_numbers[index],
-                    can_overwrite=True,
                 )
 
             def get_parent(self, index, no_parent=None):

--- a/tests/modules/test_exporttodatabase.py
+++ b/tests/modules/test_exporttodatabase.py
@@ -1090,7 +1090,7 @@ def make_workspace(
                 return ["Plate", "Well"]
             return []
 
-    m = cellprofiler_core.measurement.Measurements(can_overwrite=True)
+    m = cellprofiler_core.measurement.Measurements()
     for i in range(image_set_count):
         if i > 0:
             m.next_image_set()


### PR DESCRIPTION
Linked to CellProfiler/core#4. This legacy parameter didn't do anything and had been partially removed from core, causing problems with TrackObjects.