### PR TITLE
Add rescaling to GrayToColor

### DIFF
--- a/cellprofiler/modules/graytocolor.py
+++ b/cellprofiler/modules/graytocolor.py
@@ -114,7 +114,8 @@ This option also ensures that channels occupy the full intensity range
 available, which is useful for displaying images in other software.
 
 This rescaling is applied before any multiplication factors set in this 
-module's options."""
+module's options. Using a multiplication factor >1 would therefore result 
+in clipping."""
         )
 
         # # # # # # # # # # # # # # # #

--- a/tests/modules/test_graytocolor.py
+++ b/tests/modules/test_graytocolor.py
@@ -16,6 +16,7 @@ OUTPUT_IMAGE_NAME = "outputimage"
 def make_workspace(scheme, images, adjustments=None, colors=None, weights=None):
     module = cellprofiler.modules.graytocolor.GrayToColor()
     module.scheme_choice.value = scheme
+    module.wants_rescale.value = False
     if scheme not in (
         cellprofiler.modules.graytocolor.SCHEME_COMPOSITE,
         cellprofiler.modules.graytocolor.SCHEME_STACK,
@@ -240,6 +241,128 @@ def test_composite():
         channel = sum(
             [
                 image * weight * float(color[i]) / 255
+                for image, color, weight in zip(images, colors, weights)
+            ]
+        )
+        numpy.testing.assert_array_almost_equal(output[:, :, i], channel)
+
+
+def test_rgb_rescale():
+    numpy.random.seed(0)
+    for combination in (
+        (True, True, True),
+        (True, True, False),
+        (True, False, True),
+        (True, False, False),
+        (False, True, True),
+        (False, True, False),
+        (False, False, True),
+    ):
+        adjustments = numpy.random.uniform(size=7)
+        images = [
+            numpy.random.uniform(size=(10, 15)) if combination[i] else None
+            for i in range(3)
+        ]
+        images += [None] * 4
+        workspace, module = make_workspace(
+            cellprofiler.modules.graytocolor.SCHEME_RGB, images, adjustments
+        )
+        module.wants_rescale.value = True
+        module.run(workspace)
+        image = workspace.image_set.get_image(OUTPUT_IMAGE_NAME)
+        pixel_data = image.pixel_data
+
+        expected = numpy.dstack(
+            [
+                image if image is not None else numpy.zeros((10, 15))
+                for image in images[:3]
+            ]
+        )
+        for i in range(3):
+            plane = expected[:, :, i]
+            if plane.max() > 0:
+                plane = plane / numpy.max(plane)
+            plane *= adjustments[i]
+            expected[:, :, i] = plane
+        assert numpy.all(numpy.abs(expected - pixel_data) <= 0.00001)
+
+
+def test_cmyk_rescale():
+    numpy.random.seed(0)
+    for combination in [[(i & 2 ^ j) != 0 for j in range(4)] for i in range(1, 16)]:
+        adjustments = numpy.random.uniform(size=7)
+        images = [
+            numpy.random.uniform(size=(10, 15)) if combination[i] else None
+            for i in range(4)
+        ]
+        images = [None] * 3 + images
+        workspace, module = make_workspace(
+            cellprofiler.modules.graytocolor.SCHEME_CMYK, images, adjustments
+        )
+        module.wants_rescale.value = True
+        module.run(workspace)
+        image = workspace.image_set.get_image(OUTPUT_IMAGE_NAME)
+        pixel_data = image.pixel_data
+
+        expected = numpy.array(
+            [
+                numpy.dstack(
+                    [(image/numpy.max(image)) * adjustment if image is not None else numpy.zeros((10, 15))]
+                    * 3
+                )
+                * numpy.array(multiplier)
+                / numpy.sum(multiplier)
+                for image, multiplier, adjustment in (
+                    (images[3], (0, 1, 1), adjustments[3]),
+                    (images[4], (1, 1, 0), adjustments[4]),
+                    (images[5], (1, 0, 1), adjustments[5]),
+                    (images[6], (1, 1, 1), adjustments[6]),
+                )
+            ]
+        )
+        expected = numpy.sum(expected, 0)
+        assert numpy.all(numpy.abs(expected - pixel_data) <= 0.00001)
+
+
+def test_stack_rescale():
+    # Shouldn't do anything to the result, setting not supported.
+    r = numpy.random.RandomState()
+    r.seed(41)
+    images = [r.uniform(size=(11, 13)) for _ in range(5)]
+    workspace, module = make_workspace(
+        cellprofiler.modules.graytocolor.SCHEME_STACK, images
+    )
+    module.wants_rescale.value = True
+    module.run(workspace)
+    output = workspace.image_set.get_image(OUTPUT_IMAGE_NAME).pixel_data
+    assert output.shape[:2] == images[0].shape
+    assert output.shape[2] == len(images)
+    for i, image in enumerate(images):
+        numpy.testing.assert_array_almost_equal(output[:, :, i], image)
+
+
+def test_composite_rescale():
+    r = numpy.random.RandomState()
+    r.seed(41)
+    images = [r.uniform(size=(11, 13)) for _ in range(5)]
+    colors = [r.randint(0, 255, size=3) for _ in range(5)]
+    weights = r.uniform(low=1.0 / 255, high=1.5, size=5).tolist()
+    color_names = ["#%02x%02x%02x" % tuple(color.tolist()) for color in colors]
+    workspace, module = make_workspace(
+        cellprofiler.modules.graytocolor.SCHEME_COMPOSITE,
+        images,
+        colors=color_names,
+        weights=weights,
+    )
+    module.wants_rescale.value = True
+    module.run(workspace)
+    output = workspace.image_set.get_image(OUTPUT_IMAGE_NAME).pixel_data
+    assert output.shape[:2] == images[0].shape
+    assert output.shape[2] == 3
+    for i in range(3):
+        channel = sum(
+            [
+                (image / image.max()) * weight * float(color[i]) / 255
                 for image, color, weight in zip(images, colors, weights)
             ]
         )


### PR DESCRIPTION
Closes #3538

In this PR I've added an optional setting to GrayToColor to rescale the input images to the 0-1 range prior to merging. This is done by dividing each channel by it's maximum.

For the moment I've made it do this before applying the multiplication factor specified by the user. In theory the user can then use a factor <1 to balance the brightness of the channels as they wish (or deliberately blow out the intensity for some reason).

Hopefully this'll be pretty useful, since it avoids the need to run a rescaling module before making such overlays.

New copies of the module will default to having rescaling enabled. Upgraded pipelines will keep it disabled for compatibility.