### PR TITLE
Add "Faster" Costes mode to MeasureColocalization

### DIFF
--- a/cellprofiler/modules/measurecolocalization.py
+++ b/cellprofiler/modules/measurecolocalization.py
@@ -130,7 +130,7 @@ F_COSTES_FORMAT = "Correlation_Costes_%s_%s"
 class MeasureColocalization(Module):
     module_name = "MeasureColocalization"
     category = "Measurement"
-    variable_revision_number = 6
+    variable_revision_number = 5
 
     def create_settings(self):
         """Create the initial settings for the module"""
@@ -1607,9 +1607,6 @@ Alternatively, you may want to disable these specific measurements entirely
             # Add costes mode switch
             setting_values += [M_ACCURATE]
             variable_revision_number = 5
-        if variable_revision_number == 5:
-            # Added "Faster" mode, no settings change
-            variable_revision_number = 6
         return setting_values, variable_revision_number
 
     def volumetric(self):


### PR DESCRIPTION
We noticed that performance of the Costes measurements in MeasureColocalization was extremely bad when working with 16-bit images. While potentially more accurate than the CP3 implementation, enabling them took module execution time from 1s to ~40s, which isn't very practical.

In this PR I've added a third mode to supplement the "Fast" mode we introduced in CP4, termed "Faster" mode. This method implements a sort-of bisection search to find the correct threshold quickly. To be precise, we progressively refine the window of possible thresholds using `min + (5/6 * width)` of the window. This prioritises the higher candidate thresholds and in practice seems to prevent us missing the target in unusual images where R value can vary wildly towards the lower threshold values.


In my testing we get the same results as linear mode. Performance on 8-bit images is about the same as the other modes, whereas 16-bit images are finished in a fraction of the time.

I've also moved the original code into a function to unify the image and per-object modes.

There's probably still a better way of finding the Costes threshold, but this seemed like an improvement.