### PR TITLE
New figure contrast adjustment dialog

### DIFF
--- a/cellprofiler/gui/figure.py
+++ b/cellprofiler/gui/figure.py
@@ -51,7 +51,6 @@ from cellprofiler_core.preferences import (
     get_default_colormap,
     INTENSITY_MODE_GAMMA,
     INTENSITY_MODE_LOG,
-    INTENSITY_MODE_NORMAL,
     INTENSITY_MODE_RAW,
     get_intensity_mode,
 )
@@ -59,7 +58,6 @@ from cellprofiler_core.utilities.core.object import overlay_labels
 from numpy.ma import MaskedArray
 from wx.lib.intctrl import IntCtrl
 from wx.lib.masked import NumCtrl, EVT_NUM
-from wx.lib.plot import PolyHistogram, PlotGraphics, PlotCanvas
 
 import cellprofiler.gui
 import cellprofiler.gui.artist

--- a/cellprofiler/gui/figure.py
+++ b/cellprofiler/gui/figure.py
@@ -306,7 +306,7 @@ def get_matplotlib_interpolation_preference():
     elif interpolation == IM_BILINEAR:
         return "bilinear"
     elif interpolation == IM_BICUBIC:
-        return "bilinear"
+        return "bicubic"
     return "nearest"
 
 
@@ -1143,7 +1143,7 @@ class Figure(wx.Frame):
 
         if params["interpolation"] == "bilinear":
             item_bilinear.Check()
-        elif params["interpolation"] == "bilinear":
+        elif params["interpolation"] == "bicubic":
             item_bicubic.Check()
         else:
             item_nearest.Check()
@@ -1315,7 +1315,7 @@ class Figure(wx.Frame):
             elif evt.Id == MENU_INTERPOLATION_BILINEAR:
                 params["interpolation"] = "bilinear"
             elif evt.Id == MENU_INTERPOLATION_BICUBIC:
-                params["interpolation"] = "bilinear"
+                params["interpolation"] = "bicubic"
             axes = self.subplot(x, y)
             for artist in axes.artists:
                 if isinstance(artist, cellprofiler.gui.artist.CPImageArtist):

