### PR TITLE
Fix Welcome Screen on OSX

### DIFF
--- a/cellprofiler/gui/_welcome_frame.py
+++ b/cellprofiler/gui/_welcome_frame.py
@@ -106,6 +106,8 @@ class WelcomeFrame(wx.Frame):
         href = event.URL
         if href.startswith("help:"):
             self.__display_help(href[5:])
+        elif href.startswith("file:"):
+            self.__display_help(href[8:])
         elif href.startswith("loadexample:"):
             self.__load_example_pipeline(href[12:])
         elif href.startswith("pref:"):
@@ -118,7 +120,10 @@ class WelcomeFrame(wx.Frame):
         if href == "welcome":
             self.__display_welcome()
             return
-        html_path = self.href_to_help[href]
+        if href in self.href_to_help:
+            html_path = self.href_to_help[href]
+        else:
+            html_path = href
         with open(os.path.join(os.path.dirname(__file__), html_path)) as fp:
             template = jinja2.Template(fp.read())
             self.content.SetPage(

--- a/cellprofiler/gui/_welcome_frame.py
+++ b/cellprofiler/gui/_welcome_frame.py
@@ -107,7 +107,8 @@ class WelcomeFrame(wx.Frame):
         if href.startswith("help:"):
             self.__display_help(href[5:])
         elif href.startswith("file:"):
-            self.__display_help(href[8:])
+            # Ignore incorrect navigation calls on Mac
+            return
         elif href.startswith("loadexample:"):
             self.__load_example_pipeline(href[12:])
         elif href.startswith("pref:"):


### PR DESCRIPTION
WebView on OSX has a habit of trying to affix "file://" to our custom navigation calls. The correct navigation event is sent first, then the dodgy "file://" events are also sent. Ignoring these events appears to fix it.

Fixes #4219