### PR TITLE
Disable automatic module activation when running test mode

### DIFF
--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -3278,7 +3278,7 @@ class PipelineController(object):
         self.__pipeline.end_run()
         self.show_launch_controls()
 
-    def do_step(self, module, select_next_module=True):
+    def do_step(self, module, select_next_module=False):
         """Do a debugging step by running a module
         """
         failure = 1

--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -3339,6 +3339,7 @@ class PipelineController(object):
             logging.error("Failed to run module %s", module.module_name, exc_info=True)
             event = RunException(instance, module)
             self.__pipeline.notify_listeners(event)
+            self.__pipeline_list_view.select_one_module(module.module_num)
             if event.cancel_run:
                 self.on_debug_stop(event)
                 failure = -1

--- a/cellprofiler/gui/pipelinelistview.py
+++ b/cellprofiler/gui/pipelinelistview.py
@@ -371,7 +371,6 @@ class PipelineListView(object):
         list_ctrl, index = self.get_ctrl_and_index(module)
         if list_ctrl is self.list_ctrl:
             self.list_ctrl.set_running_item(index)
-        self.select_one_module(module.module_num)
 
     def reset_debug_module(self):
         """Set the pipeline slider to the first module to be debugged
@@ -512,7 +511,7 @@ class PipelineListView(object):
             if module.module_num == module_num:
                 break
         else:
-            logging.warn("Could not find module %d" % module_num)
+            logging.warning("Could not find module %d" % module_num)
             for ctrl, idx in self.iter_list_items():
                 ctrl.Select(idx, False)
             self.__on_item_selected(None)
@@ -1694,9 +1693,6 @@ class PipelineListCtrl(wx.ScrolledWindow):
 
             if self.test_mode and self.running_item == index:
                 dc.SetFont(font.MakeUnderlined())
-                cellprofiler.gui.draw_item_selection_rect(
-                    self, dc, rectangle, flags | wx.CONTROL_SELECTED
-                )
 
             dc.SetBackgroundMode(wx.PENSTYLE_TRANSPARENT)
 


### PR DESCRIPTION
Currently CellProfiler automatically displays each module's settings panel as it runs in Test Mode. Particularly when using 'Run' across multiple modules, this results in the settings panel rapidly redrawing for each module. It looks like this interface rendering actually slows down test mode quite a bit, since the drawing has to finish before the next module executes.

In this PR I've disabled the call to display a module's settings when it executes in test mode. This makes using 'Run' much smoother. This also applies to the 'Step' functionality, but in my view it's more convenient to not have to keep re-selecting a module when trying to tweak it's settings. Since we now have better control over stepping from specific modules, keeping the current settings panel open might make more sense.

A potential downside is that the selected (settings shown) and active (next to run) module won't be the same after running a module, although this was the case when manually selecting modules anyway. I think the step marker we added recently makes the active module a lot clearer, but I've removed it's background highlight since when the window is not selected that highlight is indistinguishable from the selected module's highlight on Windows.

Font styles still apply, so in this setup Selected module = highlighted and bold. Active module = underlined and marked by a 'Step' icon. Do we think that's clear enough? Another possibility might be to introduce a "currently displayed" icon of some sort.

Oh, and I've made it so that if a module fails to run then the problem module's settings are displayed automatically.

This is largely all achieved by changing the `do_step` function's default parameters (showing settings is optional). In theory we could make this a preference if people are attached to the old functionality.