### PR TITLE
Add true randomisation of figure colourmaps

### DIFF
--- a/cellprofiler/gui/figure.py
+++ b/cellprofiler/gui/figure.py
@@ -1826,7 +1826,7 @@ class Figure(wx.Frame):
         else:
             # Mask the original labels
             label_image = numpy.ma.masked_where(image == 0, image)
-            if colormap is None:
+            if not colormap:
                 colormap = self.return_cmap(numpy.max(image))
             else:
                 colormap = colormap

--- a/cellprofiler/gui/figure.py
+++ b/cellprofiler/gui/figure.py
@@ -1826,8 +1826,8 @@ class Figure(wx.Frame):
         else:
             # Mask the original labels
             label_image = numpy.ma.masked_where(image == 0, image)
-            if colormap == None:
-                colormap = self.return_cmap()
+            if colormap is None:
+                colormap = self.return_cmap(numpy.max(image))
             else:
                 colormap = colormap
 
@@ -1846,10 +1846,10 @@ class Figure(wx.Frame):
             colormap=colormap,
         )
 
-    def return_cmap(self):
+    def return_cmap(self, nindexes=None):
         # Get the colormap from the user preferences
         colormap = matplotlib.cm.get_cmap(
-            cellprofiler_core.preferences.get_default_colormap()
+            cellprofiler_core.preferences.get_default_colormap(), lut=nindexes,
         )
         # Initialize the colormap so we have access to the LUT
         colormap._init()

--- a/cellprofiler/modules/expandorshrinkobjects.py
+++ b/cellprofiler/modules/expandorshrinkobjects.py
@@ -248,7 +248,7 @@ order to keep from breaking up the object or breaking the hole.
         output_objects_segmented = workspace.display_data.output_objects_segmented
 
         figure.set_subplots((2, 1))
-        cmap = figure.return_cmap()
+        cmap = figure.return_cmap(numpy.max(input_objects_segmented))
 
         figure.subplot_imshow_labels(
             0, 0, input_objects_segmented, self.object_name.value, colormap=cmap,

--- a/cellprofiler/modules/identifytertiaryobjects.py
+++ b/cellprofiler/modules/identifytertiaryobjects.py
@@ -401,7 +401,7 @@ but the results will be zero or not-a-number (NaN).
         #
         figure.set_subplots((2, 2))
 
-        cmap = figure.return_cmap()
+        cmap = figure.return_cmap(np.max(primary_labels))
 
         figure.subplot_imshow_labels(
             0, 0, primary_labels, self.primary_objects_name.value, colormap=cmap,

--- a/cellprofiler/modules/maskobjects.py
+++ b/cellprofiler/modules/maskobjects.py
@@ -422,7 +422,7 @@ controls how remaining objects are associated with their predecessors:
         #
         outlines = outline(original_labels) > 0
 
-        cm = figure.return_cmap()
+        cm = figure.return_cmap(np.max(original_labels))
         sm = matplotlib.cm.ScalarMappable(cmap=cm)
         #
         # Paint the labels in color

--- a/cellprofiler/modules/relateobjects.py
+++ b/cellprofiler/modules/relateobjects.py
@@ -491,7 +491,7 @@ parents or children of the parent object.""",
 
         seed = numpy.random.randint(256)
 
-        cmap = figure.return_cmap()
+        cmap = figure.return_cmap(max_label)
 
         figure.subplot_imshow_labels(
             0,


### PR DESCRIPTION
Fixes #3956 

By default matplotlib generates a 256 colour colourmap for displaying figures. We shuffle this map, but it still gets stretched when handling large numbers of labels, resulting in neighbouring objects being assigned similar colours. We can solve this by supplying the `lut` parameter in the cmap call to specify how many unique values we need.