### PR TITLE
Adjust Figure parameters to handle large numbers of subplots

### DIFF
--- a/cellprofiler/gui/figure/_figure.py
+++ b/cellprofiler/gui/figure/_figure.py
@@ -150,6 +150,7 @@ class Figure(wx.Frame):
         self.subplot_menus = {}
         self.widgets = []
         self.mouse_down = None
+        self.many_plots = False
         self.remove_menu = []
         self.figure = matplotlib.pyplot.Figure(constrained_layout=True)
         self.figure.set_constrained_layout_pads(
@@ -724,6 +725,9 @@ class Figure(wx.Frame):
 
         self.dimensions = dimensions
 
+        if max(subplots) > 3:
+            self.many_plots = True
+
         if subplots is None:
             if hasattr(self, "subplots"):
                 delattr(self, "subplots")
@@ -773,8 +777,12 @@ class Figure(wx.Frame):
         y - subplot's row
         """
         fontname = get_title_font_name()
+        if self.many_plots:
+            fontsize = 8
+        else:
+            fontsize = get_title_font_size()
         self.subplot(x, y).set_title(
-            textwrap.fill(title, 30), fontname=fontname, fontsize=get_title_font_size(),
+            textwrap.fill(title, 30 if fontsize > 10 else 50), fontname=fontname, fontsize=fontsize,
         )
 
     def clear_subplot(self, x, y):
@@ -1575,6 +1583,8 @@ class Figure(wx.Frame):
         subplot.set_xlim([0, imshape[1]])
         subplot.set_ylim([imshape[0] - 0.5, -0.5])
         subplot.set_aspect("equal")
+        if self.many_plots:
+            subplot.tick_params(labelsize=6)
 
         # Set title
         if title is not None:

--- a/cellprofiler/modules/correctilluminationapply.py
+++ b/cellprofiler/modules/correctilluminationapply.py
@@ -313,6 +313,7 @@ somewhat empirical.
     def display(self, workspace, figure):
         """ Display one row of orig / illum / output per image setting group"""
         figure.set_subplots((3, len(self.images)))
+        nametemplate = "Illumination function:" if len(self.images) < 3 else "Illum:"
         for j, image in enumerate(self.images):
             image_name = image.image_name.value
             illum_correct_function_image_name = (
@@ -339,11 +340,8 @@ somewhat empirical.
                 "Original image: %s" % image_name,
                 sharexy=figure.subplot(0, 0),
             )
-            title = "Illumination function: %s\nmin=%f, max=%f" % (
-                illum_correct_function_image_name,
-                round(illum_image.min(), 4),
-                round(illum_image.max(), 4),
-            )
+            title = f"{nametemplate} {illum_correct_function_image_name}, " \
+                    f"min={illum_image.min():0.4f}, max={illum_image.max():0.4f}"
 
             imshow(1, j, illum_image, title, sharexy=figure.subplot(0, 0))
             imshow(


### PR DESCRIPTION
Fix #4228

Figures with excessive numbers of subplots are still cramped, but I've made CellProfiler use a smaller font size when a row or column will contain more than 3 plots. This should leave the plot visible.

I've also tidied up the formatting for CorrectIlluminationApply's plot titles. It now rounds properly and uses a shorter label for the middle plot when we have a lot to display.

![Manyplots](https://user-images.githubusercontent.com/26802537/92807669-18c73900-f389-11ea-9a52-61cb51d201da.png)
