### PR TITLE
Disable WSV when in 3D mode

### DIFF
--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -3823,6 +3823,13 @@ class PipelineController(object):
                 parent=self.__frame,
             )
             return
+        elif self.__pipeline.volumetric():
+            wx.MessageBox(
+                "Workspace Viewer is currently only available with 2D Pipelines",
+                style=wx.OK | wx.ICON_ERROR,
+                parent=self.__frame,
+            )
+            return
         # Need to pack the measurements into the workspace
         workspace = cellprofiler.gui._workspace_model.Workspace(
             self.__pipeline,


### PR DESCRIPTION
The artist currently can't handle 3D images (it was originally made before volumetric pipelines were a thing). It'll probably take some work to get it fully functional, so let's disable WSV in 3D mode for now.