### PR TITLE
Fix inappropriate calls for MetadataControl when leaving module view

### DIFF
--- a/cellprofiler/gui/metadatactrl.py
+++ b/cellprofiler/gui/metadatactrl.py
@@ -86,7 +86,8 @@ class MetadataControl(wx.Control):
 
         def on_show(event):
             if event:
-                self.make_caret()
+                if isinstance(event.EventObject, MetadataControl):
+                    self.make_caret()
             else:
                 del self.__caret
                 self.__caret = None


### PR DESCRIPTION
Hopefully fixes #4085

It looks like in WX4 an `EVT_SHOW` event is generated for both a module and the window itself. I think this meant that if you were leaving a module with a MetadataControl filed, the module event would delete the controller but the Window event would then try and fail to fetch it again. Ignoring the Window events seems to fix it. Might be helpful if someone could verify this on Mac.