### PR TITLE
Implement fftconvolve in place of binary_dilate for MeasureObjectNeighbors

### DIFF
--- a/cellprofiler/modules/measureobjectneighbors.py
+++ b/cellprofiler/modules/measureobjectneighbors.py
@@ -544,7 +544,7 @@ previously discarded objects.""".format(
                     else:
                         extended = scipy.signal.fftconvolve(extendme, strel_touching, mode='same') > 0.5
                 else:
-                    if distance <= 3:
+                    if distance <= 5:
                         extended = scind.binary_dilation((npatch != 0), strel_touching)
                     else:
                         extended = scipy.signal.fftconvolve((npatch != 0), strel_touching, mode='same') > 0.5

--- a/cellprofiler/modules/measureobjectneighbors.py
+++ b/cellprofiler/modules/measureobjectneighbors.py
@@ -501,7 +501,10 @@ previously discarded objects.""".format(
                 # Find the neighbors
                 #
                 patch_mask = patch == (index + 1)
-                extended = scipy.signal.fftconvolve(patch_mask, strel, mode='same') > 0.5
+                if distance <= 5:
+                    extended = scind.binary_dilation(patch_mask, strel)
+                else:
+                    extended = scipy.signal.fftconvolve(patch_mask, strel, mode='same') > 0.5
                 neighbors = np.unique(npatch[extended])
                 neighbors = neighbors[neighbors != 0]
                 if self.neighbors_are_objects:
@@ -536,9 +539,15 @@ previously discarded objects.""".format(
                     )
                 if self.neighbors_are_objects:
                     extendme = (patch != 0) & (patch != object_number)
-                    extended = scipy.signal.fftconvolve(extendme, strel_touching, mode='same') > 0.5
+                    if distance <= 5:
+                        extended = scind.binary_dilation(extendme, strel_touching)
+                    else:
+                        extended = scipy.signal.fftconvolve(extendme, strel_touching, mode='same') > 0.5
                 else:
-                    extended = scipy.signal.fftconvolve((npatch != 0), strel_touching, mode='same') > 0.5
+                    if distance <= 3:
+                        extended = scind.binary_dilation((npatch != 0), strel_touching)
+                    else:
+                        extended = scipy.signal.fftconvolve((npatch != 0), strel_touching, mode='same') > 0.5
                 overlap = np.sum(outline_patch & extended)
                 pixel_count[index] = overlap
             if sum([len(x) for x in first_objects]) > 0:

--- a/cellprofiler/modules/measureobjectneighbors.py
+++ b/cellprofiler/modules/measureobjectneighbors.py
@@ -68,6 +68,7 @@ will be positive, but there may not be a corresponding
 import matplotlib.cm
 import numpy as np
 import scipy.ndimage as scind
+import scipy.signal
 import skimage.morphology
 from centrosome.cpmorphology import fixup_scipy_ndimage_result as fix
 from centrosome.cpmorphology import strel_disk, centers_of_labels
@@ -500,7 +501,7 @@ previously discarded objects.""".format(
                 # Find the neighbors
                 #
                 patch_mask = patch == (index + 1)
-                extended = scind.binary_dilation(patch_mask, strel)
+                extended = scipy.signal.fftconvolve(patch_mask, strel, mode='same') > 0.5
                 neighbors = np.unique(npatch[extended])
                 neighbors = neighbors[neighbors != 0]
                 if self.neighbors_are_objects:
@@ -534,11 +535,10 @@ previously discarded objects.""".format(
                         == object_number
                     )
                 if self.neighbors_are_objects:
-                    extended = scind.binary_dilation(
-                        (patch != 0) & (patch != object_number), strel_touching
-                    )
+                    extendme = (patch != 0) & (patch != object_number)
+                    extended = scipy.signal.fftconvolve(extendme, strel_touching, mode='same') > 0.5
                 else:
-                    extended = scind.binary_dilation((npatch != 0), strel_touching)
+                    extended = scipy.signal.fftconvolve((npatch != 0), strel_touching, mode='same') > 0.5
                 overlap = np.sum(outline_patch & extended)
                 pixel_count[index] = overlap
             if sum([len(x) for x in first_objects]) > 0:


### PR DESCRIPTION
As raised on Slack, MeasureObjectNeighbors had miserable performance when using larger expansion distances. I found that this was a problem with scipy.ndimage's binary_dilation function (mentioned [here](https://github.com/scikit-image/scikit-image/issues/1190)).

However, per [this thread](https://stackoverflow.com/a/51159444), it's possible to achieve the same results using the Fast Fourier Transform. In my testing this gives us exactly the same results with a substantial increase in speed and better memory usage. The caveat to this is that it's marginally slower when working with small images and structuring elements, although at that size the overall time taken is relatively small to begin with. 

Some testing results on 1 image, with 250 objects:
- Old method, 1 pixel dilation - 0.375s
- New method, 1 pixel dilation - 0.422s
- Old method, 25 pixel dilation - 29.171s
- New method, 25 pixel dilation - 0.625s

As for the 3D monolayer example, with 26 objects:
- Old method, 5 pixel 3D dilation - 1.813s
- New method, 5 pixel 3D dilation - 1.750s
- Old method, 25 pixel 3D dilation - Failed, memory error
- New method, 25 pixel 3D dilation - 6.922s

I'm not sure if it's worth it, but we could have it fall back to using standard binary_dilation when using a distance <5?