### PR TITLE
Fix removal of WSV measurement rows

### DIFF
--- a/cellprofiler/gui/workspace_view/_workspace_view.py
+++ b/cellprofiler/gui/workspace_view/_workspace_view.py
@@ -344,34 +344,40 @@ class WorkspaceView:
         row = WorkspaceViewMeasurementRow(
             panel, self.m_grid, row_idx, lambda: self.on_measurement_changed(mr[0])
         )
+        bitmap = wx.ArtProvider.GetBitmap(wx.ART_DELETE, wx.ART_TOOLBAR, (16, 16))
+        row.remove_button = wx.BitmapButton(panel, bitmap=bitmap)
         mr.append(row)
         self.measurement_rows.append(row)
-        bitmap = wx.ArtProvider.GetBitmap(wx.ART_DELETE, wx.ART_TOOLBAR, (16, 16))
 
-        remove_button = wx.BitmapButton(panel, bitmap=bitmap)
         self.m_grid.Add(
-            remove_button,
+            row.remove_button,
             (row_idx, C_REMOVE),
             flag=wx.ALIGN_CENTER_HORIZONTAL | wx.ALIGN_TOP,
         )
-        remove_button.Bind(
-            wx.EVT_BUTTON, lambda event: self.remove_measurement_row(row, remove_button)
+        row.remove_button.Bind(
+            wx.EVT_BUTTON, lambda event: self.remove_measurement_row(row, row.remove_button)
         )
         if not can_delete:
-            remove_button.Hide()
+            row.remove_button.Hide()
         row.update(self.workspace)
 
     def remove_measurement_row(self, measurement_row, remove_button):
         if measurement_row in self.measurement_rows:
             idx = self.measurement_rows.index(measurement_row)
-            measurement_row.destroy(self.m_grid)
-            self.m_grid.Remove(remove_button)
+            measurement_row.destroy()
             remove_button.Destroy()
             self.measurement_rows.remove(measurement_row)
             for ii in range(idx, len(self.measurement_rows)):
-                for j in (C_CHOOSER, C_COLOR, C_SHOW, C_REMOVE):
-                    item = self.m_grid.FindItemAtPosition(wx.GBPosition(ii + 1, j))
-                    self.m_grid.SetItemPosition(item, (ii, j))
+                m_row = self.measurement_rows[ii]
+                for j, control in enumerate(
+                        (
+                                m_row.choice_panel,
+                                m_row.font_button,
+                                m_row.show_ctrl,
+                                m_row.remove_button,
+                        )
+                ):
+                    self.m_grid.SetItemPosition(control, (ii + 1, j))
             self.layout()
             self.redraw()
 

--- a/cellprofiler/gui/workspace_view/_workspace_view_measurement_row.py
+++ b/cellprofiler/gui/workspace_view/_workspace_view_measurement_row.py
@@ -242,10 +242,7 @@ class WorkspaceViewMeasurementRow:
         self.update_choices(self.category_choice, sorted(categories))
         self.update_choices(self.measurement_choice, sorted(measurements))
 
-    def destroy(self, grid_sizer):
-        grid_sizer.Remove(self.choice_panel)
-        grid_sizer.Remove(self.font_button)
-        grid_sizer.Remove(self.show_ctrl)
+    def destroy(self):
         self.object_choice.Destroy()
         self.category_choice.Destroy()
         self.measurement_choice.Destroy()


### PR DESCRIPTION
Fix #4257 

Removing measurement rows uses a different function from the other WSV artist types due to the need for multiple comboboxes. It wasn't successfully rearranging the grid when a measurements row was removed from the middle of the list (moving the subsequent items up was erroring out). I've revised this function to operate more similarly to the code used by the other artist types.