### PR TITLE
Add CombineObjects module

### DIFF
--- a/cellprofiler/modules/combineobjects.py
+++ b/cellprofiler/modules/combineobjects.py
@@ -19,6 +19,10 @@ When performing operations, this module treats the first selected object set, te
 "initial objects" as the starting point for a joined set. CellProfiler will try to add
 objects from the second selected set to the initial set.
 
+Object label numbers are re-assigned after merging the object sets. This can mean that
+if your settings result in one object being cut into two by another object, the divided
+segments will be reassigned as seperate objects.
+
 |
 
 ============ ============ ===============
@@ -67,9 +71,10 @@ same location. Use this setting to choose how to handle objects which overlap wi
 eachother.
         
 - Selecting "Merge" will make overlapping objects combine into a single object, taking
-  on the label of the object from the initial set. When more than two objects overlap,
-  each pixel of an added object will be assigned to the closest object from the initial
-  set. This is primarily useful when the same objects appear in both sets.
+  on the label of the object from the initial set. When an added object would overlap
+  with multiple objects from the initial set, each pixel of the added object will be
+  assigned to the closest object from the initial set. This is primarily useful when
+  the same objects appear in both sets.
         
 - Selecting "Preserve" will protect the initial object set. Any overlapping regions
   from the second set will be ignored in favour of the object from the initial set.
@@ -79,7 +84,8 @@ eachother.
         
 - Selecting "Segment" will combine both object sets and attempt to re-draw segmentation to
   separate objects which overlapped. Note: This is less reliable when more than
-  two objects were overlapping.      
+  two objects were overlapping. If two object sets genuinely occupy the same space
+  it may be better to consider them seperately.
          """
         )
 
@@ -87,7 +93,7 @@ eachother.
             "Name the combined object set",
             "CombinedObjects",
             doc="""\
-Enter the name for the combined object set. These objects will be available for use by
+Enter the name for the combined object set. These objects will be available for use in
 subsequent modules.""",
         )
 
@@ -132,7 +138,6 @@ subsequent modules.""",
         figure.set_subplots((2, 2))
         cmap = figure.return_cmap()
 
