### PR TITLE
Prompt users to drag & drop pipelines to get started

### DIFF
--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -2313,6 +2313,9 @@ class PipelineController(object):
         self.__add_module_frame.Show()
         self.__add_module_frame.Raise()
 
+    def open_add_modules(self):
+        self.__on_add_module(None)
+
     def populate_edit_menu(self, menu):
         """Display a menu of modules to add"""
 

--- a/cellprofiler/gui/pipelinelistview.py
+++ b/cellprofiler/gui/pipelinelistview.py
@@ -564,7 +564,8 @@ class PipelineListView(object):
     def __on_list_dclick(self, event):
         list_ctrl = event.GetEventObject()
         item, hit_code, subitem = list_ctrl.HitTestSubItem(event.Position)
-
+        if list_ctrl.ItemCount == 0:
+            return
         if (
             0 <= item < list_ctrl.ItemCount
             and (hit_code & wx.LIST_HITTEST_ONITEM)
@@ -1603,10 +1604,21 @@ class PipelineListCtrl(wx.ScrolledWindow):
             wx.SYS_COLOUR_LISTBOXHIGHLIGHTTEXT
         )
 
+        if len(self.items) == 0:
+            text = "Drop a pipeline file here (.cppipe or .cpproj)\n or add modules using the buttons below"
+            dc.SetTextForeground(
+                wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)
+            )
+            text_width, text_height = dc.GetTextExtent(text)/2
+            width, height = self.GetSize()
+            dc.DrawText(
+                text, (width - text_width) / 2, (height - text_height) / 2
+            )
+
         for index, item in enumerate(self.items):
             item_text_color = text_color
 
-            dc.SetFont(self.Font)
+            dc.SetFont(self.GetFont())
 
             if self.show_step and self.test_mode:
                 rectangle = self.get_step_rect(index)

--- a/cellprofiler/gui/pipelinelistview.py
+++ b/cellprofiler/gui/pipelinelistview.py
@@ -564,7 +564,9 @@ class PipelineListView(object):
     def __on_list_dclick(self, event):
         list_ctrl = event.GetEventObject()
         item, hit_code, subitem = list_ctrl.HitTestSubItem(event.Position)
-        if list_ctrl.ItemCount == 0:
+        if item is None:
+            # Open the add modules window
+            self.__frame.pipeline_controller.open_add_modules()
             return
         if (
             0 <= item < list_ctrl.ItemCount
@@ -584,6 +586,8 @@ class PipelineListView(object):
 
     def __on_step_column_clicked(self, event):
         module = self.get_event_module(event)
+        if not self.list_ctrl.test_mode:
+            return
         if (
             self.get_current_debug_module().module_num >= module.module_num
             and module.enabled
@@ -1605,14 +1609,12 @@ class PipelineListCtrl(wx.ScrolledWindow):
         )
 
         if len(self.items) == 0:
-            text = "Drop a pipeline file here (.cppipe or .cpproj)\n or add modules using the buttons below"
+            text = "Drop a pipeline file here (.cppipe or .cpproj)\n or double-click to add modules"
             dc.SetTextForeground(
                 wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)
             )
-            text_width, text_height = dc.GetTextExtent(text)/2
-            width, height = self.GetSize()
-            dc.DrawText(
-                text, (width - text_width) / 2, (height - text_height) / 2
+            dc.DrawLabel(
+                text, wx.Bitmap(), wx.Rect(self.GetSize()), alignment=wx.ALIGN_CENTER,
             )
 
         for index, item in enumerate(self.items):


### PR DESCRIPTION
Closes #2601.

I've added this to make using the pipeline list a bit clearer to new users. Are we happy with this text?

I've also made it so that double clicking on the pipeline list will open the 'add modules' window if you aren't clicking on an existing module.

Also fixed a bug where the step function would try to run when not in test mode. The icon was invisible but still tried to do things.

![Dropper](https://user-images.githubusercontent.com/26802537/89062607-c2e88580-d334-11ea-9560-13c59e7f5aaa.png)
