### PR TITLE
Added ability to add port number to MySQL host.

### DIFF
--- a/cellprofiler/modules/exporttodatabase.py
+++ b/cellprofiler/modules/exporttodatabase.py
@@ -920,7 +920,12 @@ the *classification\_type* field.
         self.db_host = Text(
             text="Database host",
             value="",
-            doc="""Enter the address CP must contact to write to the database.""",
+            doc="""Enter the address CellProfiler must contact to write to the database.
+        
+Database port can also be specified in the format [host]:[port], e.g. "127.0.0.1:1234".
+        
+If not provided the default port of 3306 is used.
+            """,
         )
 
         self.db_user = Text(


### PR DESCRIPTION
Added a function that picks out the hostname and port number, if any, from the specified MySQL host.
Has to be in one of the following formats:
```
# IPv4 no port specified
192.168.1.10

# IPv4 with port specified
192.168.1.10:3306

# IPv6 no port specified
9001:0db8:85a3:0000:0000:8a2e:0370:7334

# IPv6 with port specified
[9001:0db8:85a3:0000:0000:8a2e:0370:7334]:3306
```