### PR TITLE
Remove extra URL box from directory widget

### DIFF
--- a/cellprofiler/gui/module_view/_module_view.py
+++ b/cellprofiler/gui/module_view/_module_view.py
@@ -1488,13 +1488,8 @@ class ModuleView:
             ):
                 custom_label.Label = "Sub-folder:"
             elif v.dir_choice == URL_FOLDER_NAME:
-                if v.support_urls:
-                    custom_label.Label = "URL:"
-                    custom_label.Show()
-                    custom_ctrl.Show()
-                else:
-                    custom_label.Hide()
-                    custom_ctrl.Hide()
+                custom_label.Hide()
+                custom_ctrl.Hide()
                 browse_ctrl.Hide()
             if custom_ctrl.Value != v.custom_path:
                 custom_ctrl.Value = v.custom_path


### PR DESCRIPTION
Alongside CellProfiler/core#60, fixes #4286

It looks like all modules which currently use `URL_FOLDER_NAME` as a directory option have an independent setting for specifying the URL of interest. They seem to ignore whatever is in the URL box provided by the directory widget, so I've removed this to reduce confusion.

CP3 appears to have had the same issue. Nonetheless since the custom path box appears to be ignored when in URL mode I think this shouldn't break anything.