### PR TITLE
Set sensible colormap defaults

### DIFF
--- a/cellprofiler/modules/measureobjectintensitydistribution.py
+++ b/cellprofiler/modules/measureobjectintensitydistribution.py
@@ -477,6 +477,7 @@ objects chosen in "Select objects to measure".""",
             "colormap",
             Colormap(
                 "Color map",
+                value="Blues",
                 doc="""\
 The color map setting chooses the color palette that will be
 used to render the different values for your measurement. If you
@@ -777,7 +778,7 @@ be selected in a later **SaveImages** or other module.
                         normalize=False,
                         vmin=numpy.min(heatmap_img),
                         vmax=numpy.max(heatmap_img),
-                        colorbar=True,
+                        colorbar=False,
                     )
                 else:
                     figure.subplot_imshow(
@@ -786,7 +787,7 @@ be selected in a later **SaveImages** or other module.
                         heatmap_img,
                         title=title,
                         colormap=colormap,
-                        colorbar=True,
+                        colorbar=False,
                         normalize=False,
                         vmin=numpy.min(heatmap_img),
                         vmax=numpy.max(heatmap_img),

--- a/cellprofiler/modules/measureobjectneighbors.py
+++ b/cellprofiler/modules/measureobjectneighbors.py
@@ -206,6 +206,7 @@ of neighbors to be selected later in the pipeline.""",
 
         self.count_colormap = Colormap(
             "Select colormap",
+            value="Blues",
             doc="""\
 *(Used only if the image of objects colored by numbers of neighbors is
 to be retained for later use in the pipeline)*
@@ -241,6 +242,7 @@ of touching pixels to be selected later in the pipeline.""",
 
         self.touching_colormap = Colormap(
             "Select colormap",
+            value="Oranges",
             doc="""\
 *(Used only if the image of objects colored by percent touching is to be
 retained for later use in the pipeline)*
@@ -727,7 +729,7 @@ previously discarded objects.""".format(
             count_image = Image(img, masking_objects=objects)
             image_set.add(self.count_image_name.value, count_image)
         else:
-            neighbor_cm_name = get_default_colormap()
+            neighbor_cm_name = "Blues"
             neighbor_cm = matplotlib.cm.get_cmap(neighbor_cm_name)
         if self.wants_percent_touching_image:
             percent_touching_cm_name = self.touching_colormap.value
@@ -740,7 +742,7 @@ previously discarded objects.""".format(
             touching_image = Image(img, masking_objects=objects)
             image_set.add(self.touching_image_name.value, touching_image)
         else:
-            percent_touching_cm_name = get_default_colormap()
+            percent_touching_cm_name = "Oranges"
             percent_touching_cm = matplotlib.cm.get_cmap(percent_touching_cm_name)
 
         if self.show_window:


### PR DESCRIPTION
This PR makes modules which display objects coloured by data values use a more sensible (linear) colormap by default.

In the case of MeasureObjectNeighbours, it'll no longer use the default (random) map when colouring by number of neighbors. The map was/is only customisable if you enable retention of the plot as an image, so I think a better default makes sense.

In MeasureObjectIntensityDistribution the same applies to heatmaps, and I've also disabled colorbars on this module since they really don't play well with the WX table plot.