### PR TITLE
Add custom percentile calculation to MeasureImageIntensity

### DIFF
--- a/cellprofiler/modules/measureimageintensity.py
+++ b/cellprofiler/modules/measureimageintensity.py
@@ -4,6 +4,7 @@ import numpy
 from cellprofiler_core.constants.measurement import COLTYPE_FLOAT
 from cellprofiler_core.module import Module
 from cellprofiler_core.setting import Binary, ValidationError, Divider
+from cellprofiler_core.setting.text import Text
 from cellprofiler_core.setting.subscriber import (
     LabelListSubscriber,
     ImageListSubscriber,
@@ -62,6 +63,8 @@ Measurements made by this module
    75% of the pixels in the object have lower values.
 -  *TotalArea:* Number of pixels measured, e.g., the area of the image
    excluding masked regions.
+-  *Percentile_N:* The intensity value of the pixel for which
+   N% of the pixels in the object have lower values.
 
 """.format(
     **{"HELP_ON_MEASURING_INTENSITIES": _help.HELP_ON_MEASURING_INTENSITIES}
@@ -116,7 +119,7 @@ ALL_MEASUREMENTS = [
 class MeasureImageIntensity(Module):
     module_name = "MeasureImageIntensity"
     category = "Measurement"
-    variable_revision_number = 3
+    variable_revision_number = 4
 
     def create_settings(self):
         """Create the settings & name the module"""
@@ -144,6 +147,25 @@ class MeasureImageIntensity(Module):
             doc="""Select the object sets whose intensity you want to measure.""",
         )
 
+        self.wants_percentiles = Binary(
+            text="Calculate custom percentiles",
+            value=False,
+            doc="""Choose whether to enable measurement of custom percentiles.
+            
+            Note that the Upper and Lower Quartile measurements are automatically calculated by this module,
+            representing the 25th and 75th percentiles.
+            """,
+        )
+
+        self.percentiles = Text(
+            text="Specify percentiles to measure",
+            value="10,90",
+            doc="""Specify the percentiles to measure. Values should range from 0-100 inclusive and be whole integers.
+            Multiple values can be specified by seperating them with a comma,
+            eg. "10,90" will measure the 10th and 90th percentiles.
+            """,
+        )
+
     def validate_module(self, pipeline):
         """Make sure chosen objects and images are selected only once"""
         images = set()
@@ -165,21 +187,47 @@ class MeasureImageIntensity(Module):
                         "%s has already been selected" % object_name, object_name
                     )
                 objects.add(object_name)
+        if self.wants_percentiles:
+            percentiles = self.percentiles.value.replace(" ", "")
+            if len(percentiles) == 0:
+                raise ValidationError(
+                    "No percentiles have been specified", self.percentiles
+                )
+            for percentile in percentiles.split(","):
+                if percentile == "":
+                    continue
+                elif percentile.isdigit():
+                    percentile = int(percentile)
+                else:
+                    raise ValidationError(
+                        "Percentile was not a valid integer", self.percentiles
+                    )
+                if not 0 <= percentile <= 100:
+                    raise ValidationError(
+                        "Percentile not within valid range (0-100)", self.percentiles
+                    )
 
     def settings(self):
-        result = [self.images_list, self.wants_objects, self.objects_list]
+        result = [self.images_list, self.wants_objects, self.objects_list, self.wants_percentiles, self.percentiles]
         return result
 
     def visible_settings(self):
         result = [self.images_list, self.wants_objects]
         if self.wants_objects:
             result += [self.objects_list]
+        result += [self.wants_percentiles]
+        if self.wants_percentiles:
+            result += [self.percentiles]
         return result
 
     def run(self, workspace):
         """Perform the measurements on the image sets"""
         col_labels = ["Image", "Masking object", "Feature", "Value"]
         statistics = []
+        if self.wants_percentiles:
+            percentiles = self.get_percentiles(self.percentiles.value, stop=True)
+        else:
+            percentiles = None
         for im in self.images_list.value:
             image = workspace.image_set.get_image(im, must_be_grayscale=True)
             input_pixels = image.pixel_data
@@ -204,7 +252,7 @@ class MeasureImageIntensity(Module):
                     else:
                         pixels = input_pixels[objects.segmented != 0]
                     statistics += self.measure(
-                        pixels, im, object_set, measurement_name, workspace
+                        pixels, im, object_set, measurement_name, workspace, percentiles=percentiles
                     )
             else:
                 if image.has_mask:
@@ -212,7 +260,7 @@ class MeasureImageIntensity(Module):
                 else:
                     pixels = input_pixels
                 statistics += self.measure(
-                    pixels, im, None, measurement_name, workspace
+                    pixels, im, None, measurement_name, workspace, percentiles=percentiles
                 )
         workspace.display_data.statistics = statistics
         workspace.display_data.col_labels = col_labels
@@ -226,7 +274,7 @@ class MeasureImageIntensity(Module):
             col_labels=workspace.display_data.col_labels,
         )
 
-    def measure(self, pixels, image_name, object_name, measurement_name, workspace):
+    def measure(self, pixels, image_name, object_name, measurement_name, workspace, percentiles=None):
         """Perform measurements on an array of pixels
         pixels - image pixel data, masked to objects if applicable
         image_name - name of the current input image
@@ -235,6 +283,7 @@ class MeasureImageIntensity(Module):
         workspace - has all the details for current image set
         """
         pixel_count = numpy.product(pixels.shape)
+        percentile_measures = {}
         if pixel_count == 0:
             pixel_sum = 0
             pixel_mean = 0
@@ -246,6 +295,9 @@ class MeasureImageIntensity(Module):
             pixel_pct_max = 0
             pixel_lower_qrt = 0
             pixel_upper_qrt = 0
+            if percentiles:
+                for percentile in percentiles:
+                    percentile_measures[percentile] = 0
         else:
             pixels = pixels.flatten()
             pixels = pixels[
@@ -263,9 +315,13 @@ class MeasureImageIntensity(Module):
             pixel_pct_max = (
                 100.0 * float(numpy.sum(pixels == pixel_max)) / float(pixel_count)
             )
-            sorted_pixel_data = sorted(pixels)
-            pixel_lower_qrt = sorted_pixel_data[int(len(sorted_pixel_data) * 0.25)]
-            pixel_upper_qrt = sorted_pixel_data[int(len(sorted_pixel_data) * 0.75)]
+            pixel_lower_qrt, pixel_upper_qrt = numpy.percentile(pixels, [25, 75])
+
+            if percentiles:
+                percentile_results = numpy.percentile(pixels, percentiles)
+                for percentile, res in zip(percentiles, percentile_results):
+                    percentile_measures[percentile] = res
+
 
         m = workspace.measurements
         m.add_image_measurement(F_TOTAL_INTENSITY % measurement_name, pixel_sum)
@@ -279,14 +335,8 @@ class MeasureImageIntensity(Module):
         m.add_image_measurement(F_PERCENT_MAXIMAL % measurement_name, pixel_pct_max)
         m.add_image_measurement(F_LOWER_QUARTILE % measurement_name, pixel_lower_qrt)
         m.add_image_measurement(F_UPPER_QUARTILE % measurement_name, pixel_upper_qrt)
-        return [
-            [
-                image_name,
-                object_name if self.wants_objects.value else "",
-                feature_name,
-                str(value),
-            ]
-            for feature_name, value in (
+
+        all_features = [
                 ("Total intensity", pixel_sum),
                 ("Mean intensity", pixel_mean),
                 ("Median intensity", pixel_median),
@@ -298,26 +348,44 @@ class MeasureImageIntensity(Module):
                 ("Lower quartile", pixel_lower_qrt),
                 ("Upper quartile", pixel_upper_qrt),
                 ("Total area", pixel_count),
-            )
+        ]
+        for percentile, value in percentile_measures.items():
+            m.add_image_measurement(f"Intensity_Percentile_{percentile}_{measurement_name}", value)
+            all_features.append((f"Percentile {percentile}", value))
+
+        return [
+            [
+                image_name,
+                object_name if self.wants_objects.value else "",
+                feature_name,
+                str(value),
+            ]
+            for feature_name, value in all_features
         ]
 
     def get_measurement_columns(self, pipeline):
         """Return column definitions for measurements made by this module"""
         columns = []
+        col_defs = [
+            (F_TOTAL_INTENSITY, COLTYPE_FLOAT),
+            (F_MEAN_INTENSITY, COLTYPE_FLOAT),
+            (F_MEDIAN_INTENSITY, COLTYPE_FLOAT),
+            (F_STD_INTENSITY, COLTYPE_FLOAT),
+            (F_MAD_INTENSITY, COLTYPE_FLOAT),
+            (F_MIN_INTENSITY, COLTYPE_FLOAT),
+            (F_MAX_INTENSITY, COLTYPE_FLOAT),
+            (F_TOTAL_AREA, "integer"),
+            (F_PERCENT_MAXIMAL, COLTYPE_FLOAT),
+            (F_LOWER_QUARTILE, COLTYPE_FLOAT),
+            (F_UPPER_QUARTILE, COLTYPE_FLOAT),
+        ]
+        if self.wants_percentiles:
+            percentiles = self.get_percentiles(self.percentiles.value, stop=False)
+            for percentile in percentiles:
+                col_defs.append((f"Intensity_Percentile_{percentile}_%s", COLTYPE_FLOAT))
+
         for im in self.images_list.value:
-            for feature, coltype in (
-                (F_TOTAL_INTENSITY, COLTYPE_FLOAT),
-                (F_MEAN_INTENSITY, COLTYPE_FLOAT),
-                (F_MEDIAN_INTENSITY, COLTYPE_FLOAT),
-                (F_STD_INTENSITY, COLTYPE_FLOAT),
-                (F_MAD_INTENSITY, COLTYPE_FLOAT),
-                (F_MIN_INTENSITY, COLTYPE_FLOAT),
-                (F_MAX_INTENSITY, COLTYPE_FLOAT),
-                (F_TOTAL_AREA, "integer"),
-                (F_PERCENT_MAXIMAL, COLTYPE_FLOAT),
-                (F_LOWER_QUARTILE, COLTYPE_FLOAT),
-                (F_UPPER_QUARTILE, COLTYPE_FLOAT),
-            ):
+            for feature, coltype in col_defs:
                 if self.wants_objects:
                     for object_set in self.objects_list.value:
                         measurement_name = im + "_" + object_set
@@ -335,14 +403,24 @@ class MeasureImageIntensity(Module):
 
     def get_measurements(self, pipeline, object_name, category):
         if object_name == "Image" and category == "Intensity":
-            return ALL_MEASUREMENTS
+            measures = ALL_MEASUREMENTS
+            if self.wants_percentiles:
+                percentiles = self.get_percentiles(self.percentiles.value, stop=False)
+                for i in percentiles:
+                    measures.append(f"Percentile_{i}")
+            return measures
         return []
 
     def get_measurement_images(self, pipeline, object_name, category, measurement):
+        measures = ALL_MEASUREMENTS
+        if self.wants_percentiles:
+            percentiles = self.get_percentiles(self.percentiles.value, stop=False)
+            for i in percentiles:
+                measures.append(f"Percentile_{i}")
         if (
             object_name == "Image"
             and category == "Intensity"
-            and measurement in ALL_MEASUREMENTS
+            and measurement in measures
         ):
             result = []
             for im in self.images_list.value:
@@ -382,7 +460,24 @@ class MeasureImageIntensity(Module):
                     "copy of the module.",
                 )
             variable_revision_number = 3
+        if variable_revision_number == 3:
+            setting_values += ["No", "10,90"]
+            variable_revision_number = 4
         return setting_values, variable_revision_number
 
     def volumetric(self):
         return True
+
+    @staticmethod
+    def get_percentiles(percentiles_list, stop=False):
+        # Converts a comma-seperated string of percentiles into a sorted, deduplicated list.
+        # "stop" parameter determines whether to raise an error or ignore invalid values.
+        percentiles = []
+        for percentile in percentiles_list.replace(" ", "").split(","):
+            if percentile == "":
+                continue
+            elif percentile.isdigit() and 0 <= int(percentile) <= 100:
+                percentiles.append(int(percentile))
+            elif stop:
+                raise ValueError(f"Percentile '{percentile}' is not a valid integer between 0 and 100")
+        return sorted(set(percentiles))


### PR DESCRIPTION
Resolves #4283 

I've added a setting to MeasureImageIntensity to allow the user to specify custom percentiles that they'd like to calculate. This is a bit fiddly with all the measurement generators but I think I've got it working and properly validated. Users enable the new option then enter their percentiles as a comma-separated string, e.g. "10, 20, 30" would do the 10th, 20th and 30th percentiles.

I also switched the Upper and Lower Quartile calculations over to the numpy implementation, which is much faster. Results were identical in my testing. I opted to keep these two (functionally the 25th and 75th percentiles) separate from the custom ones, partly because we want them enabled by default, but mostly because their names are pre-defined and I don't want to change what we call them in a minor update. Custom percentiles have their measurements names generated as `Intensity_Percentile_{N}_Image`.

