### PR TITLE
New 3D viewer

### DIFF
--- a/cellprofiler/gui/constants/figure.py
+++ b/cellprofiler/gui/constants/figure.py
@@ -43,4 +43,3 @@ NAV_MODE_NONE = ""
 NAV_MODE_PAN = "pan/zoom"
 NAV_MODE_ZOOM = "zoom rect"
 WINDOW_IDS = []
-CROSSHAIR_CURSOR = None

--- a/cellprofiler/gui/constants/figure.py
+++ b/cellprofiler/gui/constants/figure.py
@@ -43,4 +43,4 @@ NAV_MODE_NONE = ""
 NAV_MODE_PAN = "pan/zoom"
 NAV_MODE_ZOOM = "zoom rect"
 WINDOW_IDS = []
-__CROSSHAIR_CURSOR = None
+CROSSHAIR_CURSOR = None

--- a/cellprofiler/gui/figure/_figure.py
+++ b/cellprofiler/gui/figure/_figure.py
@@ -1155,6 +1155,10 @@ class Figure(wx.Frame):
                                 else:
                                     # Should be a table, make sure the invisible subplot stays hidden.
                                     subplot_item.axis("off")
+                                    if not hasattr(subplot_item, "deleted") and self.dimensions == 3:
+                                        self.figure.delaxes(subplot_item)
+                                        subplot_item.deleted = True
+
                         self.figure.canvas.draw()
                     else:
                         event.Skip()
@@ -1718,7 +1722,10 @@ class Figure(wx.Frame):
                             subplot_item.displayed.set_data(img_data)
                         else:
                             # Should be a table, make sure the invisible subplot stays hidden.
-                            subplot_item.axis("off")
+#                            subplot_item.axis("off")
+                            if not hasattr(subplot_item, "deleted"):
+                                self.figure.delaxes(subplot_item)
+                                subplot_item.deleted = True
                         # Updating the slider will force a refresh, so we don't need to explicitly draw
             splane.on_changed(change_plane)
             self.sliders[subplot] = (axplane, splane)

--- a/cellprofiler/gui/utilities/figure.py
+++ b/cellprofiler/gui/utilities/figure.py
@@ -15,6 +15,8 @@ from cellprofiler_core.preferences import IM_BICUBIC
 
 from .. import errordialog
 
+CROSSHAIR_CURSOR = None
+
 
 def wraparound(sequence):
     while True:
@@ -188,7 +190,7 @@ def get_matplotlib_interpolation_preference():
 
 
 def get_crosshair_cursor():
-    from ..constants.figure import CROSSHAIR_CURSOR
+    global CROSSHAIR_CURSOR
     if CROSSHAIR_CURSOR is None:
         if sys.platform.lower().startswith("win"):
             #

--- a/cellprofiler/gui/utilities/figure.py
+++ b/cellprofiler/gui/utilities/figure.py
@@ -24,7 +24,7 @@ def wraparound(sequence):
 
 def match_rgbmask_to_image(rgb_mask, image):
     rgb_mask = list(rgb_mask)  # copy
-    nchannels = image.shape[2]
+    nchannels = image.shape[-1]
     del rgb_mask[nchannels:]
     if len(rgb_mask) < nchannels:
         rgb_mask = rgb_mask + [1] * (nchannels - len(rgb_mask))

--- a/cellprofiler/gui/utilities/figure.py
+++ b/cellprofiler/gui/utilities/figure.py
@@ -16,10 +16,6 @@ from cellprofiler_core.preferences import IM_BICUBIC
 from .. import errordialog
 
 
-def is_color_image(image):
-    return image.ndim == 3 and image.shape[2] >= 2
-
-
 def wraparound(sequence):
     while True:
         for l in sequence:
@@ -192,8 +188,8 @@ def get_matplotlib_interpolation_preference():
 
 
 def get_crosshair_cursor():
-    global __crosshair_cursor
-    if __crosshair_cursor is None:
+    from ..constants.figure import CROSSHAIR_CURSOR
+    if CROSSHAIR_CURSOR is None:
         if sys.platform.lower().startswith("win"):
             #
             # Build the crosshair cursor image as a numpy array.
@@ -205,7 +201,7 @@ def get_crosshair_cursor():
             image = wx.ImageFromBuffer(16, 16, buf.tostring(), abuf.tostring())
             image.SetOption(wx.IMAGE_OPTION_CUR_HOTSPOT_X, 7)
             image.SetOption(wx.IMAGE_OPTION_CUR_HOTSPOT_Y, 7)
-            __crosshair_cursor = wx.Cursor(image)
+            CROSSHAIR_CURSOR = wx.Cursor(image)
         else:
-            __crosshair_cursor = wx.CROSS_CURSOR
-    return __crosshair_cursor
+            CROSSHAIR_CURSOR = wx.CROSS_CURSOR
+    return CROSSHAIR_CURSOR


### PR DESCRIPTION
This PR replaces the 3x3 grid-based plots for 3D images with a single plane view accompanied by a slider for switching plane.

<img src="https://user-images.githubusercontent.com/26802537/89928273-94d93000-dbd5-11ea-8c0f-39bef4188eda.png" data-canonical-src="https://user-images.githubusercontent.com/26802537/89928273-94d93000-dbd5-11ea-8c0f-39bef4188eda.png" height="400" />


The plots will initialise with the middle plane displayed, and users can click/drag the slider or use dedicated buttons to change the displayed plane. Normalisation is calculated across the entire stack (thanks Allen!). The buttons don't really position well with `constrained_layout` and had to be done manually, so they'll only display with up to 2x2 subplots.

Buttons can also appear underneath (rather than above) the slider on the top row if you have 2 rows of subplots with sliders. Not sure if there's a better solution because plot size can be different if you have tables on the bottom row, but it looks acceptable with everything I could find. Fortunately very few 3D-compatible modules display more than 2 plots to begin with. Matplotlib appear to be rewriting `constrained_layout` for the next version, so perhaps it's best to not worry about it too much for this release.

These changes also allowed me to enable the contrast, interpolation, histogram, length measurement and plot saving features which were previously exclusive to 2D plots.

I wonder if this may also provide a means for viewing timelapse images in the future?

I also fixed the plot zoom cursor.

Resolves #2496