### PR TITLE
Issues/4261

### DIFF
--- a/cellprofiler/gui/cpframe.py
+++ b/cellprofiler/gui/cpframe.py
@@ -1029,11 +1029,7 @@ class CPFrame(wx.Frame):
     @staticmethod
     def __on_new_cp(event):
         if hasattr(sys, "frozen"):
-            os.system(
-                "open -na /Applications/CellProfiler-{}.app".format(
-                    cellprofiler.__version__
-                )
-            )
+            os.system("open -na /Applications/CellProfiler.app")
         else:
             os.system("python3 -m cellprofiler")
 

--- a/cellprofiler/gui/cpframe.py
+++ b/cellprofiler/gui/cpframe.py
@@ -1029,7 +1029,8 @@ class CPFrame(wx.Frame):
     @staticmethod
     def __on_new_cp(event):
         if hasattr(sys, "frozen"):
-            os.system("open -na /Applications/CellProfiler.app")
+            app_path = sys.executable.split("/Contents")[0]
+            os.system(f"open -na {app_path}")
         else:
             os.system("python3 -m cellprofiler")
 


### PR DESCRIPTION
Hopefully closes #4261. 

"File" -> "Open a new CP Window" previously assumed a specific location and name for CellProfiler.app. The new window wouldn't open if CellProfiler's path did not match the assumed directory. 

In this PR we first obtain the path of the currently running executable and then extract the application's path from it. A new CellProfiler window will open regardless of its name and directory. 