-        # Display image 3 times w/ input object a, input object b, and merged output object:
         ax = figure.subplot_imshow_labels(0, 0, workspace.display_data.input_object_x,
                                           workspace.display_data.input_object_x_name,
                                           colormap=cmap,
@@ -193,6 +198,5 @@ subsequent modules.""",
                 labels_x == 0, return_indices=True
             )
             output[to_segment] = labels_x[i[to_segment], j[to_segment]]
-
 
         return output

--- a/cellprofiler/modules/combineobjects.py
+++ b/cellprofiler/modules/combineobjects.py
@@ -1,0 +1,172 @@
+# coding=utf-8
+
+"""
+CombineObjects
+=============
+
+**CombineObjects** allows you to merge two object sets into a single object set.
+
+|
+
+============ ============ ===============
+Supports 2D? Supports 3D? Respects masks?
+============ ============ ===============
+YES          NO          NO
+============ ============ ===============
+
+"""
+
+import cellprofiler_core.module
+import cellprofiler_core.object
+import cellprofiler_core.setting
+import numpy
+import skimage.segmentation
+import skimage.morphology
+from scipy.ndimage import distance_transform_edt
+
+class CombineObjects(cellprofiler_core.module.image_segmentation.ObjectProcessing):
+    category = "Object Processing"
+
+    module_name = "CombineObjects"
+
+    variable_revision_number = 1
+
+    def create_settings(self):
+        self.objects_x = cellprofiler_core.setting.ObjectNameSubscriber(
+            "Select first object set to merge",
+            "None",
+            doc="""\
+        Select the object sets which you want to merge.""",
+        )
+
+        self.objects_y = cellprofiler_core.setting.ObjectNameSubscriber(
+            "Select second object set to merge",
+            "None",
+            doc="""\
+        Select the object sets which you want to merge.""",
+        )
+
+        self.merge_method = cellprofiler_core.setting.Choice(
+            "Choose how to handle overlapping objects",
+            choices=["Merge", "Separate"],
+            doc="""\
+        Use this setting to choose how to handle objects which overlap with eachother.
+         Selecting "Merge" will combine touching objects into a single object. Selecting
+         "Separate" will attempt to divide the objects.
+         """
+        )
+
+        self.output_object = cellprofiler_core.setting.ObjectNameProvider(
+            "Output object set name",
+            "CombinedObjects",
+            doc="""\
+Enter the name for the combined object set. These objects will be available for use by
+subsequent modules.""",
+        )
+
+    def settings(self):
+        return [self.objects_x, self.objects_y, self.merge_method, self.output_object]
+
+    def visible_settings(self):
+        return [self.objects_x, self.objects_y, self.merge_method, self.output_object]
+
+    def run(self, workspace):
+        for object_name in (self.objects_x.value, self.objects_y.value):
+            if object_name not in workspace.object_set.object_names:
+                raise ValueError(
+                    "The %s objects are missing from the pipeline." % object_name
+                )
+        objects_x = workspace.object_set.get_objects(self.objects_x.value)
+
+        objects_y = workspace.object_set.get_objects(self.objects_y.value)
+
+        assert objects_x.shape == objects_y.shape,\
+            "Objects sets must have the same dimensions"
+
+        overlay_matrix = numpy.zeros_like(objects_x.segmented)
+
+        overlay_matrix[objects_x.segmented > 0] += 1
+        overlay_matrix[objects_y.segmented > 0] += 1
+
+        labels_x = objects_x.segmented.copy()
+        indices_x = objects_x.indices
+        labels_y = objects_y.segmented.copy()
+        labels_y[labels_y > 0] += labels_x.max()
+        indices_y = [ind + labels_x.max() for ind in objects_y.indices]
+
+        output = numpy.zeros_like(labels_x)
+
+        # Resolve non-conflicting labels first
+        undisputed = numpy.logical_xor(labels_x > 0, labels_y > 0)
+        for label in indices_x:
+            mapped = labels_x == label
+            if numpy.all(undisputed[mapped]):
+                output[mapped] = label
+                labels_x[mapped] = 0
+                indices_x = indices_x[indices_x != label]
+        for label in indices_y:
+            mapped = labels_y == label
+            if numpy.all(undisputed[mapped]):
+                output[mapped] = label
+                labels_y[mapped] = 0
+
+        # Resolve conflicting labels
+        if self.merge_method.value == "Merge":
+            for label in indices_x:
+                mapped = labels_x == label
+                target_labels = numpy.unique(labels_y[mapped])
+                target_labels = target_labels[target_labels != 0]
+                for indice in target_labels:
+                    mask = labels_y == indice
+                    output[mask] = label
+                    labels_y[mask] = 0
+                    labels_x[mask] = 0
+        elif self.merge_method.value == "Separate":
+            for label in indices_x:
+                only_labels_x = labels_x.copy()
+                only_labels_x[only_labels_x != label] = 0
+                target_labels = numpy.unique(labels_y[only_labels_x > 0])
+                target_labels = target_labels[target_labels != 0]
+                only_labels_y = numpy.zeros_like(only_labels_x)
+                for indice in target_labels:
+                    only_labels_y[labels_y == indice] = indice
+                mask = numpy.logical_or(only_labels_x > 0, only_labels_y > 0)
+                undisputed = numpy.logical_xor(only_labels_x > 0, only_labels_y > 0)
+                seeds = numpy.add(only_labels_x, only_labels_y)
+                seeds[~undisputed] = 0
+                distance = distance_transform_edt(mask)
+                watershed = skimage.morphology.watershed(distance, seeds, mask=mask)
+                output = numpy.where(watershed > 0, watershed, output)
+                # Do a seeded watershed with non conflicting areas as seeds
+                # flaw = multiple overlap
+
+        output_labels, _, _ = skimage.segmentation.relabel_sequential(output)
+        output_objects = cellprofiler_core.object.Objects()
+        output_objects.segmented = output_labels
+
+        workspace.object_set.add_objects(output_objects, self.output_object.value)
+
+        if self.show_window:
+            workspace.display_data.input_object_x_name = self.objects_x.value
+            workspace.display_data.input_object_x = objects_x.segmented
+            workspace.display_data.input_object_y_name = self.objects_y.value
+            workspace.display_data.input_object_y = objects_y.segmented
+            workspace.display_data.output_object_name = self.output_object.value
+            workspace.display_data.output_object = output_objects.segmented
+
+    #
+    # display lets you use matplotlib to display your results.
+    #
+    def display(self, workspace, figure):
+        figure.set_subplots((2, 2))
+
+        # Display image 3 times w/ input object a, input object b, and merged output object:
+        ax = figure.subplot_imshow_labels(0, 0, workspace.display_data.input_object_x,
+                                     workspace.display_data.input_object_x_name
+                                          )
+        figure.subplot_imshow_labels(1, 0, workspace.display_data.input_object_y,
+                                     workspace.display_data.input_object_y_name,
+                                     sharexy=ax)
+        figure.subplot_imshow_labels(0, 1, workspace.display_data.output_object,
+                                     workspace.display_data.output_object_name,
+                                     sharexy=ax)

--- a/cellprofiler/modules/combineobjects.py
+++ b/cellprofiler/modules/combineobjects.py
@@ -33,31 +33,46 @@ class CombineObjects(cellprofiler_core.module.image_segmentation.ObjectProcessin
 
     def create_settings(self):
         self.objects_x = cellprofiler_core.setting.ObjectNameSubscriber(
-            "Select first object set to merge",
+            "Select initial object set",
             "None",
             doc="""\
         Select the object sets which you want to merge.""",
         )
 
         self.objects_y = cellprofiler_core.setting.ObjectNameSubscriber(
-            "Select second object set to merge",
+            "Select object set to combine",
             "None",
             doc="""\
         Select the object sets which you want to merge.""",
         )
 
         self.merge_method = cellprofiler_core.setting.Choice(
-            "Choose how to handle overlapping objects",
-            choices=["Merge", "Separate"],
+            "Select how to handle overlapping objects",
+            choices=["Merge", "Preserve", "Discard", "Segment"],
             doc="""\
-        Use this setting to choose how to handle objects which overlap with eachother.
-         Selecting "Merge" will combine touching objects into a single object. Selecting
-         "Separate" will attempt to divide the objects.
+        When combining sets of objects, it is possible that both sets had an object in the
+        same location. Use this setting to choose how to handle objects which overlap with
+        eachother.
+        
+        - Selecting "Merge" will make overlapping objects combine into a single object.
+        This can work well if you expect the same object to appear in both sets.
+        Note that this method is not suitable for combining dense object sets with multiple
+        overlapping neighbours.
+        
+        - Selecting "Preserve" will protect the initial object set. Any overlapping regions
+        from the second set will be cut out in favour of the object from the initial set.
+        
+        - Selecting "Discard" will only add objects which do not have any overlap with objects
+        in the initial object set.
+        
+        - Selecting "Segment" will combine both object sets and attempt to re-draw lines to
+        separate objects which overlapped. Note: This becomes less reliable when more than
+        two objects were overlapping. 
          """
         )
 
         self.output_object = cellprofiler_core.setting.ObjectNameProvider(
-            "Output object set name",
+            "Name the combined object set",
             "CombinedObjects",
             doc="""\
 Enter the name for the combined object set. These objects will be available for use by
@@ -88,59 +103,12 @@ subsequent modules.""",
         overlay_matrix[objects_x.segmented > 0] += 1
         overlay_matrix[objects_y.segmented > 0] += 1
 
+        # Ensure array Y's labels don't conflict with array X.
         labels_x = objects_x.segmented.copy()
-        indices_x = objects_x.indices
         labels_y = objects_y.segmented.copy()
-        labels_y[labels_y > 0] += labels_x.max()
-        indices_y = [ind + labels_x.max() for ind in objects_y.indices]
 
-        output = numpy.zeros_like(labels_x)
-
-        # Resolve non-conflicting labels first
-        undisputed = numpy.logical_xor(labels_x > 0, labels_y > 0)
-        for label in indices_x:
-            mapped = labels_x == label
-            if numpy.all(undisputed[mapped]):
-                output[mapped] = label
-                labels_x[mapped] = 0
-                indices_x = indices_x[indices_x != label]
-        for label in indices_y:
-            mapped = labels_y == label
-            if numpy.all(undisputed[mapped]):
-                output[mapped] = label
-                labels_y[mapped] = 0
-
-        # Resolve conflicting labels
-        if self.merge_method.value == "Merge":
-            for label in indices_x:
-                mapped = labels_x == label
-                target_labels = numpy.unique(labels_y[mapped])
-                target_labels = target_labels[target_labels != 0]
-                for indice in target_labels:
-                    mask = labels_y == indice
-                    output[mask] = label
-                    labels_y[mask] = 0
-                    labels_x[mask] = 0
-        elif self.merge_method.value == "Separate":
-            for label in indices_x:
-                only_labels_x = labels_x.copy()
-                only_labels_x[only_labels_x != label] = 0
-                target_labels = numpy.unique(labels_y[only_labels_x > 0])
-                target_labels = target_labels[target_labels != 0]
-                only_labels_y = numpy.zeros_like(only_labels_x)
-                for indice in target_labels:
-                    only_labels_y[labels_y == indice] = indice
-                mask = numpy.logical_or(only_labels_x > 0, only_labels_y > 0)
-                undisputed = numpy.logical_xor(only_labels_x > 0, only_labels_y > 0)
-                seeds = numpy.add(only_labels_x, only_labels_y)
-                seeds[~undisputed] = 0
-                distance = distance_transform_edt(mask)
-                watershed = skimage.morphology.watershed(distance, seeds, mask=mask)
-                output = numpy.where(watershed > 0, watershed, output)
-                # Do a seeded watershed with non conflicting areas as seeds
-                # flaw = multiple overlap
-
-        output_labels, _, _ = skimage.segmentation.relabel_sequential(output)
+        output = self.combine_arrays(labels_x, labels_y)
+        output_labels = skimage.morphology.label(output)
         output_objects = cellprofiler_core.object.Objects()
         output_objects.segmented = output_labels
 
@@ -154,9 +122,6 @@ subsequent modules.""",
             workspace.display_data.output_object_name = self.output_object.value
             workspace.display_data.output_object = output_objects.segmented
 
-    #
-    # display lets you use matplotlib to display your results.
-    #
     def display(self, workspace, figure):
         figure.set_subplots((2, 2))
 
@@ -170,3 +135,73 @@ subsequent modules.""",
         figure.subplot_imshow_labels(0, 1, workspace.display_data.output_object,
                                      workspace.display_data.output_object_name,
                                      sharexy=ax)
+
+    def combine_arrays(self, labels_x, labels_y):
+        output = numpy.zeros_like(labels_x)
+        method = self.merge_method.value
+
+        if method == "Preserve":
+            return numpy.where(labels_x > 0, labels_x, labels_y)
+
+        indices_x = numpy.unique(labels_x)
+        indices_x = indices_x[indices_x > 0]
+        indices_y = numpy.unique(labels_y)
+        indices_y = indices_y[indices_y > 0]
+
+        # Resolve non-conflicting and totally overlapped labels first
+        undisputed = numpy.logical_xor(labels_x > 0, labels_y > 0)
+        disputed = numpy.logical_and(labels_x > 0, labels_y > 0)
+        for label in indices_x:
+            mapped = labels_x == label
+            if numpy.all(undisputed[mapped]):
+                # Only appeared in one object set
+                output[mapped] = label
+                labels_x[mapped] = 0
+                indices_x = indices_x[indices_x != label]
+            elif numpy.all(disputed[mapped]):
+                # Completely covered by objects in other set
+                labels_x[mapped] = 0
+                indices_x = indices_x[indices_x != label]
+        # Recalcualate overlapping areas
+        disputed = numpy.logical_and(labels_x > 0, labels_y > 0)
+        for label in indices_y:
+            mapped = labels_y == label
+            if numpy.all(undisputed[mapped]):
+                output[mapped] = label
+                labels_y[mapped] = 0
+            elif numpy.all(disputed[mapped]):
+                labels_x[mapped] = 0
+                indices_x = indices_x[indices_x != label]
+
+        # Resolve conflicting labels
+        if method == "Merge":
+            for x_label in indices_x:
+                mapped = labels_x == x_label
+                target_labels = numpy.unique(labels_y[mapped])
+                target_labels = target_labels[target_labels != 0]
+                output[mapped] = x_label
+                for y_label in target_labels:
+                    mask = labels_y == y_label
+                    output[mask] = x_label
+                    labels_y[mask] = 0
+                    labels_x[mask] = 0
+
+        elif method == "Discard":
+            print(True)
+            output2 = numpy.where(labels_x > 0, labels_x, labels_y)
+            print(True)
+
+        elif self.merge_method.value == "Segment":
+            to_segment = numpy.logical_or(labels_x > 0, labels_y > 0)
+            undisputed = numpy.logical_xor(labels_x > 0, labels_y > 0)
+            seeds = numpy.add(labels_x, labels_y)
+            seeds[~undisputed] = 0
+
+            distances, (i, j) = distance_transform_edt(
+                ~undisputed, return_indices=True
+            )
+
+            output[to_segment] = seeds[i[to_segment], j[to_segment]]
+
+
+        return output


### PR DESCRIPTION
Resolves #2140

Bringing back the idea from #2151.

I've gone for trying to keep this relatively simple for now. Some of the methods could probably be more efficient, but it seems to work. The general idea for this module is to allow people to combine two object sets into a single set, which is primarily useful if you needed different detection settings for different objects within the same image.

At present I've added 4 methods of handling overlapping objects, as follows:
- Merge - Touching objects are assigned the label from the first object set. When touching multiple objects each pixel is assigned to the nearest object from the initial set.
- Preserve - Add the second object set array to areas where there are no objects in the first set. Basically 'preserves' all the objects in the initial set.
- Discard - Only add objects which don't overlap with anything from the initial set.
- Segment - Add both object sets together, then re-segment overlapping areas by assigning pixels to the nearest non-conflicting region of an object.

Ultimately people shouldn't be trying to combine object sets with 'real' overlap in which two objects occupy the same space, so hopefully those options will cover the intended use cases.

I still need to write some tests, but figured I'd put a PR together in case people have further input.