### PR TITLE
Revise Threshold module

### DIFF
--- a/cellprofiler/modules/identifyprimaryobjects.py
+++ b/cellprofiler/modules/identifyprimaryobjects.py
@@ -1205,7 +1205,7 @@ If "*{NO}*" is selected, the following settings are used:
             self.y_name.value, workspace.measurements, image, binary_image
         )
 
-        return binary_image, orig_threshold, sigma
+        return binary_image, numpy.mean(numpy.atleast_1d(final_threshold)), sigma
 
     def smooth_image(self, image, mask):
         """Apply the smoothing filter to the image"""

--- a/cellprofiler/modules/identifyprimaryobjects.py
+++ b/cellprofiler/modules/identifyprimaryobjects.py
@@ -1189,23 +1189,23 @@ If "*{NO}*" is selected, the following settings are used:
     def _threshold_image(self, image_name, workspace, automatic=False):
         image = workspace.image_set.get_image(image_name, must_be_grayscale=True)
 
-        local_threshold, global_threshold = self.threshold.get_threshold(
+        final_threshold, orig_threshold, guide_threshold = self.threshold.get_threshold(
             image, workspace, automatic
         )
 
         self.threshold.add_threshold_measurements(
-            self.y_name.value, workspace.measurements, local_threshold, global_threshold
+            self.y_name.value, workspace.measurements, final_threshold, orig_threshold, guide_threshold
         )
 
         binary_image, sigma = self.threshold.apply_threshold(
-            image, local_threshold, automatic
+            image, final_threshold, automatic
         )
 
         self.threshold.add_fg_bg_measurements(
             self.y_name.value, workspace.measurements, image, binary_image
         )
 
-        return binary_image, global_threshold, sigma
+        return binary_image, orig_threshold, sigma
 
     def smooth_image(self, image, mask):
         """Apply the smoothing filter to the image"""

--- a/cellprofiler/modules/identifysecondaryobjects.py
+++ b/cellprofiler/modules/identifysecondaryobjects.py
@@ -801,7 +801,7 @@ segmentation.""",
             self.y_name.value, workspace.measurements, image, binary_image
         )
 
-        return binary_image, orig_threshold, sigma
+        return binary_image, numpy.mean(numpy.atleast_1d(final_threshold)), sigma
 
     def display(self, workspace, figure):
         object_pct = workspace.display_data.object_pct

--- a/cellprofiler/modules/identifysecondaryobjects.py
+++ b/cellprofiler/modules/identifysecondaryobjects.py
@@ -785,23 +785,23 @@ segmentation.""",
     def _threshold_image(self, image_name, workspace, automatic=False):
         image = workspace.image_set.get_image(image_name, must_be_grayscale=True)
 
-        local_threshold, global_threshold = self.threshold.get_threshold(
+        final_threshold, orig_threshold, guide_threshold = self.threshold.get_threshold(
             image, workspace, automatic
         )
 
         self.threshold.add_threshold_measurements(
-            self.y_name.value, workspace.measurements, local_threshold, global_threshold
+            self.y_name.value, workspace.measurements, final_threshold, orig_threshold, guide_threshold
         )
 
         binary_image, sigma = self.threshold.apply_threshold(
-            image, local_threshold, automatic
+            image, final_threshold, automatic
         )
 
         self.threshold.add_fg_bg_measurements(
             self.y_name.value, workspace.measurements, image, binary_image
         )
 
-        return binary_image, global_threshold, sigma
+        return binary_image, orig_threshold, sigma
 
     def display(self, workspace, figure):
         object_pct = workspace.display_data.object_pct

--- a/cellprofiler/modules/threshold.py
+++ b/cellprofiler/modules/threshold.py
@@ -842,7 +842,7 @@ Often a good choice is some multiple of the largest expected object size.
 
         # Shortcuts - Check if image array is empty or all pixels are the same value.
         if len(image_data) == 0:
-            threshold = 0
+            threshold = 0.0
 
         elif numpy.all(image_data == image_data[0]):
             threshold = image_data[0]
@@ -967,7 +967,7 @@ Often a good choice is some multiple of the largest expected object size.
                 block = image_data[i0:i1, j0:j1]
                 block = block[~numpy.isnan(block)]
                 if len(block) == 0:
-                    threshold_out = 0
+                    threshold_out = 0.0
                 elif numpy.all(block == block[0]):
                     # Don't compute blocks with only 1 value.
                     threshold_out = block[0]

--- a/cellprofiler/modules/threshold.py
+++ b/cellprofiler/modules/threshold.py
@@ -340,7 +340,7 @@ threshold value.
    thresholding strategy, originally developed for text recognition. A
    threshold is determined for every individual pixel, based on the mean and
    standard deviation of the surrounding pixels within a square window. The
-   size of this window is set using the adaptive window parameter. 
+   size of this window is set using the adaptive window parameter.
 
    |image4| This thresholding method can be helpful when you want to use 
    a very small adaptive window size, which may be useful when trying to
@@ -353,6 +353,12 @@ threshold value.
    pixel seperately (no interpolation) without needing excessive computation
    time.
 
+   |image3| As regions are likely to contain no cells, adaptive thresholds are constrained
+   to ensure all pixel thresholds are between 0.7x and 1.5x a global threshold, termed the
+   "Guide Threshold". This guide is calculated using the global strategy using the same
+   method as selected for adaptive mode. The one exception to this is Sauvola thresholding,
+   which uses a Minimum Cross-Entropy global threshold as a guide (since Sauvola is only
+   available as a local threshold).
 
 **References**
 

--- a/cellprofiler/modules/threshold.py
+++ b/cellprofiler/modules/threshold.py
@@ -191,7 +191,7 @@ There are a number of methods for finding thresholds automatically:
    
    NOTE that from CellProfiler 4.0.0 and onwards the standard implementation will
    be used for three-class Otsu thresholding as well. Results with three-class
-   Otsu thresholding are likely to be slight different from older versions, so
+   Otsu thresholding are likely to be slightly different from older versions, so
    imported pipelines which use these methods should be checked when converting
    to the latest version to ensure that settings are still appropriate.
 

--- a/cellprofiler/modules/threshold.py
+++ b/cellprofiler/modules/threshold.py
@@ -821,7 +821,6 @@ Often a good choice is some multiple of the largest expected object size.
             return self.manual_threshold.value, self.manual_threshold.value, None
 
         elif self.threshold_operation == TM_MEASUREMENT:
-            # m = workspace.measurements
             # Thresholds are stored as single element arrays.  Cast to float to extract the value.
             orig_threshold = float(
                 workspace.measurements.get_current_image_measurement(self.thresholding_measurement.value)

--- a/cellprofiler/modules/threshold.py
+++ b/cellprofiler/modules/threshold.py
@@ -750,11 +750,7 @@ Often a good choice is some multiple of the largest expected object size.
     def run(self, workspace):
         input_image = workspace.image_set.get_image(self.x_name.value, must_be_grayscale=True)
         dimensions = input_image.dimensions
-        import time
-        start = time.perf_counter()
         final_threshold, orig_threshold, guide_threshold = self.get_threshold(input_image, workspace, automatic=False)
-        time2 = time.perf_counter() - start
-        print("Threshold: ", "%.4f" % numpy.mean(numpy.atleast_1d(final_threshold)), " in ", "%.4fs" % time2)
 
         self.add_threshold_measurements(
             self.get_measurement_objects_name(),

--- a/cellprofiler/modules/threshold.py
+++ b/cellprofiler/modules/threshold.py
@@ -878,11 +878,15 @@ Often a good choice is some multiple of the largest expected object size.
 
         elif self.threshold_operation == TM_LI:
             local_threshold = self._run_local_threshold(image_data,
-                                                        method=skimage.filters.threshold_li)
+                                                        method=skimage.filters.threshold_li,
+                                                        volumetric=image.volumetric,
+                                                        )
         elif self.threshold_operation == TM_OTSU:
             if self.two_class_otsu.value == O_TWO_CLASS:
                 local_threshold = self._run_local_threshold(image_data,
-                                                            method=skimage.filters.threshold_otsu)
+                                                            method=skimage.filters.threshold_otsu,
+                                                            volumetric=image.volumetric,
+                                                            )
 
             elif self.two_class_otsu.value == O_THREE_CLASS:
                 local_threshold = self._run_local_threshold(image_data,
@@ -894,6 +898,7 @@ Often a good choice is some multiple of the largest expected object size.
         elif self.threshold_operation == TM_ROBUST_BACKGROUND:
             local_threshold = self._run_local_threshold(image_data,
                                                         method=self.get_threshold_robust_background,
+                                                        volumetric=image.volumetric,
                                                         )
 
         elif self.threshold_operation == TM_SAUVOLA:

--- a/cellprofiler/modules/threshold.py
+++ b/cellprofiler/modules/threshold.py
@@ -750,7 +750,10 @@ Often a good choice is some multiple of the largest expected object size.
     def run(self, workspace):
         input_image = workspace.image_set.get_image(self.x_name.value, must_be_grayscale=True)
         dimensions = input_image.dimensions
-        final_threshold, orig_threshold, guide_threshold = self.get_threshold(input_image, workspace, automatic=False)
+        final_threshold, orig_threshold, guide_threshold = self.get_threshold(input_image,
+                                                                              workspace,
+                                                                              automatic=False,
+                                                                              )
 
         self.add_threshold_measurements(
             self.get_measurement_objects_name(),
@@ -846,6 +849,8 @@ Often a good choice is some multiple of the largest expected object size.
 
         elif automatic or self.threshold_operation in (TM_LI, TM_SAUVOLA):
             threshold = skimage.filters.threshold_li(image_data)
+            if automatic:
+                return threshold, threshold, None
 
         elif self.threshold_operation == TM_ROBUST_BACKGROUND:
             threshold = self.get_threshold_robust_background(image_data)

--- a/tests/modules/test_threshold.py
+++ b/tests/modules/test_threshold.py
@@ -141,7 +141,7 @@ def test_load_v9():
 
     module = pipeline.modules()[6]
     assert module.threshold_scope.value == cellprofiler.modules.threshold.TS_GLOBAL
-    assert module.global_operation.value == centrosome.threshold.TM_ROBUST_BACKGROUND
+    assert module.global_operation.value == cellprofiler.modules.threshold.TM_ROBUST_BACKGROUND
 
     module = pipeline.modules()[7]
     assert module.threshold_scope.value == cellprofiler.modules.threshold.TS_GLOBAL


### PR DESCRIPTION
Requires CellProfiler/core#7.

Closes #3953.

Probably fixes #3738.

This is a rewrite of the Threshold module to make things more consistent. Key changes are:

- When writing measurements, "Original Threshold" will always be the uncorrected threshold, while "Final Threshold" will refer to the corrected threshold with multipliers and limits applied. "Guide Threshold" has been added to record a global threshold which was used to constrain an adaptive threshold.

- MCE and RobustBackground are now available as adaptive threshold methods.

- Skimage methods are now used wherever possible. RobustBackground is unfortunately not available but the other methods were. We're still using centrosome's block-based adaptive thresholding as the skimage local_threshold function currently performs very poorly if you try to pass it a complex thresholding algorithm.

- Added Sauvola local thresholding. This will hopefully be useful as it's fast and doesn't suffer from performance degradation when using a small window size.

- Otsu 3-class thresholding now uses the standard Skimage implementation. This will change results from older pipelines. I'm not sure why but the original methods were giving much lower thresholds than you might anticipate, but on the plus side that's now fixed.

- For consistency, adaptive Otsu thresholding will now use the block-based method regardless of whether you're using 2 or 3 class mode. Skimage does have a truly local 2-class Otsu, but there was a performance hit in some situations and the results weren't substantially different.

- Smoothing can now be applied when using the Measurement and Manual methods.

- The display output from the Threshold module now includes a panel showing the local threshold values. This should allow users to inspect and understand how their min/max constraints are impacting the final threshold array.

- Moved towards having constants within Threshold, rather than duplicated between Threshold and centrosome.

I still need to fix all the tests, but making a record of all this now before I forget.