--- a/cellprofiler/gui/figure.py
+++ b/cellprofiler/gui/figure.py
@@ -1048,10 +1048,6 @@ class Figure(wx.Frame):
         Note: Each item is bound to a handler.
         """
         (x, y) = coordinates
-        MENU_CONTRAST_RAW = wx.NewId()
-        MENU_CONTRAST_NORMALIZED = wx.NewId()
-        MENU_CONTRAST_LOG = wx.NewId()
-        MENU_CONTRAST_GAMMA = wx.NewId()
         MENU_INTERPOLATION_NEAREST = wx.NewId()
         MENU_INTERPOLATION_BILINEAR = wx.NewId()
         MENU_INTERPOLATION_BICUBIC = wx.NewId()
@@ -1166,7 +1162,7 @@ class Figure(wx.Frame):
             size = self.images[(x, y)].shape[:2]
             axesdata = axes.plot([0, 0], list(size), "k")[0]
 
-            with wx.Dialog(self, title="Adjust contrast", size=wx.Size(250, 300)) as dlg:
+            with wx.Dialog(self, title="Adjust contrast", size=wx.Size(250, 350)) as dlg:
                 dlg.Sizer = wx.BoxSizer(wx.VERTICAL)
 
                 sizer = wx.BoxSizer(wx.VERTICAL)
@@ -1365,7 +1361,7 @@ class Figure(wx.Frame):
 
                 # For small images we can draw fast enough for a live preview.
                 # For large images, we draw when the slider is released.
-                if size[0] * size[1] > 1166400:  # 1080x1080
+                if size[0] * size[1] > 262144:  # 512x512
                     dlg.Bind(wx.EVT_SCROLL_THUMBRELEASE, apply_contrast)
                     dlg.Bind(wx.EVT_SCROLL_CHANGED, apply_contrast)
                 else:

--- a/cellprofiler/gui/figure.py
+++ b/cellprofiler/gui/figure.py
@@ -1064,52 +1064,13 @@ class Figure(wx.Frame):
         popup = wx.Menu()
         self.popup_menus[(x, y)] = popup
         has_image = params["vmax"] is not None
-        if has_image:
-            contrast_item = wx.MenuItem(popup, -1, "Adjust Contrast")
-            popup.Append(contrast_item)
         open_in_new_figure_item = wx.MenuItem(popup, -1, "Open image in new window")
         popup.Append(open_in_new_figure_item)
         if has_image:
+            contrast_item = wx.MenuItem(popup, -1, "Adjust Contrast")
+            popup.Append(contrast_item)
             show_hist_item = wx.MenuItem(popup, -1, "Show image histogram")
             popup.Append(show_hist_item)
-
-            submenu = wx.Menu()
-            item_raw = submenu.Append(
-                MENU_CONTRAST_RAW,
-                "Raw",
-                "Do not transform pixel intensities",
-                wx.ITEM_RADIO,
-            )
-            item_normalized = submenu.Append(
-                MENU_CONTRAST_NORMALIZED,
-                "Normalized",
-                "Stretch pixel intensities to fit " "the interval [0,1]",
-                wx.ITEM_RADIO,
-            )
-            item_log = submenu.Append(
-                MENU_CONTRAST_LOG,
-                "Log normalized",
-                "Log transform pixel intensities, after stretching them to fit the interval [0,1]",
-                wx.ITEM_RADIO,
-            )
-
-            item_gamma = submenu.Append(
-                MENU_CONTRAST_GAMMA,
-                "Adjust gamma",
-                "Apply gamma correction (a.k.a., power law transform) pixel intensities, after stretching them"
-                " to fit the interval [0,1].",
-                wx.ITEM_RADIO,
-            )
-
-            if params["normalize"] == "log":
-                item_log.Check()
-            elif params["normalize"] == "gamma":
-                item_gamma.Check()
-            elif params["normalize"]:
-                item_normalized.Check()
-            else:
-                item_raw.Check()
-            popup.Append(-1, "Image contrast", submenu)
 
         submenu = wx.Menu()
         item_nearest = submenu.Append(
@@ -1423,51 +1384,6 @@ class Figure(wx.Frame):
                     params = orig_params
                     refresh_figure()
 
-        def change_contrast(evt):
-            """Callback for Image contrast menu items"""
-            axes = self.subplot(x, y)
-            if evt.Id == MENU_CONTRAST_RAW:
-                params["normalize"] = False
-                params["vmin"] = 0
-                params["vmax"] = max(1, self.images[(x, y)].max())
-            elif evt.Id == MENU_CONTRAST_NORMALIZED:
-                params["normalize"] = True
-                params["vmin"] = 0
-                params["vmax"] = 1
-            elif evt.Id == MENU_CONTRAST_LOG:
-                params["normalize"] = "log"
-                params["vmin"] = 0
-                params["vmax"] = 1
-            elif evt.Id == MENU_CONTRAST_GAMMA:
-                params["normalize"] = "gamma"
-                params["vmin"] = 0
-                params["vmax"] = 1
-            for artist in axes.artists:
-                if isinstance(artist, cellprofiler.gui.artist.CPImageArtist):
-                    artist.kwargs["normalize"] = params["normalize"]
-                    self.figure.canvas.draw()
-                    return
-            else:
-                refresh_figure()
-
-        def adjust_gamma(evt):
-            dlg = wx.TextEntryDialog(self, "Normalization factor", "Adjust gamma")
-            dlg.SetValue(get_normalization_factor())
-            if dlg.ShowModal() == wx.ID_OK:
-                params["normalize_args"] = {"gamma": float(dlg.GetValue())}
-            dlg.Destroy()
-
-            change_contrast(evt)
-
-        def adjust_log(evt):
-            dlg = wx.TextEntryDialog(self, "Normalization factor", "Log normalization")
-            dlg.SetValue(get_normalization_factor())
-            if dlg.ShowModal() == wx.ID_OK:
-                params["normalize_args"] = {"gain": float(dlg.GetValue())}
-            dlg.Destroy()
-
-            change_contrast(evt)
-
         def refresh_figure(axes=None, background=None, axesdata=None):
             image = self.images[(x, y)]
             subplot = self.subplot(x, y)
@@ -1616,10 +1532,6 @@ class Figure(wx.Frame):
         if has_image:
             self.Bind(wx.EVT_MENU, open_contrast_dialog, contrast_item)
             self.Bind(wx.EVT_MENU, show_hist, show_hist_item)
-        self.Bind(wx.EVT_MENU, change_contrast, id=MENU_CONTRAST_RAW)
-        self.Bind(wx.EVT_MENU, change_contrast, id=MENU_CONTRAST_NORMALIZED)
-        self.Bind(wx.EVT_MENU, adjust_log, id=MENU_CONTRAST_LOG)
-        self.Bind(wx.EVT_MENU, adjust_gamma, id=MENU_CONTRAST_GAMMA)
         self.Bind(wx.EVT_MENU, change_interpolation, id=MENU_INTERPOLATION_NEAREST)
         self.Bind(wx.EVT_MENU, change_interpolation, id=MENU_INTERPOLATION_BICUBIC)
         self.Bind(wx.EVT_MENU, change_interpolation, id=MENU_INTERPOLATION_BILINEAR)

--- a/cellprofiler/gui/figure.py
+++ b/cellprofiler/gui/figure.py
@@ -2244,14 +2244,12 @@ class Figure(wx.Frame):
 
     @staticmethod
     def normalize_image(image, **kwargs):
-        import time
         """Produce a color image normalized according to user spec"""
         if 0 in image.shape:
             # No normalization to perform for images with an empty dimension.
             # Return the image.
             # https://github.com/CellProfiler/CellProfiler/issues/3330
             return image
-        start = time.perf_counter()
         colormap = kwargs["colormap"]
         normalize = kwargs["normalize"]
         vmin = kwargs["vmin"]
@@ -2362,7 +2360,6 @@ class Figure(wx.Frame):
                     image[labels != 0, :] *= 1 - alpha
                     image[labels != 0, :] += limage * alpha
                 loffset += numpy.max(labels)
-        #print(f"Norm'd image in {time.perf_counter() - start}s")
         return image
 
     def subplot_table(

--- a/cellprofiler/gui/figure.py
+++ b/cellprofiler/gui/figure.py
@@ -1058,50 +1058,53 @@ class Figure(wx.Frame):
         # If no popup has been built for this subplot yet, then create one
         popup = wx.Menu()
         self.popup_menus[(x, y)] = popup
-        contrast_item = wx.MenuItem(popup, -1, "Adjust Contrast")
-        popup.Append(contrast_item)
+        has_image = params["vmax"] is not None
+        if has_image:
+            contrast_item = wx.MenuItem(popup, -1, "Adjust Contrast")
+            popup.Append(contrast_item)
         open_in_new_figure_item = wx.MenuItem(popup, -1, "Open image in new window")
         popup.Append(open_in_new_figure_item)
-        show_hist_item = wx.MenuItem(popup, -1, "Show image histogram")
-        popup.Append(show_hist_item)
+        if has_image:
+            show_hist_item = wx.MenuItem(popup, -1, "Show image histogram")
+            popup.Append(show_hist_item)
 
-        submenu = wx.Menu()
-        item_raw = submenu.Append(
-            MENU_CONTRAST_RAW,
-            "Raw",
-            "Do not transform pixel intensities",
-            wx.ITEM_RADIO,
-        )
-        item_normalized = submenu.Append(
-            MENU_CONTRAST_NORMALIZED,
-            "Normalized",
-            "Stretch pixel intensities to fit " "the interval [0,1]",
-            wx.ITEM_RADIO,
-        )
-        item_log = submenu.Append(
-            MENU_CONTRAST_LOG,
-            "Log normalized",
-            "Log transform pixel intensities, after stretching them to fit the interval [0,1]",
-            wx.ITEM_RADIO,
-        )
+            submenu = wx.Menu()
+            item_raw = submenu.Append(
+                MENU_CONTRAST_RAW,
+                "Raw",
+                "Do not transform pixel intensities",
+                wx.ITEM_RADIO,
+            )
+            item_normalized = submenu.Append(
+                MENU_CONTRAST_NORMALIZED,
+                "Normalized",
+                "Stretch pixel intensities to fit " "the interval [0,1]",
+                wx.ITEM_RADIO,
+            )
+            item_log = submenu.Append(
+                MENU_CONTRAST_LOG,
+                "Log normalized",
+                "Log transform pixel intensities, after stretching them to fit the interval [0,1]",
+                wx.ITEM_RADIO,
+            )
 
-        item_gamma = submenu.Append(
-            MENU_CONTRAST_GAMMA,
-            "Adjust gamma",
-            "Apply gamma correction (a.k.a., power law transform) pixel intensities, after stretching them"
-            " to fit the interval [0,1].",
-            wx.ITEM_RADIO,
-        )
+            item_gamma = submenu.Append(
+                MENU_CONTRAST_GAMMA,
+                "Adjust gamma",
+                "Apply gamma correction (a.k.a., power law transform) pixel intensities, after stretching them"
+                " to fit the interval [0,1].",
+                wx.ITEM_RADIO,
+            )
 
-        if params["normalize"] == "log":
-            item_log.Check()
-        elif params["normalize"] == "gamma":
-            item_gamma.Check()
-        elif params["normalize"]:
-            item_normalized.Check()
-        else:
-            item_raw.Check()
-        popup.Append(-1, "Image contrast", submenu)
+            if params["normalize"] == "log":
+                item_log.Check()
+            elif params["normalize"] == "gamma":
+                item_gamma.Check()
+            elif params["normalize"]:
+                item_normalized.Check()
+            else:
+                item_raw.Check()
+            popup.Append(-1, "Image contrast", submenu)
 
         submenu = wx.Menu()
         item_nearest = submenu.Append(
@@ -1439,8 +1442,9 @@ class Figure(wx.Frame):
                 popup.Append(-1, name, submenu)
 
         self.Bind(wx.EVT_MENU, open_image_in_new_figure, open_in_new_figure_item)
-        self.Bind(wx.EVT_MENU, open_contrast_dialog, contrast_item)
-        self.Bind(wx.EVT_MENU, show_hist, show_hist_item)
+        if has_image:
+            self.Bind(wx.EVT_MENU, open_contrast_dialog, contrast_item)
+            self.Bind(wx.EVT_MENU, show_hist, show_hist_item)
         self.Bind(wx.EVT_MENU, change_contrast, id=MENU_CONTRAST_RAW)
         self.Bind(wx.EVT_MENU, change_contrast, id=MENU_CONTRAST_NORMALIZED)
         self.Bind(wx.EVT_MENU, adjust_log, id=MENU_CONTRAST_LOG)

--- a/cellprofiler/gui/figure.py
+++ b/cellprofiler/gui/figure.py
@@ -1161,6 +1161,10 @@ class Figure(wx.Frame):
             background = self.figure.canvas.copy_from_bbox(axes.bbox)
             size = self.images[(x, y)].shape[:2]
             axesdata = axes.plot([0, 0], list(size), "k")[0]
+            if sys.platform == "win32":
+                slider_flags = wx.SL_HORIZONTAL | wx.SL_MIN_MAX_LABELS
+            else:
+                slider_flags = wx.SL_HORIZONTAL
 
             with wx.Dialog(self, title="Adjust contrast", size=wx.Size(250, 350)) as dlg:
                 dlg.Sizer = wx.BoxSizer(wx.VERTICAL)
@@ -1192,7 +1196,7 @@ class Figure(wx.Frame):
                     value=start_min,
                     minValue=0,
                     maxValue=255,
-                    style=wx.SL_HORIZONTAL | wx.SL_MIN_MAX_LABELS,
+                    style=slider_flags,
                     name="Minimum Intensity",
                 )
                 sliderminbox = IntCtrl(dlg, id=0, value=start_min, min=-999, max=9999, limited=True, size=wx.Size(35, 22),
@@ -1214,7 +1218,7 @@ class Figure(wx.Frame):
                     value=start_max,
                     minValue=0,
                     maxValue=255,
-                    style=wx.SL_HORIZONTAL | wx.SL_MIN_MAX_LABELS,
+                    style=slider_flags,
                     name="Maximum Intensity"
                 )
                 slidermaxbox = IntCtrl(dlg, id=1, value=start_max, min=-999, max=9999, limited=True, size=wx.Size(35, 22),
@@ -1236,7 +1240,7 @@ class Figure(wx.Frame):
                     value=4.5,
                     minValue=0,
                     maxValue=20,
-                    style=wx.SL_HORIZONTAL | wx.SL_MIN_MAX_LABELS,
+                    style=slider_flags,
                     name="Normalisation Factor"
                 )
                 slidernormbox = NumCtrl(
@@ -1355,6 +1359,9 @@ class Figure(wx.Frame):
                                     image = self.images[(xcoord, ycoord)]
                                     if not isinstance(image, MaskedArray):
                                         subplot_item.displayed.set_data(self.normalize_image(image, **plot_params))
+                                else:
+                                    # Should be a table, make sure the invisible subplot stays hidden.
+                                    subplot_item.axis("off")
                         self.figure.canvas.draw()
                     else:
                         event.Skip()


### PR DESCRIPTION
Resolves #2446.

This PR replaces the right click submenus for adjusting figure contrast with an all-in-one popup. Right clicking a figure plot now has an option labelled "Change Contrast" which brings up the following tool window:

![Contrast](https://user-images.githubusercontent.com/26802537/89210189-a72bec00-d58d-11ea-9bc5-f4a73575304e.png)

Within this you can change the normalisation mode, intensity display limits and normalisation factor (for log and gamma modes). The sliders represent a 'sensible' range, but these bounds can be exceeded by entering values into the boxes next to them. Changing these settings should update the plot immediately to give an instant preview.

I've also added an 'Apply to all' button. This will grab the display/normalisation settings and try to apply them to other subplots in the same window which are displaying an image... so that you don't have to repeat the process on multiple plots.

For colour images, normalisation modes work fine but the brightness sliders won't take effect due to the way the normalisation was originally set up. Nonetheless brightness adjustment is no longer exclusive to raw/linear normalised mode so I think that's an improvement.

Could probably do with some more testing on 'weird' images.