### PR TITLE
Disable module activation when operating on multiple modules

### DIFF
--- a/cellprofiler/gui/pipelinelistview.py
+++ b/cellprofiler/gui/pipelinelistview.py
@@ -920,7 +920,8 @@ class PipelineListView(object):
         module = pipeline.modules(False)[event.module_num - 1]
         self.__populate_row(module)
         self.__adjust_rows()
-        self.select_one_module(event.module_num)
+        if len(self.get_selected_modules()) <= 1:
+            self.select_one_module(event.module_num)
         self.request_validation(module)
         self.notify_has_file_list(self.__has_file_list)
 


### PR DESCRIPTION
At the moment, duplicating or moving multiple modules upsets the GUI as CellProfiler tries to display the settings panel for each module as it's 'added'. This change makes it so that an added module is only activated if a single module was selected, which is typically the case when adding to the pipeline or moving a particular module of interest. This makes operations on multiple modules much smoother.