### PR TITLE
Add "View Workspace" button, prevent opening when not in Test Mode.

### DIFF
--- a/cellprofiler/gui/cpframe.py
+++ b/cellprofiler/gui/cpframe.py
@@ -979,6 +979,7 @@ class CPFrame(wx.Frame):
         ID_DEBUG_CHOOSE_IMAGE_SET,
         ID_DEBUG_CHOOSE_RANDOM_IMAGE_SET,
         ID_DEBUG_CHOOSE_RANDOM_IMAGE_GROUP,
+        ID_DEBUG_VIEW_WORKSPACE,
     )
 
     def enable_debug_commands(self):

--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -3814,6 +3814,13 @@ class PipelineController(object):
             self.next_debug_module()
 
     def on_view_workspace(self, event):
+        if not self.is_in_debug_mode():
+            wx.MessageBox(
+                "Workspace Viewer is only available in Test Mode",
+                style=wx.OK | wx.ICON_ERROR,
+                parent=self.__frame,
+            )
+            return
         # Need to pack the measurements into the workspace
         workspace = cellprofiler.gui._workspace_model.Workspace(
             self.__pipeline,
@@ -3828,6 +3835,7 @@ class PipelineController(object):
         else:
             self.workspace_view.set_workspace(workspace)
             self.workspace_view.frame.Show()
+            self.workspace_view.frame.Raise()
 
     def on_sample_init(self, event):
         if self.__module_view is not None:

--- a/cellprofiler/gui/pipelinelistview.py
+++ b/cellprofiler/gui/pipelinelistview.py
@@ -161,12 +161,18 @@ class PipelineListView(object):
         self.outputs_panel.SetSizer(wx.BoxSizer())
         self.outputs_panel.SetBackgroundStyle(wx.BG_STYLE_ERASE)
         self.outputs_button = wx.Button(
-            self.outputs_panel, label="View output settings", style=wx.BU_EXACTFIT
+            self.outputs_panel, label="Output Settings", style=wx.BU_EXACTFIT
+        )
+        self.wsv_button = wx.Button(
+            self.outputs_panel, label="View Workspace", style=wx.BU_EXACTFIT
         )
         self.outputs_panel.GetSizer().AddStretchSpacer(1)
         self.outputs_panel.GetSizer().Add(self.outputs_button, 0, wx.ALL, 2)
+        self.outputs_panel.GetSizer().Add(self.wsv_button, 0, wx.ALL, 2)
         self.outputs_panel.GetSizer().AddStretchSpacer(1)
         self.outputs_button.Bind(wx.EVT_BUTTON, self.on_outputs_button)
+        self.wsv_button.Bind(wx.EVT_BUTTON, self.on_wsv_button)
+        self.wsv_button.Enable(False)
         self.outputs_panel.SetAutoLayout(True)
         self.__panel.Layout()
         self.outputs_panel.Layout()
@@ -308,6 +314,9 @@ class PipelineListView(object):
     def on_outputs_button(self, event):
         self.__frame.show_preferences(True)
 
+    def on_wsv_button(self, event):
+        self.__frame.pipeline_controller.on_view_workspace(event)
+
     def request_validation(self, module=None):
         """Request validation of the pipeline, starting at the given module"""
         if module is None:
@@ -353,6 +362,7 @@ class PipelineListView(object):
             if len(modules) > 0:
                 self.select_one_module(modules[0].module_num)
         self.list_ctrl.set_test_mode(mode)
+        self.wsv_button.Enable(mode)
         self.__debug_mode = mode
         self.__sizer.Layout()
         self.request_validation()


### PR DESCRIPTION
This PR adds a button to the UI for opening the workspace viewer. I placed this next to the "View Output Settings" button since there's plenty of unused space there. This button and the menu option will be disabled when the user is not in Test Mode, which should prevent people from breaking it.

<img src="https://user-images.githubusercontent.com/26802537/90676951-b2884400-e22a-11ea-89a1-e63186e53d30.png" data-canonical-src="https://user-images.githubusercontent.com/26802537/90676951-b2884400-e22a-11ea-89a1-e63186e53d30.png" width="300" />

Recommend merging #4153 before this.