### PR TITLE
Fix Window menu item population on Windows

### DIFF
--- a/cellprofiler/gui/cpframe.py
+++ b/cellprofiler/gui/cpframe.py
@@ -823,6 +823,8 @@ class CPFrame(wx.Frame):
             "Open the plate viewer to inspect the images in the current workspace",
         )
 
+        if sys.platform == "win32":
+            self.__menu_window.AppendSeparator()
 
         self.__menu_help = Menu(self)
 

--- a/cellprofiler/gui/figure/_figure.py
+++ b/cellprofiler/gui/figure/_figure.py
@@ -195,7 +195,7 @@ class Figure(wx.Frame):
                 parent_menu_bar = None
             if parent_menu_bar is not None and isinstance(parent_menu_bar, wx.MenuBar):
                 for menu, label in parent_menu_bar.GetMenus():
-                    if label == "Window":
+                    if "Window" in label:
                         menu_ids = [menu_item.Id for menu_item in menu.MenuItems]
                         for window_id in WINDOW_IDS + [None]:
                             if window_id not in menu_ids:


### PR DESCRIPTION
The "Window" menu used to contain a list of open figure windows, but stopped working in CP4. Turns out the assigned menu label in WX4 is actually "&Window", so the previous check didn't catch it. I've just made the search for it less strict.