### PR TITLE
Fix NameSubscriber right click functionality

### DIFF
--- a/cellprofiler/gui/namesubscriber.py
+++ b/cellprofiler/gui/namesubscriber.py
@@ -117,9 +117,16 @@ class NameSubscriberComboBox(wx.Panel):
         def fn_key(x):
             return x[2], x
 
+        def on_selection(event):
+            self.Value = index[event.Id]
+            self.choice_made(event)
+
         choices_sorted_by_num = sorted(self.orig_choices, key=fn_key)
-        for name, annotation, num, is_input_module, choiceid in choices_sorted_by_num:
-            all_menu.Append(choiceid, "filler")
+        index = {}
+        for idx, choice in enumerate(choices_sorted_by_num):
+            choices_sorted_by_num[idx] = choice + (idx,)
+            all_menu.Append(idx, "filler")
+            index[idx] = choice[0]
 
         align_twosided_items(
             self.combo_dlg,
@@ -152,6 +159,7 @@ class NameSubscriberComboBox(wx.Panel):
                 for (num, annotation, is_input_module), v in sorted_submenus
             ],
         )
+        menu.Bind(wx.EVT_MENU, on_selection)
         self.PopupMenu(menu)
         menu.Destroy()
 


### PR DESCRIPTION
This PR should restore the ability to right click a NameSubscriber and see a context menu listing available images/objects by their source modules. I think this is actually a pretty useful feature when working with complex pipelines.

The original functionality was removed/broken in #3490, I think because a new wx item ID was generated for every menu option each time a module was viewed, which eventually exhausted all possible IDs.

I'm not sure how to properly 'free up' wx IDs, it seems like once an ID is generated the `NewId()` function just continues counting up regardless (so it'll hit the limit regardless of the ID not being used). Instead I've had the menu generate it's own local index and use that. Since the menu is destroyed immediately after use it doesn't seem to conflict with other CPFrame menu elements, or at least I couldn't get it to despite manually forcing the same ID onto a main window menu event. Nonetheless there may still be a better solution somewhere.