### PR TITLE
Fix Metadata regex field behaviour

### DIFF
--- a/cellprofiler/gui/moduleview.py
+++ b/cellprofiler/gui/moduleview.py
@@ -1435,7 +1435,7 @@ class ModuleView(object):
             sizer.Add(bitmap_button, 0, wx.EXPAND)
 
             def on_cell_change(event, setting=v, control=text_ctrl):
-                self.__on_cell_change(event, setting, control)
+                self.__on_cell_change(event, setting, control, timeout=False)
 
             def on_button_pressed(event, setting=v, control=text_ctrl):
                 #
@@ -2307,12 +2307,13 @@ class ModuleView(object):
         proposed_value = ",".join([control.Items[i] for i in control.Selections])
         self.on_value_change(setting, control, proposed_value, event)
 
-    def __on_cell_change(self, event, setting, control):
+    def __on_cell_change(self, event, setting, control, timeout=True):
         if not self.__handle_change:
             return
         proposed_value = six.text_type(control.GetValue())
+        timeout_sec = EDIT_TIMEOUT_SEC * 1000 if timeout else False
         self.on_value_change(
-            setting, control, proposed_value, event, EDIT_TIMEOUT_SEC * 1000
+            setting, control, proposed_value, event, timeout_sec
         )
 
     def on_value_change(self, setting, control, proposed_value, event, timeout=None):

--- a/cellprofiler/gui/moduleview.py
+++ b/cellprofiler/gui/moduleview.py
@@ -1478,6 +1478,7 @@ class ModuleView(object):
                 # in process. Doing so may have adverse effects (e.g. disappearing textboxes)
                 if self.__module is not None and self.__handle_change:
                     self.set_selection(self.__module.module_num)
+                event.Skip()
 
             self.__module_panel.Bind(wx.EVT_TEXT, on_cell_change, text_ctrl)
             self.__module_panel.Bind(wx.EVT_BUTTON, on_button_pressed, bitmap_button)


### PR DESCRIPTION
Fixes #2738

At least on Windows, once a module view refresh was triggered (5 seconds after typing) the regex text boxes in the Metadata module became completely unresponsive to user input (related to #3104).

Allowing event processing to continue after `on_kill_focus` appears to resolve this problem and allows further editing after a settings refresh.

On top of this, I've added an option to disable a text box's timed module refresh and used this to disable such refreshing specifically for the regex fields. It often takes more than 5 seconds to write an expression and so the refresh could disrupt input. Since the regex fields don't directly impact other module content I don't think the lack of a refresh will cause any problems.