### PR TITLE
Skimage Watershed moved to segmentation

### DIFF
--- a/cellprofiler/modules/identifyprimaryobjects.py
+++ b/cellprofiler/modules/identifyprimaryobjects.py
@@ -9,7 +9,7 @@ import centrosome.threshold
 import numpy
 import scipy.ndimage
 import scipy.sparse
-import skimage.morphology
+import skimage.segmentation
 from cellprofiler_core.setting import Binary, Color
 from cellprofiler_core.setting.choice import Choice
 from cellprofiler_core.setting.range import IntegerRange
@@ -1382,7 +1382,7 @@ If "*{NO}*" is selected, the following settings are used:
             # will be split up.
             #
 
-            watershed_boundaries = skimage.morphology.watershed(
+            watershed_boundaries = skimage.segmentation.watershed(
                 connectivity=numpy.ones((3, 3), bool),
                 image=watershed_image,
                 markers=markers,

--- a/cellprofiler/modules/identifysecondaryobjects.py
+++ b/cellprofiler/modules/identifysecondaryobjects.py
@@ -2,7 +2,7 @@
 import centrosome.propagate
 import numpy
 import scipy.ndimage
-import skimage.morphology
+import skimage.segmentation
 from cellprofiler_core.constants.measurement import (
     FF_CHILDREN_COUNT,
     FF_PARENT,
@@ -636,7 +636,7 @@ segmentation.""",
             # Perform the first watershed
             #
 
-            labels_out = skimage.morphology.watershed(
+            labels_out = skimage.segmentation.watershed(
                 connectivity=numpy.ones((3, 3), bool),
                 image=sobel_image,
                 markers=labels_in,
@@ -668,7 +668,7 @@ segmentation.""",
             # Perform the watershed
             #
 
-            labels_out = skimage.morphology.watershed(
+            labels_out = skimage.segmentation.watershed(
                 connectivity=numpy.ones((3, 3), bool),
                 image=inverted_img,
                 markers=labels_in,

--- a/cellprofiler/modules/watershed.py
+++ b/cellprofiler/modules/watershed.py
@@ -6,7 +6,7 @@ import skimage.color
 import skimage.feature
 import skimage.filters
 import skimage.measure
-import skimage.morphology
+import skimage.segmentation
 import skimage.transform
 from cellprofiler_core.module.image_segmentation import ImageSegmentation
 from cellprofiler_core.setting import Binary
@@ -316,7 +316,7 @@ the image is not downsampled.
 
                 mask_data = mask.pixel_data
 
-            y_data = skimage.morphology.watershed(
+            y_data = skimage.segmentation.watershed(
                 image=x_data,
                 markers=markers_data,
                 mask=mask_data,

--- a/tests/modules/test_watershed.py
+++ b/tests/modules/test_watershed.py
@@ -8,7 +8,6 @@ import skimage.feature
 import skimage.filters
 import skimage.filters.rank
 import skimage.measure
-import skimage.morphology
 import skimage.segmentation
 import skimage.transform
 import skimage.util
@@ -112,7 +111,7 @@ def test_run_markers(
 
         markers = skimage.color.rgb2gray(markers)
 
-    expected = skimage.morphology.watershed(
+    expected = skimage.segmentation.watershed(
         gradient,
         markers,
         connectivity=connectivity,


### PR DESCRIPTION
Fixes a deprecation warning, `morphology.watershed` currently redirects to `segmentation.watershed` but this link is being removed in 0.19.