### PR TITLE
Trim extra masking on Norm sliders

### DIFF
--- a/cellprofiler/gui/figure/_figure.py
+++ b/cellprofiler/gui/figure/_figure.py
@@ -1030,6 +1030,7 @@ class Figure(wx.Frame):
                     max=1000,
                     limited=True,
                     size=wx.Size(35, 22),
+                    integerWidth=4,
                     fractionWidth=1,
                     autoSize=False,
                     style=wx.TE_CENTRE,


### PR DESCRIPTION
Fixes #4268, for the most part.

WX for some reason only has "masked" widgets for input of floats, meaning it fills unused space with empty characters. On OSX this pushes the text out of the visible area.

It was defaulting to 10 characters of space before the decimal, so I've trimmed that down to 4 (since the max allowed value is 1000). If that still doesn't fit sensibly let me know and I'll widen the entry box a bit.