### PR TITLE
Fix for pipelinelistview drag/drop functionality with wx 4.1

### DIFF
--- a/cellprofiler/gui/module_view/_module_view.py
+++ b/cellprofiler/gui/module_view/_module_view.py
@@ -128,7 +128,6 @@ class ModuleView:
         self.notes_panel = notes_panel
         self.__frame = frame
         self.top_panel = top_panel
-        self.showing_tables = False
         background_color = get_background_color()
         #############################################
         #
@@ -517,14 +516,7 @@ class ModuleView:
                 #
                 self.__frame.layout_pmi_panel()
                 self.top_panel.Layout()
-                # Running FitInside interferes with text wrapping if the previous module contained a table.
-                if not self.showing_tables:
-                    self.module_panel.FitInside()
-                # Keep a note of whether the last module had a table.
-                if imageset_control or table_control or self.__module.module_num == 1:
-                    self.showing_tables = True
-                else:
-                    self.showing_tables = False
+                self.module_panel.FitInside()
                 if self.DO_FREEZE:
                     self.module_panel.Thaw()
             else:

--- a/cellprofiler/gui/pipelinelistview.py
+++ b/cellprofiler/gui/pipelinelistview.py
@@ -733,9 +733,9 @@ class PipelineListView(object):
         selected_module_ids = [m.id for m in self.get_selected_modules()]
         self.__pipeline.start_undoable_action()
         try:
-            result = drop_source.DoDragDrop(wx.Drag_AllowMove)
+            result = drop_source.DoDragDrop(wx.Drag_DefaultMove)
             self.drag_underway = False
-            if result in (wx.DragMove, wx.DragCopy):
+            if result == wx.DragMove:
                 for identifier in selected_module_ids:
                     for module in self.__pipeline.modules(False):
                         if module.id == identifier:
@@ -1117,6 +1117,9 @@ class PipelineDropTarget(wx.DropTarget):
                 self.window.on_filelist_data(
                     x, y, action, self.file_data_object.GetFilenames()
                 )
+        if action == 1:
+            # Bug in wx 4.1 returns the wrong action ID on Windows. Get the right one.
+            action = self.OnDragOver(x, y, None)
         return action
 
 

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setuptools.setup(
         "scikit-learn>=0.20",
         "scipy>=1.4.1",
         "six",
-        "wxPython==4.0.7.post2",
+        "wxPython>=4.1.0",
     ],
     license="BSD",
     name="CellProfiler",


### PR DESCRIPTION
Hopefully backwards compatible.

Things to test on OSX:
- Dragging a module moves it. Module persists when activated.
- Dragging while holding `control` duplicates that module at the targetted position.
- Dragging to somewhere else on the window (not the pipeline list) does not delete modules.
- Dragging to a second CP window moves the module from one to the other, deleting it from the source window (with ctrl it should copy). Pipeline then doesn't revert when a module is activated.

This may also finally enable moving AND duplication on OSX, since we'd disabled the latter.