### PR TITLE
Add automatic update notifications

### DIFF
--- a/cellprofiler/gui/app.py
+++ b/cellprofiler/gui/app.py
@@ -55,13 +55,14 @@ class App(wx.App):
         super(App, self).__init__(*args, **kwargs)
 
     def OnInit(self):
-        from .cpframe import CPFrame
-        from cellprofiler import __version__
         if platform.system() == "Windows":
             import locale
-            # Windows system locale names follow the pattern "en-US", but python expects "en_US".
-            # So we set this up properly using the valid name populated by wx
-            locale.setlocale(locale.LC_ALL, wx.GetLocale().Name)
+            # Need to startup wx in English, otherwise C++ can't load images.
+            self.locale = wx.Locale(wx.LANGUAGE_ENGLISH)
+            # Ensure Python uses the same locale as wx
+            locale.setlocale(locale.LC_ALL, self.locale.GetName())
+        from .cpframe import CPFrame
+        from cellprofiler import __version__
 
         # This import is needed to populate the modules list
         import cellprofiler_core.modules

--- a/cellprofiler/gui/app.py
+++ b/cellprofiler/gui/app.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 import platform
+import sys
 
 import sentry_sdk
 import wx
@@ -74,6 +75,10 @@ class App(wx.App):
         self.SetTopWindow(self.frame)
 
         self.frame.Show()
+
+        if hasattr(sys, "frozen"):
+            from cellprofiler.gui.checkupdate import check_update
+            check_update(self.frame)
 
         if get_telemetry_prompt():
             telemetry = Telemetry()

--- a/cellprofiler/gui/app.py
+++ b/cellprofiler/gui/app.py
@@ -57,6 +57,11 @@ class App(wx.App):
     def OnInit(self):
         from .cpframe import CPFrame
         from cellprofiler import __version__
+        if platform.system() == "Windows":
+            import locale
+            # Windows system locale names follow the pattern "en-US", but python expects "en_US".
+            # So we set this up properly using the valid name populated by wx
+            locale.setlocale(locale.LC_ALL, wx.GetLocale().Name)
 
         # This import is needed to populate the modules list
         import cellprofiler_core.modules

--- a/cellprofiler/gui/checkupdate.py
+++ b/cellprofiler/gui/checkupdate.py
@@ -1,34 +1,56 @@
-from cellprofiler import __version__ as current_version
-
+import datetime
 import requests
 import wx
 
+from cellprofiler_core.preferences import get_check_update, set_check_update, get_check_update_bool
+from cellprofiler import __version__ as current_version
 
-def check_update(parent):
-    try:
-        response = requests.get("https://api.github.com/repos/cellprofiler/cellprofiler/releases/latest")
-    except:
-        print("CellProfiler was unable to connect to GitHub to check for updates")
+
+def check_update(parent, force=False):
+    if not force and not check_date():
         return
-    response = response.json()
-    if 'name' in response:
-        latest_version = response['name'][1:]
-        if current_version < latest_version:
-            print("You'd better update dude")
-            body_text = response['body']
-            if len(body_text) > 100:
-                body_text = body_text[:100] + "..."
-            elif len(body_text) == 0:
-                body_text = "No information available"
-            show_message(parent, latest_version, body_text)
+    try:
+        response = requests.get("https://api.github.com/repos/cellprofiler/cellprofiler/releases/latest", timeout=0.25)
+    except:
+        response = False
+        message = "CellProfiler was unable to connect to GitHub to check for updates"
+    if response:
+        status = response.status_code
+        response = response.json()
+        if status == 200 and 'name' in response:
+            latest_version = response['name'][1:]
+            if current_version < latest_version or len(current_version) != len(latest_version):
+                body_text = response['body']
+                if len(body_text) > 100:
+                    body_text = body_text[:100] + "..."
+                elif len(body_text) == 0:
+                    body_text = "No information available"
+                show_message(parent, latest_version, body_text)
+                return
+            else:
+                message = "CellProfiler is up-to-date"
+                if get_check_update() != "Disabled":
+                    set_check_update(datetime.date.today().strftime("%Y%m%d"))
+                if not force:
+                    return
+        elif status == 200:
+            message = "Unable to read data from GitHub, API may have changed."
         else:
