### PR TITLE
Fix ExportToSpreadsheet settings upgrade

### DIFF
--- a/cellprofiler/modules/exporttospreadsheet.py
+++ b/cellprofiler/modules/exporttospreadsheet.py
@@ -1568,7 +1568,6 @@ desired.
         # Standardize input/output directory name references
         SLOT_DIRCHOICE = 7
         directory = setting_values[SLOT_DIRCHOICE]
-        directory = directory.encode("utf-8").decode("unicode_escape")
         directory = cps.DirectoryPath.upgrade_setting(directory)
         setting_values = (
             setting_values[:SLOT_DIRCHOICE]


### PR DESCRIPTION
I believe we now handle decoding when reading settings, so this extra en/decode step that we added when setting up core has started causing problems.