### PR TITLE
Fix `--print-groups` by coercing np.int64 to int

### DIFF
--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -667,7 +667,12 @@ def print_groups(filename):
 
     groupings = m.get_groupings(metadata_tags)
 
-    json.dump(groupings, sys.stdout)
+    # Groupings are np.int64 which cannot be dumped to json
+    groupings_export = []
+    for g in groupings:
+        groupings_export.append((g[0], [int(imgnr) for imgnr in g[1]]))
+
+    json.dump(groupings_export, sys.stdout)
 
 
 def get_batch_commands(filename, n_per_job=1):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -64,3 +64,25 @@ def test_get_batch_commands_grouped_by_metadata_batch_data(resources, capsys):
     ]
 
     assert groups == expected_groups
+
+def test_print_groups(resources, capsys):
+    batch_file = os.path.join(resources, "batch_data.h5")
+
+    cellprofiler.__main__.print_groups(batch_file)
+
+    print_groups_str = capsys.readouterr()[0].strip()
+    print_groups = eval(print_groups_str)
+
+    assert len(print_groups) == 9
+
+    for i, g in enumerate(print_groups):
+        # Assert only 1 image per group
+        assert len(g[1]) == 1
+
+        imnr = g[1][0]
+        # Assert internal consistency between group metadata and image number
+        assert int(g[0]['ImageNumber']) == imnr
+        # Assert order correctly
+        assert i+1 == imnr
+
+


### PR DESCRIPTION
Json dumping used by `--print-groups` doesnt support the np.int64 returned by Measurement.get_groupings (Issue #4294).
This pull request coerces the image numbers to Python int before generating the json file..

I wasn't sure if this could also be better fixed within the Measurement.get_groupings function. But then it might be better internally  keep image numbers consistently as np.int64.

I now also covered `print_groups` with a test.