### PR TITLE
Make metadata matching auto-fill empty columns

### DIFF
--- a/cellprofiler/gui/module_view/_joiner_controller.py
+++ b/cellprofiler/gui/module_view/_joiner_controller.py
@@ -215,10 +215,11 @@ class JoinerController:
             joins.append(dict([(cn, "") for cn in self.column_names]))
         join = joins[row].copy()
         join[self.column_names[column]] = new_value
-        # Fill other empty fields if present.
-        for col in self.column_names:
-            if join[col] in ("", None) and new_value in self.v.entities[col]:
-                join[col] = new_value
+        if wx.GetKeyState(wx.WXK_SHIFT):
+            # Fill other empty fields if present.
+            for col in self.column_names:
+                if join[col] in ("", None) and new_value in self.v.entities[col]:
+                    join[col] = new_value
         joins[row] = join
         self.module_view.on_value_change(
             self.v, self.panel, self.v.build_string(joins), event

--- a/cellprofiler/gui/module_view/_joiner_controller.py
+++ b/cellprofiler/gui/module_view/_joiner_controller.py
@@ -215,6 +215,10 @@ class JoinerController:
             joins.append(dict([(cn, "") for cn in self.column_names]))
         join = joins[row].copy()
         join[self.column_names[column]] = new_value
+        # Fill other empty fields if present.
+        for col in self.column_names:
+            if join[col] in ("", None) and new_value in self.v.entities[col]:
+                join[col] = new_value
         joins[row] = join
         self.module_view.on_value_change(
             self.v, self.panel, self.v.build_string(joins), event


### PR DESCRIPTION
Resolves #4027

Per @ErinWeisbart's request, because this was indeed annoying and it's a simple fix. This PR makes selecting a metadata matching key automatically populate any other empty fields in that row with the same key (if it's available for that item).

I figure there's no need for a dedicated button, if the cells aren't empty they'll be left alone, and if there's an exactly matching key then users will in most instances want to use it.