### PR TITLE
Add log normalisation option to Threshold

### DIFF
--- a/cellprofiler/modules/threshold.py
+++ b/cellprofiler/modules/threshold.py
@@ -1309,15 +1309,20 @@ staining.
             else:
                 setting_values += [centrosome.threshold.TM_OTSU]
             variable_revision_number = 10
+        used_log_otsu = False
         if variable_revision_number == 10:
             # Relabel method names
             if setting_values[3] == "RobustBackground":
                 setting_values[3] = TM_ROBUST_BACKGROUND
             elif setting_values[3] == "Minimum cross entropy":
                 setting_values[3] = TM_LI
+            if (setting_values[2] == TS_GLOBAL and setting_values[3] == TM_OTSU) or (
+                    setting_values[2] == TS_ADAPTIVE and setting_values[-1] == TM_OTSU):
+                if setting_values[9] == O_THREE_CLASS:
+                    used_log_otsu = True
             variable_revision_number = 11
         if variable_revision_number == 11:
-            setting_values.insert(10, False)
+            setting_values.insert(10, used_log_otsu)
             variable_revision_number = 12
         return setting_values, variable_revision_number
 

--- a/cellprofiler/modules/threshold.py
+++ b/cellprofiler/modules/threshold.py
@@ -40,7 +40,7 @@ from cellprofiler_core.constants.measurement import (
 )
 from cellprofiler_core.image import Image
 from cellprofiler_core.module import ImageProcessing
-from cellprofiler_core.setting import Measurement, ValidationError
+from cellprofiler_core.setting import Measurement, ValidationError, Binary
 from cellprofiler_core.setting.choice import Choice
 from cellprofiler_core.setting.range import FloatRange
 from cellprofiler_core.setting.text import Float, Integer
@@ -79,7 +79,7 @@ TECH_NOTE_ICON = "gear.png"
 class Threshold(ImageProcessing):
     module_name = "Threshold"
 
-    variable_revision_number = 11
+    variable_revision_number = 12
 
     def create_settings(self):
         super(Threshold, self).create_settings()
@@ -662,6 +662,27 @@ Often a good choice is some multiple of the largest expected object size.
                 **{"TS_ADAPTIVE": TS_ADAPTIVE}
             ),
         )
+        self.log_transform = Binary(
+            "Log transform before thresholding?",
+            value=False,
+            doc=f"""\
+*(Used only with the "{TM_LI}" and "{TM_OTSU}" methods)*
+
+Choose whether to log-transform intensity values before thresholding.
+The log transformation is applied before calculating the threshold, and the resulting 
+threshold values will be converted back onto a linear scale.
+
+Automatic thresholding is usually performed using histograms of pixel intensities. Areas of similar intensity, 
+such as positive staining, form a peak which is used to determine the threshold. Log transformation 
+helps to enhance peaks of intensity which are particularly wide. This helps to detect areas of staining 
+which have a wide dynamic range.
+
+In practice this tends to increase the sensitivity of the resulting threshold, which is useful when trying to detect 
+objects such as cells which are not stained uniformly throughout. You might want to enable this option if you're
+trying to detect autofluorescence or to pick up the entire cytoplasm of cells which contain smaller areas of intense 
+staining.
+""",
+        )
 
     @property
     def threshold_operation(self):
@@ -706,6 +727,9 @@ Often a good choice is some multiple of the largest expected object size.
         if self.threshold_scope == TS_ADAPTIVE:
             visible_settings += [self.adaptive_window_size]
 
+        if self.threshold_operation in (TM_LI, TM_OTSU):
+            visible_settings += [self.log_transform]
+
         return visible_settings
 
     def settings(self):
@@ -720,6 +744,7 @@ Often a good choice is some multiple of the largest expected object size.
             self.manual_threshold,
             self.thresholding_measurement,
             self.two_class_otsu,
+            self.log_transform,
             self.assign_middle_to_foreground,
             self.adaptive_window_size,
             self.lower_outlier_fraction,
@@ -821,6 +846,17 @@ Often a good choice is some multiple of the largest expected object size.
         return (blurred_image >= threshold) & mask, sigma
 
     def get_threshold(self, image, workspace, automatic=False):
+        need_transform = (
+                not automatic and
+                self.threshold_operation in (TM_LI, TM_OTSU) and
+                self.log_transform
+        )
+
+        if need_transform:
+            image_data, conversion_dict = centrosome.threshold.log_transform(image.pixel_data)
+        else:
+            image_data = image.pixel_data
+
         if self.threshold_operation == TM_MANUAL:
             return self.manual_threshold.value, self.manual_threshold.value, None
 