-            print("CellProfiler is up-to-date")
+            message = "Invalid response from GitHub server, site may be down."
+    if force:
+        dlg = wx.MessageDialog(
+            parent,
+            message,
+            caption="Check for updates",
+            style=wx.ICON_INFORMATION | wx.OK,
+        )
+        dlg.ShowModal()
     else:
-        print("Unable to read data from GitHub, API may have changed.")
+        print(message)
 
 
 def show_message(parent, version, blurb):
-    message = f"""A new version of CellProfiler is available:\nVersion {version}\n
+    message = f"""A new CellProfiler release is available:\n\nVersion {version}\n
 Would you like to visit the download page?"""
     dlg = wx.RichMessageDialog(
         parent,
@@ -37,9 +59,26 @@ Would you like to visit the download page?"""
         style=wx.YES_NO | wx.CENTRE | wx.ICON_INFORMATION,
     )
     dlg.ShowDetailedText(f"Release Notes:\n{blurb}")
-    dlg.ShowCheckBox("Check for updates on startup", checked=True)
+    dlg.ShowCheckBox("Check for updates on startup", checked=get_check_update_bool())
     response = dlg.ShowModal()
     if response == wx.ID_YES:
         wx.LaunchDefaultBrowser("https://cellprofiler.org/releases")
+    if not dlg.IsCheckBoxChecked():
+        set_check_update("Disabled")
     else:
-        return
+        set_check_update(datetime.date.today().strftime("%Y%m%d"))
+
+
+def check_date():
+    last_checked = get_check_update()
+    if last_checked == "Disabled":
+        # Updating is disabled
+        return False
+    elif last_checked == "Never":
+        return True
+    today = datetime.date.today()
+    last_checked = datetime.datetime.strptime(last_checked, "%Y%m%d").date()
+    if (last_checked - today).days >= 7:
+        return True
+    else:
+        return False

--- a/cellprofiler/gui/checkupdate.py
+++ b/cellprofiler/gui/checkupdate.py
@@ -1,0 +1,45 @@
+from cellprofiler import __version__ as current_version
+
+import requests
+import wx
+
+
+def check_update(parent):
+    try:
+        response = requests.get("https://api.github.com/repos/cellprofiler/cellprofiler/releases/latest")
+    except:
+        print("CellProfiler was unable to connect to GitHub to check for updates")
+        return
+    response = response.json()
+    if 'name' in response:
+        latest_version = response['name'][1:]
+        if current_version < latest_version:
+            print("You'd better update dude")
+            body_text = response['body']
+            if len(body_text) > 100:
+                body_text = body_text[:100] + "..."
+            elif len(body_text) == 0:
+                body_text = "No information available"
+            show_message(parent, latest_version, body_text)
+        else:
+            print("CellProfiler is up-to-date")
+    else:
+        print("Unable to read data from GitHub, API may have changed.")
+
+
+def show_message(parent, version, blurb):
+    message = f"""A new version of CellProfiler is available:\nVersion {version}\n
+Would you like to visit the download page?"""
+    dlg = wx.RichMessageDialog(
+        parent,
+        message,
+        caption="CellProfiler Update Available",
+        style=wx.YES_NO | wx.CENTRE | wx.ICON_INFORMATION,
+    )
+    dlg.ShowDetailedText(f"Release Notes:\n{blurb}")
+    dlg.ShowCheckBox("Check for updates on startup", checked=True)
+    response = dlg.ShowModal()
+    if response == wx.ID_YES:
+        wx.LaunchDefaultBrowser("https://cellprofiler.org/releases")
+    else:
+        return

