### PR TITLE
Improve "Search Help" speed

### DIFF
--- a/cellprofiler/gui/help/search.py
+++ b/cellprofiler/gui/help/search.py
@@ -247,6 +247,16 @@ def __search_fn(html, text):
     ]
 
 
+def quick_search(module, text):
+    mod_doc, mod_settings = module.get_help_text()
+    if text in mod_doc.lower():
+        return True
+    for setting_name, setting_doc in mod_settings:
+        if text in setting_doc.lower():
+            return True
+    return False
+
+
 def search_module_help(text):
     """
     Search the help for a string
@@ -278,14 +288,14 @@ def search_module_help(text):
         if location == cellprofiler_core.preferences.get_plugin_directory():
             continue
 
-        help_text = module.get_help()
+        prelim_matches = quick_search(module, text.lower())
+        if prelim_matches:
+            help_text = module.get_help()
+            matches = __search_fn(help_text, text)
 
-        matches = __search_fn(help_text, text)
-
-        if len(matches) > 0:
-            matching_help.append((module_name, help_text, matches))
-
-            count += len(matches)
+            if len(matches) > 0:
+                matching_help.append((module_name, help_text, matches))
+                count += len(matches)
 
     if len(matching_help) == 0:
         return None


### PR DESCRIPTION
Requires CellProfiler/core#6.

The search function spends a lot of time converting every module's help text into HTML before searching for the user's keyword. This pull makes CP fetch the raw help text from each module and do a preliminary scan on that to determine which modules actually need a full fat search performed on them. At least on Windows this dramatically speeds up the function.