@@ -834,16 +870,23 @@ Often a good choice is some multiple of the largest expected object size.
             return self._correct_global_threshold(orig_threshold), orig_threshold, None
 
         elif self.threshold_scope.value == TS_GLOBAL or automatic:
-            return self.get_global_threshold(image, automatic=automatic)
+            th_corrected, th_original, th_guide = self.get_global_threshold(image_data, image.mask, automatic=automatic)
 
         elif self.threshold_scope.value == TS_ADAPTIVE:
-            return self.get_local_threshold(image)
-
+            th_corrected, th_original, th_guide = self.get_local_threshold(image_data, image.mask, image.volumetric)
         else:
             raise ValueError("Invalid thresholding settings")
 
-    def get_global_threshold(self, image, automatic=False):
-        image_data = image.pixel_data[image.mask]
+        if need_transform:
+            th_corrected = centrosome.threshold.inverse_log_transform(th_corrected, conversion_dict)
+            th_original = centrosome.threshold.inverse_log_transform(th_original, conversion_dict)
+            if th_guide is not None:
+                th_guide = centrosome.threshold.inverse_log_transform(th_guide, conversion_dict)
+
+        return th_corrected, th_original, th_guide
+
+    def get_global_threshold(self, image, mask, automatic=False):
+        image_data = image[mask]
 
         # Shortcuts - Check if image array is empty or all pixels are the same value.
         if len(image_data) == 0:
@@ -873,9 +916,9 @@ Often a good choice is some multiple of the largest expected object size.
             raise ValueError("Invalid thresholding settings")
         return self._correct_global_threshold(threshold), threshold, None
 
-    def get_local_threshold(self, image):
-        guide_threshold, _, _ = self.get_global_threshold(image)
-        image_data = numpy.where(image.mask, image.pixel_data, numpy.nan)
+    def get_local_threshold(self, image, mask, volumetric):
+        guide_threshold, _, _ = self.get_global_threshold(image, mask)
+        image_data = numpy.where(mask, image, numpy.nan)
 
         if len(image_data) == 0 or numpy.all(image_data == numpy.nan):
             local_threshold = numpy.zeros_like(image_data)
@@ -887,21 +930,21 @@ Often a good choice is some multiple of the largest expected object size.
             local_threshold = self._run_local_threshold(
                 image_data,
                 method=skimage.filters.threshold_li,
-                volumetric=image.volumetric,
+                volumetric=volumetric,
             )
         elif self.threshold_operation == TM_OTSU:
             if self.two_class_otsu.value == O_TWO_CLASS:
                 local_threshold = self._run_local_threshold(
                     image_data,
                     method=skimage.filters.threshold_otsu,
-                    volumetric=image.volumetric,
+                    volumetric=volumetric,
                 )
 
             elif self.two_class_otsu.value == O_THREE_CLASS:
                 local_threshold = self._run_local_threshold(
                     image_data,
                     method=skimage.filters.threshold_multiotsu,
-                    volumetric=image.volumetric,
+                    volumetric=volumetric,
                     nbins=128,
                 )
 
@@ -909,11 +952,11 @@ Often a good choice is some multiple of the largest expected object size.
             local_threshold = self._run_local_threshold(
                 image_data,
                 method=self.get_threshold_robust_background,
-                volumetric=image.volumetric,
+                volumetric=volumetric,
             )
 
         elif self.threshold_operation == TM_SAUVOLA:
-            image_data = numpy.where(image.mask, image.pixel_data, 0)
+            image_data = numpy.where(mask, image, 0)
             adaptive_window = self.adaptive_window_size.value
             if adaptive_window % 2 == 0:
                 adaptive_window += 1
@@ -1273,6 +1316,9 @@ Often a good choice is some multiple of the largest expected object size.
             elif setting_values[3] == "Minimum cross entropy":
                 setting_values[3] = TM_LI
             variable_revision_number = 11
+        if variable_revision_number == 11:
+            setting_values.insert(10, False)
+            variable_revision_number = 12
         return setting_values, variable_revision_number
 
     def upgrade_threshold_settings(self, setting_values):