--- a/cellprofiler/gui/help/menu.py
+++ b/cellprofiler/gui/help/menu.py
@@ -21,6 +21,8 @@ class Menu(cellprofiler.gui.menu.Menu):
             event_fn=lambda _: self.frame.show_welcome_screen(True),
         )
 
+        self.append("Search help...", event_fn=lambda _: self.__on_search_help())
+
         self.append("Online Manual", event_fn=self.__on_help_online_manual)
 
         self.AppendSeparator()
@@ -97,7 +99,7 @@ class Menu(cellprofiler.gui.menu.Menu):
 
         self.AppendSeparator()
 
-        self.append("Search help...", event_fn=lambda _: self.__on_search_help())
+        self.append("Check for updates", event_fn=self.find_update)
 
         self.append("About CellProfiler", event_fn=lambda _: self.about())
 
@@ -105,6 +107,10 @@ class Menu(cellprofiler.gui.menu.Menu):
     def about():
         info = AboutDialogInfo()
         wx.adv.AboutBox(info)
+
+    def find_update(self, event):
+        from cellprofiler.gui.checkupdate import check_update
+        check_update(self.frame, force=True)
 
     def __figure_menu(self):
         figure_menu = cellprofiler.gui.menu.Menu(self.frame)

--- a/cellprofiler/gui/preferences_dialog/_preferences_dialog.py
+++ b/cellprofiler/gui/preferences_dialog/_preferences_dialog.py
@@ -34,7 +34,9 @@ from cellprofiler_core.preferences import SPP_ALL
 from cellprofiler_core.preferences import TABLE_FONT_HELP
 from cellprofiler_core.preferences import TEMP_DIR_HELP
 from cellprofiler_core.preferences import TERTIARY_OUTLINE_COLOR_HELP
+from cellprofiler_core.preferences import UPDATER_HELP
 from cellprofiler_core.preferences import default_max_workers
+from cellprofiler_core.preferences import get_check_update_bool
 from cellprofiler_core.preferences import get_default_colormap
 from cellprofiler_core.preferences import get_default_image_directory
 from cellprofiler_core.preferences import get_default_output_directory
@@ -61,6 +63,7 @@ from cellprofiler_core.preferences import get_tertiary_outline_color
 from cellprofiler_core.preferences import get_title_font_name
 from cellprofiler_core.preferences import get_title_font_size
 from cellprofiler_core.preferences import get_wants_pony
+from cellprofiler_core.preferences import set_check_update
 from cellprofiler_core.preferences import set_default_colormap
 from cellprofiler_core.preferences import set_default_image_directory
 from cellprofiler_core.preferences import set_default_output_directory
@@ -309,6 +312,13 @@ class PreferencesDialog(wx.Dialog):
                 set_telemetry,
                 CHOICE,
                 SHOW_TELEMETRY_HELP,
+            ],
+            [
+                "Automatically check for updates",
+                get_check_update_bool,
+                set_check_update,
+                CHOICE,
+                UPDATER_HELP,
             ],
             [
                 "Default Input Folder",


### PR DESCRIPTION
This PR adds a system to automatically check for and notify the user of updates when running frozen builds of CellProfiler.

A setting has been added to the preferences dialog (default:Enabled), and a "Help-->Check For Updates" menu option has been added to allow users with this function disabled to force an update check.

Once per week on app startup, this system will check the version of the latest GitHub release and show the notification below if they're running an older version. Date of the last update check is stored within the config key.

![UpdatePrompt](https://user-images.githubusercontent.com/26802537/93030031-e79b7280-f5ed-11ea-99c5-214fb9571981.png)

I've added a bit of code to catch errors which could happen with the web request. If running from startup errors are printed to the console. If the user activated the check using the menu option instead they'll get a dialog with the relevant message, including if CellProfiler was up-to-date.

This system does assume the version will take the format "v0.0.0", I expect we won't be changing that anyway. Pre-releases and drafts are excluded from the update search.

Requires cellprofiler/core#51