### PR TITLE
Bin grey levels before running MeasureTexture

### DIFF
--- a/tests/modules/test_measuretexture.py
+++ b/tests/modules/test_measuretexture.py
@@ -432,10 +432,10 @@ def test_no_image_measurements():
     m = workspace.measurements
     assert not m.has_feature(
         "Image",
-        "Texture_AngularSecondMoment_%s_2_00" % INPUT_IMAGE_NAME,
+        "Texture_AngularSecondMoment_%s_2_00_256" % INPUT_IMAGE_NAME,
     )
     assert m.has_feature(
-        INPUT_OBJECTS_NAME, "Texture_AngularSecondMoment_%s_2_00" % INPUT_IMAGE_NAME
+        INPUT_OBJECTS_NAME, "Texture_AngularSecondMoment_%s_2_00_256" % INPUT_IMAGE_NAME
     )
 
 
@@ -450,10 +450,10 @@ def test_no_object_measurements():
     m = workspace.measurements
     assert m.has_feature(
         "Image",
-        "Texture_AngularSecondMoment_%s_2_00" % INPUT_IMAGE_NAME,
+        "Texture_AngularSecondMoment_%s_2_00_256" % INPUT_IMAGE_NAME,
     )
     assert not m.has_feature(
-        INPUT_OBJECTS_NAME, "Texture_AngularSecondMoment_%s_2_00" % INPUT_IMAGE_NAME
+        INPUT_OBJECTS_NAME, "Texture_AngularSecondMoment_%s_2_00_256" % INPUT_IMAGE_NAME
     )
 
 
@@ -495,7 +495,7 @@ def test_volume_image_measurements():
     for direction in range(13):
         assert measurements.has_feature(
             "Image",
-            "Texture_AngularSecondMoment_{}_2_{:02d}".format(
+            "Texture_AngularSecondMoment_{}_2_{:02d}_256".format(
                 INPUT_IMAGE_NAME, direction
             ),
         )
@@ -519,7 +519,7 @@ def test_volume_object_measurements_no_objects():
     for direction in range(13):
         assert measurements.has_feature(
             INPUT_OBJECTS_NAME,
-            "Texture_AngularSecondMoment_{}_2_{:02d}".format(
+            "Texture_AngularSecondMoment_{}_2_{:02d}_256".format(
                 INPUT_IMAGE_NAME, direction
             ),
         )
@@ -544,7 +544,7 @@ def test_volume_object_measurements():
     for direction in range(13):
         assert measurements.has_feature(
             INPUT_OBJECTS_NAME,
-            "Texture_AngularSecondMoment_{}_2_{:02d}".format(
+            "Texture_AngularSecondMoment_{}_2_{:02d}_256".format(
                 INPUT_IMAGE_NAME, direction
             ),
         )

--- a/tests/modules/test_measuretexture.py
+++ b/tests/modules/test_measuretexture.py
@@ -286,12 +286,13 @@ def test_many_objects():
             INPUT_IMAGE_NAME,
         )
         for angle in range(4):
-            mname = "{}_{}_{}_{:d}_{:02d}".format(
+            mname = "{}_{}_{}_{:d}_{:02d}_{:d}".format(
                 cellprofiler.modules.measuretexture.TEXTURE,
                 measurement,
                 INPUT_IMAGE_NAME,
                 2,
                 angle,
+                256
             )
             assert mname in all_column_features
             values = m.get_current_measurement(INPUT_OBJECTS_NAME, mname)


### PR DESCRIPTION
Resolves #3386 .  

This PR allows you to adjust your grey levels before running texture feature extraction; it doesn't look like this produces an exponential speedup though, just about 3x in my (very limited) tests going from 256 grey levels to 2, and almost no appreciable speedup at all going from 256 to 8.

I think the slowdown actually didn't come from the change in gray levels, but from the fact that in 2.X we run [all objects at once](https://github.com/CellProfiler/CellProfiler/blob/stable/cellprofiler/modules/measuretexture.py#L564-L568) and in 3.X we run [one object at a time](https://github.com/CellProfiler/CellProfiler/blob/v3.1.9/cellprofiler/modules/measuretexture.py#L608-L619); image texture features are still pretty fast in 3/4, no matter what the number of gray levels.  I'll look into if there's an easier way to run all the objects at a time.
  