### PR TITLE
Add more keyboard shortcuts to 'add modules' window

### DIFF
--- a/cellprofiler/gui/addmoduleframe.py
+++ b/cellprofiler/gui/addmoduleframe.py
@@ -119,6 +119,7 @@ class AddModuleFrame(wx.Frame):
         )
         self.search_text.Bind(wx.EVT_TEXT, self.__on_search_modules)
         self.search_text.Bind(wx.EVT_TEXT_ENTER, self.__on_add_to_pipeline)
+        self.search_text.Bind(wx.EVT_CHAR_HOOK, self.__on_special_key)
         self.search_button.Bind(wx.EVT_BUTTON, self.__on_search_help)
         self.__get_module_files()
         self.__set_categories()
@@ -126,6 +127,7 @@ class AddModuleFrame(wx.Frame):
         self.__module_categories_list_box.Select(0)
         self.__on_category_selected(None)
         self.Fit()
+        self.search_text.SetFocus()
 
     def __on_close(self, event):
         self.Hide()
@@ -259,6 +261,26 @@ class AddModuleFrame(wx.Frame):
         else:
             self.__module_list_box.AppendItems("No matching modules")
             self.__module_list_box.Enable(False)
+
+    def __on_special_key(self, event):
+        # Capture keyboard shortcuts
+        key = event.GetKeyCode()
+        numitems = len(self.__module_list_box.Items)
+        if key == wx.WXK_ESCAPE:
+            self.Close()
+            return
+        elif numitems <= 1:
+            # No point moving selector
+            pass
+        elif key == wx.WXK_DOWN:
+            i = self.__module_list_box.GetSelection()
+            self.__module_list_box.Select(min(i + 1, numitems - 1))
+            return
+        elif key == wx.WXK_UP:
+            i = self.__module_list_box.GetSelection()
+            self.__module_list_box.Select(max(0, i - 1))
+            return
+        event.Skip()
 
     def __on_getting_started(self, event):
         import cellprofiler.gui.help.content


### PR DESCRIPTION
I think someone suggested this when I was making #3971, but I thought it might be tricky. I've been enjoying the quick search so much that I had a go anyway.

Changes are as follows:

- "Add Modules" launches with the search box focused by default. This has no real impact if you're not using it, but allows you to type straight away.
- While the search box is focused, pressing 'Escape' will close the 'Add Modules' window.
- While the box is focused, the 'Up' and 'Down' arrow keys can be used to highlight the desired result.
- 'Enter' adds the highlighted module to the pipeline.

This allows you to add modules entirely with the keyboard, which can be pretty fast.

Might be worth checking that these keys don't interfere with anything on mac, although I'm not expecting problems.