--- a/tests/resources/modules/threshold/v12.pipeline
+++ b/tests/resources/modules/threshold/v12.pipeline
@@ -1,0 +1,75 @@
+CellProfiler Pipeline: http://www.cellprofiler.org
+Version:5
+DateRevision:406
+GitHash:
+ModuleCount:5
+HasImagePlaneDetails:False
+
+Images:[module_num:1|svn_version:'Unknown'|variable_revision_number:2|show_window:False|notes:['To begin creating your project, use the Images module to compile a list of files and/or folders that you want to analyze. You can also specify a set of rules to include only the desired files in your selected folders.']|batch_state:array([], dtype=uint8)|enabled:True|wants_pause:False]
+    :
+    Filter images?:Images only
+    Select the rule criteria:and (extension does isimage) (directory doesnot containregexp "[\\\\/]\\.")
+
+Metadata:[module_num:2|svn_version:'Unknown'|variable_revision_number:6|show_window:False|notes:['The Metadata module optionally allows you to extract information describing your images (i.e, metadata) which will be stored along with your measurements. This information can be contained in the file name and/or location, or in an external file.']|batch_state:array([], dtype=uint8)|enabled:True|wants_pause:False]
+    Extract metadata?:No
+    Metadata data type:Text
+    Metadata types:{}
+    Extraction method count:1
+    Metadata extraction method:Extract from file/folder names
+    Metadata source:File name
+    Regular expression to extract from file name:^(?P<Plate>.*)_(?P<Well>[A-P][0-9]{2})_s(?P<Site>[0-9])_w(?P<ChannelNumber>[0-9])
+    Regular expression to extract from folder name:(?P<Date>[0-9]{4}_[0-9]{2}_[0-9]{2})$
+    Extract metadata from:All images
+    Select the filtering criteria:and (file does contain "")
+    Metadata file location:Elsewhere...|
+    Match file and image metadata:[]
+    Use case insensitive matching?:No
+    Metadata file name:None
+    Does cached metadata exist?:No
+
+NamesAndTypes:[module_num:3|svn_version:'Unknown'|variable_revision_number:8|show_window:False|notes:['The NamesAndTypes module allows you to assign a meaningful name to each image by which other modules will refer to it.']|batch_state:array([], dtype=uint8)|enabled:True|wants_pause:False]
+    Assign a name to:All images
+    Select the image type:Grayscale image
+    Name to assign these images:DNA
+    Match metadata:[]
+    Image set matching method:Order
+    Set intensity range from:Image metadata
+    Assignments count:1
+    Single images count:0
+    Maximum intensity:255.0
+    Process as 3D?:No
+    Relative pixel spacing in X:1.0
+    Relative pixel spacing in Y:1.0
+    Relative pixel spacing in Z:1.0
+    Select the rule criteria:and (file does contain "")
+    Name to assign these images:DNA
+    Name to assign these objects:Cell
+    Select the image type:Grayscale image
+    Set intensity range from:Image metadata
+    Maximum intensity:255.0
+
+Groups:[module_num:4|svn_version:'Unknown'|variable_revision_number:2|show_window:False|notes:['The Groups module optionally allows you to split your list of images into image subsets (groups) which will be processed independently of each other. Examples of groupings include screening batches, microtiter plates, time-lapse movies, etc.']|batch_state:array([], dtype=uint8)|enabled:True|wants_pause:False]
+    Do you want to group your images?:No
+    grouping metadata count:1
+    Metadata category:None
+
+Threshold:[module_num:5|svn_version:'Unknown'|variable_revision_number:12|show_window:True|notes:[]|batch_state:array([], dtype=uint8)|enabled:True|wants_pause:False]
+    Select the input image:DNA
+    Name the output image:Threshold
+    Threshold strategy:Global
+    Thresholding method:Minimum Cross-Entropy
+    Threshold smoothing scale:0.01
+    Threshold correction factor:2
+    Lower and upper bounds on threshold:0.01,0.9
+    Manual threshold:0.0
+    Select the measurement to threshold with:None
+    Two-class or three-class thresholding?:Two classes
+    Log transform before thresholding?:Yes
+    Assign pixels in the middle intensity class to the foreground or the background?:Foreground
+    Size of adaptive window:51
+    Lower outlier fraction:0.05
+    Upper outlier fraction:0.05
+    Averaging method:Mean
+    Variance method:Standard deviation
+    # of deviations:2.0
+    Thresholding method:Sauvola


### PR DESCRIPTION
This pull adds a new setting to Threshold (and therefore IDPrimary/Secondary) which allows the input image to be log-transformed before calculating Otsu or MCE thresholds.

In CP2 (Otsu 2-class) and CP3 (Otsu 3-class) the old Centrosome implementation of these methods was hard-coded to do this transform, but this was inconsistent with the Skimage methods. In CP4 we switched to all-Skimage implementations, but this effectively lost the old transformation functionality. It turns out that in practice the transform is very useful when you need to detect particularly weak staining in the presence of a stronger stain, usually when identifying cell boundaries.

To resolve this I've added the transform as a setting within the module. When enabled the transforms are applied before using the Skimage functions like normal (rather than reverting to using Centrosome Otsu).