### PR TITLE
Fix NamesAndTypes "Add single image" functionality

### DIFF
--- a/cellprofiler/gui/module_view/_module_view.py
+++ b/cellprofiler/gui/module_view/_module_view.py
@@ -1574,6 +1574,7 @@ class ModuleView:
                 if url is not None:
                     value = v.build(url)
                     self.on_value_change(v, control, value, event)
+                    url_control.Value = url2pathname(v.value)
 
             browse_button.Bind(wx.EVT_BUTTON, on_button)
         else:

--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -2203,6 +2203,8 @@ class PipelineController(object):
                 sizer.Add(wx.StaticText(dlg, label=instructions), 0, wx.EXPAND)
                 sizer.AddSpacer(2)
             old_parent = self.__path_list_ctrl.Parent
+            old_sizer = self.__path_list_ctrl.GetContainingSizer()
+            old_sizer.Detach(self.__path_list_ctrl)
             self.__path_list_ctrl.Reparent(dlg)
             try:
                 sizer.Add(self.__path_list_ctrl, 1, wx.EXPAND)
@@ -2226,6 +2228,7 @@ class PipelineController(object):
                     cellprofiler.gui.pathlist.EVT_PLC_SELECTION_CHANGED, on_plc_change
                 )
                 result = dlg.ShowModal()
+                sizer.Detach(self.__path_list_ctrl)
                 self.__path_list_ctrl.Unbind(
                     cellprofiler.gui.pathlist.EVT_PLC_SELECTION_CHANGED
                 )
@@ -2235,8 +2238,11 @@ class PipelineController(object):
                     )
                     return None if len(paths) == 0 else paths[0]
                 return None
+            except Exception as e:
+                print("Unable to build file selection panel", e)
             finally:
                 self.__path_list_ctrl.Reparent(old_parent)
+                old_sizer.Insert(0, self.__path_list_ctrl)
 
     def add_urls(self, urls):
         """Add URLS to the pipeline"""

--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -2242,7 +2242,7 @@ class PipelineController(object):
                 print("Unable to build file selection panel", e)
             finally:
                 self.__path_list_ctrl.Reparent(old_parent)
-                old_sizer.Insert(0, self.__path_list_ctrl)
+                old_sizer.Insert(0, self.__path_list_ctrl, 1, wx.EXPAND | wx.ALL)
 
     def add_urls(self, urls):
         """Add URLS to the pipeline"""


### PR DESCRIPTION
Fixes #4269

Managed to fix the file selection popup, probably worth checking on OSX too. Our previous system of pulling out the file list widget from Images wasn't compatible with WX4, we now have to remove a widget from any sizers before trying to move it.

I also added a printout of any Exceptions that do occur when running this, to help flag future errors.

To test:
- Load example pipeline
- In NamesAndTypes, hit the "add a single image" button.
- Hit "browse" to select a file.
- A dialog containing the file list should appear, containing the full file list.
- Select one file and hit "OK".
- Displayed file path should update.
- Look at the Images module and make sure that the file list widget was put back correctly.
- Return to NamesAndTypes and check that the selected file was remembered properly.