### PR TITLE
Fix edit objects manually right click conflict

### DIFF
--- a/cellprofiler/gui/editobjectsdlg.py
+++ b/cellprofiler/gui/editobjectsdlg.py
@@ -544,7 +544,6 @@ class EditObjectsDialog(wx.Dialog):
         self.Bind(wx.EVT_MENU, self.on_help, id=wx.ID_HELP)
         self.Bind(wx.EVT_CLOSE, lambda event: self.on_close(event, wx.CANCEL))
         self.Bind(wx.EVT_SIZE, self.on_size)
-        self.Bind(wx.EVT_CONTEXT_MENU, self.on_context_menu)
         self.figure.canvas.Bind(wx.EVT_WINDOW_DESTROY, self.on_destroy)
         self.toolbar.Bind(wx.EVT_WINDOW_DESTROY, self.on_destroy)
         self.help_sash.Bind(wx.EVT_WINDOW_DESTROY, self.on_destroy)
@@ -935,6 +934,7 @@ class EditObjectsDialog(wx.Dialog):
                     return
         lnum = self.get_mouse_event_object_number(event)
         if lnum is None:
+            self.on_context_menu(event)
             return
         if event.button == 1:
             # Move object into / out of working set


### PR DESCRIPTION
Fixes #3862.

The previous setup for handling right clicks was a bit messy. On mac `EVT_CONTEXT_MENU` likes to fire any time you ctrl+click, whereas on Windows it only fires if other events weren't triggered. To solve this we've made the context menu activate only when not clicking on an object within the figure, as part of the normal click flow. This does mean that the right menu can now only be accessed by clicking on the figure itself, but that also prevents the right menu from opening when clicking on objects on Mac.