### PR TITLE
Adding Conda environment file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,19 @@
+name: cp4
+
+channels:
+  - conda-forge
+  - anaconda
+  - bioconda
+  - defaults
+
+dependencies:
+  - python=3.8
+  - numpy
+  - matplotlib
+  - pandas
+  - mysqlclient
+  - openjdk
+  - gtk2
+  - wxpython
+  - pip:
+    - cellprofiler


### PR DESCRIPTION
Hi,
I couldn't find a recent Conda Environment for CellProfiler 4.
This seems to be the minimal setup to get CellProfiler 4 working with Python 3.8 on recent Linux distributions.
