### PR TITLE
Add setting for faster Costes thresholding

### DIFF
--- a/cellprofiler/modules/measurecolocalization.py
+++ b/cellprofiler/modules/measurecolocalization.py
@@ -503,7 +503,23 @@ Select *{YES}* to run the Manders coefficients using Costes auto threshold.
                 )
                 a = num / denom
                 b = ymean - a * xmean
-
+                import time
+                start = time.perf_counter()
+                i = 1
+                while i > 0.003921568627:
+                    Thr_fi_c = i
+                    Thr_si_c = (a * i) + b
+                    combt = (fi < Thr_fi_c) | (si < Thr_si_c)
+                    try:
+                        costReg = scipy.stats.pearsonr(fi[combt], si[combt])
+                        #print(costReg[0], i)
+                        if costReg[0] <= 0:
+                            break
+                        i = i - 0.003921568627
+                    except ValueError:
+                        break
+                print(f"Looped in {time.perf_counter() - start}, i was {i}")
+                start = time.perf_counter()
                 i = 1
                 while i > 0.003921568627:
                     Thr_fi_c = i
@@ -513,10 +529,17 @@ Select *{YES}* to run the Manders coefficients using Costes auto threshold.
                         costReg = scipy.stats.pearsonr(fi[combt], si[combt])
                         if costReg[0] <= 0:
                             break
-                        i = i - 0.003921568627
+                        elif costReg[0] > 0.45 and i > 0.05:
+                            i -= 0.03921568627
+                        elif costReg[0] > 0.35 and i > 0.03:
+                            i -= 0.019607843135
+                        elif costReg[0] > 0.25 and i > 0.03:
+                            i -= 0.007843137254
+                        else:
+                            i -= 0.003921568627
                     except ValueError:
                         break
-
+                print(f"Short Looped in {time.perf_counter() - start}, i was {i}")
                 # Costes' thershold calculation
                 combined_thresh_c = (fi > Thr_fi_c) & (si > Thr_si_c)
                 fi_thresh_c = fi[combined_thresh_c]

--- a/cellprofiler/modules/measurecolocalization.py
+++ b/cellprofiler/modules/measurecolocalization.py
@@ -305,6 +305,8 @@ Select *{YES}* to run the Manders coefficients using Costes auto threshold.
         """Calculate measurements on an image set"""
         col_labels = ["First image", "Second image", "Objects", "Measurement", "Value"]
         statistics = []
+        if len(self.images_list.value) < 2:
+            raise ValueError("At least 2 images must be selected for analysis.")
         for first_image_name, second_image_name in self.get_image_pairs():
             if self.wants_images():
                 statistics += self.run_image_pair_images(
@@ -1437,8 +1439,8 @@ Select *{YES}* to run the Manders coefficients using Costes auto threshold.
 
     def validate_module(self, pipeline):
         """Make sure chosen objects are selected only once"""
-        if len(self.images_list.value) == 0:
-            raise ValidationError("No images selected", self.images_list)
+        if len(self.images_list.value) < 2:
+            raise ValidationError("This module needs at least 2 images to be selected", self.images_list)
 
         if self.wants_objects():
             if len(self.objects_list.value) == 0:


### PR DESCRIPTION
Resolves #4168 somewhat.

MeasureColocalization uses a loop for determining the Costes Automated Threshold. This involves serially decreasing a 'test threshold' value and evaluating whether it brings the Pearson r value below 0. On large images this starts to seriously impact performance as, while a single test is quick, testing every possible value is very intensive.

In this PR I've added a setting to choose whether to use a "fast" or "accurate" mode for this calculation. New module instances default to 'fast', upgraded pipelines default to 'accurate'. In "fast" mode, we decrease the test threshold by a larger amount each loop if the r value was far above 0. This should 'home in' on the correct threshold and cut out some additional work. In my testing this strategy gave the same final threshold values, so hopefully it'll be fine to use in most instances.