### PR TITLE
Set multichannel plot to subplot_imshow_color in Resize module

### DIFF
--- a/cellprofiler/modules/resize.py
+++ b/cellprofiler/modules/resize.py
@@ -429,11 +429,11 @@ resized with the same settings as the first image.""",
             )
         ):
             if multichannel:
-                figure.subplot_imshow(
+                figure.subplot_imshow_color(
                     0, i, input_image_pixels, title=input_image_name,
                 )
 
-                figure.subplot_imshow(
+                figure.subplot_imshow_color(
                     1, i, output_image_pixels, title=output_image_name,
                 )
             else:


### PR DESCRIPTION
I found that the resize module was still using the old `subplot_imshow` command that fails if a multichannel image has >3 channels for display. This should fix this.

Or was there a specific reason this used `subplot_imshow` only?