### PR TITLE
Make SaveCroppedObjects compatible with color images

### DIFF
--- a/cellprofiler/modules/savecroppedobjects.py
+++ b/cellprofiler/modules/savecroppedobjects.py
@@ -116,6 +116,9 @@ The choices are:
                 mask_in = labels == label
                 images = workspace.image_set
                 x = images.get_image(self.image_name.value)
+                if len(x.pixel_data.shape) == len(mask_in.shape) + 1 and not x.volumetric:
+                    # Color 2D image, repeat mask for all channels
+                    mask_in = numpy.repeat(mask_in[:, :, numpy.newaxis], x.pixel_data.shape[-1], axis=2)
                 properties = skimage.measure.regionprops(
                     mask_in.astype(int), intensity_image=x.pixel_data
                 )

--- a/cellprofiler/modules/savecroppedobjects.py
+++ b/cellprofiler/modules/savecroppedobjects.py
@@ -126,21 +126,21 @@ The choices are:
                     directory, "{}_{}.{}".format(self.objects_name.value, label, O_PNG)
                 )
 
-                skimage.io.imsave(filename, skimage.img_as_ubyte(mask))
+                skimage.io.imsave(filename, skimage.img_as_ubyte(mask), check_contrast=False)
 
             elif self.file_format.value == O_TIFF_8:
                 filename = os.path.join(
                     directory, "{}_{}.{}".format(self.objects_name.value, label, "tiff")
                 )
 
-                skimage.io.imsave(filename, skimage.img_as_ubyte(mask), compress=6)
+                skimage.io.imsave(filename, skimage.img_as_ubyte(mask), compress=6, check_contrast=False)
 
             elif self.file_format.value == O_TIFF_16:
                 filename = os.path.join(
                     directory, "{}_{}.{}".format(self.objects_name.value, label, "tiff")
                 )
 
-                skimage.io.imsave(filename, skimage.img_as_uint(mask), compress=6)
+                skimage.io.imsave(filename, skimage.img_as_uint(mask), compress=6, check_contrast=False)
 
             filenames.append(filename)
 

--- a/cellprofiler/modules/savecroppedobjects.py
+++ b/cellprofiler/modules/savecroppedobjects.py
@@ -109,17 +109,19 @@ The choices are:
 
         filenames = []
 
+        if self.export_option == SAVE_PER_OBJECT:
+            images = workspace.image_set
+            x = images.get_image(self.image_name.value)
+            if len(x.pixel_data.shape) == len(labels.shape) + 1 and not x.volumetric:
+                # Color 2D image, repeat mask for all channels
+                labels = numpy.repeat(labels[:, :, numpy.newaxis], x.pixel_data.shape[-1], axis=2)
+
         for label in unique_labels:
             if self.export_option == SAVE_MASK:
                 mask = labels == label
 
             elif self.export_option == SAVE_PER_OBJECT:
                 mask_in = labels == label
-                images = workspace.image_set
-                x = images.get_image(self.image_name.value)
-                if len(x.pixel_data.shape) == len(mask_in.shape) + 1 and not x.volumetric:
-                    # Color 2D image, repeat mask for all channels
-                    mask_in = numpy.repeat(mask_in[:, :, numpy.newaxis], x.pixel_data.shape[-1], axis=2)
                 properties = skimage.measure.regionprops(
                     mask_in.astype(int), intensity_image=x.pixel_data
                 )

--- a/cellprofiler/modules/savecroppedobjects.py
+++ b/cellprofiler/modules/savecroppedobjects.py
@@ -4,9 +4,10 @@
 SaveCroppedObjects
 ==================
 
-**SaveCroppedObjects** exports each object as a binary image. Pixels corresponding to an exported object are assigned
-the value 255. All other pixels (i.e., background pixels and pixels corresponding to other objects) are assigned the
-value 0. The dimensions of each image are the same as the original image.
+**SaveCroppedObjects** exports each object as an individual image. Pixels corresponding to an exported object are
+assigned the value from the input image. All other pixels (i.e., background pixels and pixels corresponding to other
+objects) are assigned the value 0. The dimensions of each image are the same as the original image. Multi-channel color
+images will be represented as 3-channel RGB images when saved with this module (not available in 3D mode).
 
 The filename for an exported image is formatted as "{object name}_{label index}.{image_format}", where *object name*
 is the name of the exported objects, *label index* is the integer label of the object exported in the image (starting


### PR DESCRIPTION
Needed this for a project so it's a quick fix for now. Skimage won't allow you to supply an intensity image with more dimensions than the object mask, but if we're working in 2D we can just use the same mask for each channel. Saving takes longer in RGB mode and isn't as versatile as SaveImages, but I think it's an improvement.

I've also disabled the 'low contrast' warning that Skimage IO puts out if an image is dim, since that gets really annoying when exporting 2000 images.

Documentation also appears to have been incorrect, so I've updated it.