### PR TITLE
Handle unsupported system locale settings

### DIFF
--- a/cellprofiler/gui/app.py
+++ b/cellprofiler/gui/app.py
@@ -61,7 +61,11 @@ class App(wx.App):
             # Need to startup wx in English, otherwise C++ can't load images.
             self.locale = wx.Locale(wx.LANGUAGE_ENGLISH)
             # Ensure Python uses the same locale as wx
-            locale.setlocale(locale.LC_ALL, self.locale.GetName())
+            try:
+                locale.setlocale(locale.LC_ALL, self.locale.GetName())
+            except:
+                print(f"Python rejected the system locale detected by WX ('{self.locale.GetName()}').\n"
+                      "This shouldn't cause problems, but please let us know if you encounter errors.")
         from .cpframe import CPFrame
         from cellprofiler import __version__
 


### PR DESCRIPTION
The last locale fix resolved launch problems for the vast majority of machines, but there appear to be rare circumstances where Python rejects whichever locale wx passed forwards. These machines are still setting wx locale without problems, which is what caused the launch issues. Having wx and python's locale precisely matched was more of a best practice than something essential, so I've moved it into a try block which will log the problem locale name if it does error out.