### PR TITLE
RunImageJMacro module

### DIFF
--- a/cellprofiler/modules/__init__.py
+++ b/cellprofiler/modules/__init__.py
@@ -72,6 +72,7 @@ builtin_modules = {
     "rescaleintensity": "RescaleIntensity",
     "resizeobjects": "ResizeObjects",
     "resize": "Resize",
+    "runimagejmacro": "RunImageJMacro",
     "savecroppedobjects": "SaveCroppedObjects",
     "saveimages": "SaveImages",
     "shrinktoobjectcenters": "ShrinkToObjectCenters",

--- a/cellprofiler/modules/runimagejmacro.py
+++ b/cellprofiler/modules/runimagejmacro.py
@@ -222,12 +222,15 @@ Select the folder containing the executable. {IO_FOLDER_CHOICE_HELP_TEXT}
 
         cmd += [self.stringify_metadata(tempdir)]
 
-        subp = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        subp = subprocess.call(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
         # Load images from the temp directory
+        for image_group in self.image_groups_out:
+            image_pixels = skimage.io.imread(os.path.join(tempdir,image_group.input_filename.value))
+            #add pixels to a measurement object?
 
-        # Delete the temp directory
-
-
-
-    # ./ImageJ-win64.exe --headless --console -macro ./RunBatch.ijm 'folder=../folder1 parameters=a.properties output=../samples/Output'
+        #remove temp content and directory
+        for subdir, dirs, files in os.walk(tempdir):
+            for file in files:
+                os.remove(os.path.join(tempdir, file))
+        os.removedirs(tempdir)

--- a/cellprofiler/modules/runimagejmacro.py
+++ b/cellprofiler/modules/runimagejmacro.py
@@ -35,7 +35,7 @@ Select the folder containing the executable. {IO_FOLDER_CHOICE_HELP_TEXT}
             self.executable_directory.join_parts(dir_choice, custom_path)
 
         self.executable_file = Filename(
-            "Executable", "ImageJ.exe", doc="TODO",
+            "Executable", "ImageJ.exe", doc="Select your executable. MacOS users should select the Fiji.app application.",
             get_directory_fn=self.executable_directory.get_absolute_path,
             set_directory_fn=set_directory_fn_executable,
             browse_msg="Choose executable file"
@@ -54,7 +54,7 @@ Select the folder containing the executable. {IO_FOLDER_CHOICE_HELP_TEXT}
             self.macro_directory.join_parts(dir_choice, custom_path)
 
         self.macro_file = Filename(
-            "Macro", "macro.py", doc="TODO",
+            "Macro", "macro.py", doc="Select your macro file.",
             get_directory_fn=self.macro_directory.get_absolute_path,
             set_directory_fn=set_directory_fn_macro,
             browse_msg="Choose macro file"
@@ -70,15 +70,17 @@ Select the folder containing the executable. {IO_FOLDER_CHOICE_HELP_TEXT}
         self.macro_variable_count = HiddenCount(self.macro_variables_list)
 
         self.add_image_in(can_delete=False)
-        self.add_image_button_in = DoSomething("", 'Add another image', self.add_image_in)
+        self.add_image_button_in = DoSomething("", 'Add another input image', self.add_image_in)
 
         self.add_image_out(can_delete=False)
-        self.add_image_button_out = DoSomething("", 'Add another image', self.add_image_out)
-
+        self.add_image_button_out = DoSomething("", 'Add another output image', self.add_image_out)
 
         self.add_directory = Text("What variable in your macro defines the folder ImageJ should use?",
                                   "Directory",
-                                  doc="What variable in your macro defines the folder ImageJ should use?")
+                                  doc="Because CellProfiler will save the output images in a temporary directory, "
+                                      "this directory should be specified as a variable in the macro script. Enter "
+                                      "the variable name here. CellProfiler will automatically assign this variable "
+                                      "to the temporary directory being used.")
         self.add_variable_button_out = DoSomething("", "Add another variable", self.add_macro_variables)
 
 
@@ -91,7 +93,7 @@ Select the folder containing the executable. {IO_FOLDER_CHOICE_HELP_TEXT}
             Text(
                 'What variable name is your macro expecting?',
                 "None",
-                doc='What variable name is your macro expecting?'
+                doc='Enter the variable name that your macro is expecting. '
             )
         )
         group.append(
@@ -99,7 +101,7 @@ Select the folder containing the executable. {IO_FOLDER_CHOICE_HELP_TEXT}
             Text(
                 "What value should this variable have?",
                 "None",
-                doc="What value should this variable have?"),
+                doc="Enter the desire value for this variable."),
         )
         if len(self.macro_variables_list) == 0:  # Insert space between 1st two images for aesthetics
             group.append("extra_divider", Divider(line=False))
@@ -123,7 +125,7 @@ Select the folder containing the executable. {IO_FOLDER_CHOICE_HELP_TEXT}
             ImageSubscriber(
                 'Select an image to send to your macro',
                 "None",
-                doc='Select an image to send to your macro'
+                doc="Select an image to send to your macro. "
             )
         )
         group.append(
@@ -131,7 +133,8 @@ Select the folder containing the executable. {IO_FOLDER_CHOICE_HELP_TEXT}
             Text(
                 "What should this image temporarily saved as?",
                 "None.tiff",
-                doc="What should this image temporarily saved as?"),
+                doc='Enter the filename of the image to be used by the macro. This should be set to the name expected '
+                    'by the macro file.'),
         )
         if len(self.image_groups_in) == 0:  # Insert space between 1st two images for aesthetics
             group.append("extra_divider", Divider(line=False))
@@ -152,9 +155,11 @@ Select the folder containing the executable. {IO_FOLDER_CHOICE_HELP_TEXT}
         group.append(
             "input_filename",
             Text(
-                "What is the image name CellProfiler should load?",
+                "What is the image filename CellProfiler should load?",
                 "None.tiff",
-                doc="What is the image name CellProfiler should load?"),
+                doc="Enter the image filename CellProfiler should load. This should be set to the output filename "
+                    "written in the macro file. The image written by the macro will be saved in a temporary directory "
+                    "and read by CellProfiler."),
         )
 
         group.append(
@@ -162,7 +167,8 @@ Select the folder containing the executable. {IO_FOLDER_CHOICE_HELP_TEXT}
             ImageName(
                 r'What should CellProfiler call the loaded image?',
                 "None",
-                doc='What should CellProfiler call the loaded image?'
+                doc='Enter a name to assign to the new image loaded by CellProfiler. This image will be added to your '
+                    'workspace. '
             )
         )
 

--- a/cellprofiler/modules/runimagejmacro.py
+++ b/cellprofiler/modules/runimagejmacro.py
@@ -3,15 +3,14 @@ import os
 import subprocess
 
 from cellprofiler_core.image import Image
-
 from cellprofiler.modules import _help
 from cellprofiler_core.module import Module
-from cellprofiler_core.setting.text import Pathname, Filename, ImageName, Text, Directory
+from cellprofiler_core.setting.text import Filename, ImageName, Text, Directory
 from cellprofiler_core.setting.do_something import DoSomething, RemoveSettingButton
 from cellprofiler_core.setting._settings_group import SettingsGroup
 from cellprofiler_core.setting import Divider, HiddenCount
 from cellprofiler_core.setting.subscriber import ImageSubscriber
-from cellprofiler_core.preferences import DEFAULT_OUTPUT_FOLDER_NAME, get_default_output_directory
+from cellprofiler_core.preferences import get_default_output_directory
 
 import random
 import skimage.io

--- a/cellprofiler/modules/runimagejmacro.py
+++ b/cellprofiler/modules/runimagejmacro.py
@@ -1,3 +1,35 @@
+"""
+RunImageJMacro
+==============
+
+**RunImageJMacro** exports image(s), executes an ImageJ macro on them and
+then loads resulting image(s) back into CellProfiler.
+
+To operate, this module requires that the user has installed ImageJ (or FIJI)
+elsewhere on their system. It can be downloaded `here`_.
+You should point the module to the ImageJ executable in it's installation folder.
+
+The ImageJ macro itself should specify which input images and variables are needed.
+
+On running, CellProfiler saves required images into a temporary folder, executes the
+macro and then attempts to load images which the macro should save into that same
+temporary folder.
+
+See `this guide`_ for a full tutorial.
+
+|
+
+============ ============ ===============
+Supports 2D? Supports 3D? Respects masks?
+============ ============ ===============
+YES          NO           NO
+============ ============ ===============
+
+
+.. _here: https://imagej.nih.gov/ij/download.html
+.. _this guide: https://github.com/CellProfiler/CellProfiler/wiki/RunImageJMacro
+"""
+
 import itertools
 import os
 import subprocess

--- a/cellprofiler/modules/runimagejmacro.py
+++ b/cellprofiler/modules/runimagejmacro.py
@@ -82,7 +82,6 @@ should select the directory containing ImageJ-win64.exe (usually corresponding t
             "Macro directory", allow_metadata=False, doc=f"""Select the folder containing the macro.
 {_help.IO_FOLDER_CHOICE_HELP_TEXT}""")
 
-
         def set_directory_fn_macro(path):
             dir_choice, custom_path = self.macro_directory.get_parts_from_path(path)
             self.macro_directory.join_parts(dir_choice, custom_path)
@@ -120,7 +119,6 @@ temporary directory and assign its path as a value to this variable."""
 
         self.add_variable_button_out = DoSomething("Does your macro expect variables?", "Add another variable", self.add_macro_variables)
 
-
     def add_macro_variables(self, can_delete=True):
         group = SettingsGroup()
         if can_delete:
@@ -147,7 +145,6 @@ temporary directory and assign its path as a value to this variable."""
             group.append("remover", RemoveSettingButton("", "Remove this variable", self.macro_variables_list, group))
 
         self.macro_variables_list.append(group)
-
 
     def add_image_in(self, can_delete=True):
         """Add an image to the image_groups collection

--- a/cellprofiler/modules/runimagejmacro.py
+++ b/cellprofiler/modules/runimagejmacro.py
@@ -28,10 +28,6 @@ Select the folder containing the executable. {IO_FOLDER_CHOICE_HELP_TEXT}
                 "IO_FOLDER_CHOICE_HELP_TEXT": _help.IO_FOLDER_CHOICE_HELP_TEXT
             }))
 
-        # def get_directory_fn_executable():
-        #     '''Get the directory for the executable'''
-        #     return self.executable_directory.get_absolute_path()
-
         def set_directory_fn_executable(path):
             dir_choice, custom_path = self.executable_directory.get_parts_from_path(path)
             self.executable_directory.join_parts(dir_choice, custom_path)
@@ -50,6 +46,7 @@ Select the folder containing the executable. {IO_FOLDER_CHOICE_HELP_TEXT}
                 "IO_FOLDER_CHOICE_HELP_TEXT": _help.IO_FOLDER_CHOICE_HELP_TEXT
             }))
 
+
         def set_directory_fn_macro(path):
             dir_choice, custom_path = self.macro_directory.get_parts_from_path(path)
             self.macro_directory.join_parts(dir_choice, custom_path)
@@ -60,9 +57,6 @@ Select the folder containing the executable. {IO_FOLDER_CHOICE_HELP_TEXT}
             set_directory_fn=set_directory_fn_macro,
             browse_msg="Choose macro file"
         )
-
-        # self.executable = Filename("Executable", "ImageJ.exe" ,doc="TODO")
-        # self.macro_file = Filename("Macro", "macro.py", doc="TODO")
 
         self.image_groups_in = []
         self.image_groups_out = []
@@ -79,7 +73,6 @@ Select the folder containing the executable. {IO_FOLDER_CHOICE_HELP_TEXT}
                                   "Directory",
                                   doc="What variable in your macro defines the folder ImageJ should use?")
         self.add_variable_button_out = DoSomething("", "Add another variable", self.add_macro_variables)
-
 
 
     def add_macro_variables(self, can_delete=True):
@@ -208,9 +201,13 @@ Select the folder containing the executable. {IO_FOLDER_CHOICE_HELP_TEXT}
     def run(self, workspace):
 
         # Making a temp directory
-        tag = str(random.randint(100000, 999999))
-        tempdir = os.path.join(DEFAULT_OUTPUT_FOLDER_NAME, tag)
-        os.makedirs(tempdir, exist_ok=True)
+        # tag = str(random.randint(100000, 999999))
+        # tempdir = os.path.join(DEFAULT_OUTPUT_FOLDER_NAME, tag)
+        # os.makedirs(tempdir, exist_ok=True)
+
+        #TEMPORARY CHANGE
+        tempdir = "/Users/alucas/Downloads/tmp/"
+
         # Save image to the temp directory
         for image_group in self.image_groups_in:
             image = workspace.image_set.get_image(image_group.image_name.value)
@@ -218,12 +215,21 @@ Select the folder containing the executable. {IO_FOLDER_CHOICE_HELP_TEXT}
             skimage.io.imsave(os.path.join(tempdir, image_group.output_filename.value), image_pixels)
 
         # Execute the macro
-        if self.executable_file.value[:-4] == ".app":
-            executable = os.path.join(self.executable_directory.value, self.executable_file.value, "Contents/MacOS/ImageJ-macosx")
+
+        if self.executable_file.value[-4:] == ".app":
+            executable = os.path.join(self.executable_directory.value.split("|")[1], self.executable_file.value, "Contents/MacOS/ImageJ-macosx")
         else:
-            executable = os.path.join(self.executable_directory.value, self.executable_file.value)
-        cmd = [executable, "--headless", "console", "--run", os.path.join(self.macro_directory.value, self.macro_file.value)]
-        cmd += self.stringify_metadata(tempdir)
+            executable = os.path.join(self.executable_directory.value.split("|")[1], self.executable_file.value)
+        #cmd = [executable, "--headless", "console", "--run", os.path.join(self.macro_directory.value.split("|")[1], self.macro_file.value)]
+        #TEMPORARY CHANGE
+        cmd = [executable, "--headless", "console", "--run",
+               "/Users/alucas/Downloads/SillyMacro.py"]
+        cmd += ["directory='/Users/alucas/Downloads/tmp/',size='5'"]
+        #cmd += ["size='5'"]
+
+        #cmd += ["size='5'"]
+        #cmd += [self.stringify_metadata(tempdir)]
+
 
         subp = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 

--- a/cellprofiler/modules/runimagejmacro.py
+++ b/cellprofiler/modules/runimagejmacro.py
@@ -1,6 +1,8 @@
 import os
 import subprocess
 
+from cellprofiler_core.image import Image
+
 from cellprofiler.modules import _help
 from cellprofiler_core.module import Module
 from cellprofiler_core.setting.text import Pathname, Filename, ImageName, Text, Directory
@@ -227,7 +229,7 @@ Select the folder containing the executable. {IO_FOLDER_CHOICE_HELP_TEXT}
         # Load images from the temp directory
         for image_group in self.image_groups_out:
             image_pixels = skimage.io.imread(os.path.join(tempdir,image_group.input_filename.value))
-            #add pixels to a measurement object?
+            workspace.image_set.add(image_group.image_name.value, Image(image_pixels.astype("uint16"), convert=False))
 
         #remove temp content and directory
         for subdir, dirs, files in os.walk(tempdir):

--- a/cellprofiler/modules/runimagejmacro.py
+++ b/cellprofiler/modules/runimagejmacro.py
@@ -1,0 +1,236 @@
+import os
+import subprocess
+
+from cellprofiler.modules import _help
+from cellprofiler_core.module import Module
+from cellprofiler_core.setting.text import Pathname, Filename, ImageName, Text, Directory
+from cellprofiler_core.setting.do_something import DoSomething, RemoveSettingButton
+from cellprofiler_core.setting._settings_group import SettingsGroup
+from cellprofiler_core.setting import Divider
+from cellprofiler_core.setting.subscriber import ImageSubscriber
+from cellprofiler_core.preferences import DEFAULT_OUTPUT_FOLDER_NAME
+
+import random
+import skimage.io
+
+
+class RunImageJMacro(Module):
+    module_name = "RunImageJMacro"
+    variable_revision_number = 1
+    category = "Advanced"
+
+    def create_settings(self):
+
+        self.executable_directory = Directory(
+            "Executable directory", allow_metadata=False, doc="""\
+Select the folder containing the executable. {IO_FOLDER_CHOICE_HELP_TEXT}
+""".format(**{
+                "IO_FOLDER_CHOICE_HELP_TEXT": _help.IO_FOLDER_CHOICE_HELP_TEXT
+            }))
+
+        # def get_directory_fn_executable():
+        #     '''Get the directory for the executable'''
+        #     return self.executable_directory.get_absolute_path()
+
+        def set_directory_fn_executable(path):
+            dir_choice, custom_path = self.executable_directory.get_parts_from_path(path)
+            self.executable_directory.join_parts(dir_choice, custom_path)
+
+        self.executable_file = Filename(
+            "Executable", "ImageJ.exe", doc="TODO",
+            get_directory_fn=self.executable_directory.get_absolute_path,
+            set_directory_fn=set_directory_fn_executable,
+            browse_msg="Choose executable file"
+        )
+
+        self.macro_directory = Directory(
+            "Macro directory", allow_metadata=False, doc="""\
+        Select the folder containing the macro. {IO_FOLDER_CHOICE_HELP_TEXT}
+        """.format(**{
+                "IO_FOLDER_CHOICE_HELP_TEXT": _help.IO_FOLDER_CHOICE_HELP_TEXT
+            }))
+
+        def set_directory_fn_macro(path):
+            dir_choice, custom_path = self.macro_directory.get_parts_from_path(path)
+            self.macro_directory.join_parts(dir_choice, custom_path)
+
+        self.macro_file = Filename(
+            "Macro", "macro.py", doc="TODO",
+            get_directory_fn=self.macro_directory.get_absolute_path,
+            set_directory_fn=set_directory_fn_macro,
+            browse_msg="Choose macro file"
+        )
+
+        # self.executable = Filename("Executable", "ImageJ.exe" ,doc="TODO")
+        # self.macro_file = Filename("Macro", "macro.py", doc="TODO")
+
+        self.image_groups_in = []
+        self.image_groups_out = []
+
+        self.macro_variables_list = []
+
+        self.add_image_in(can_delete=False)
+        self.add_image_button_in = DoSomething("", 'Add another image', self.add_image_in)
+
+        self.add_image_out(can_delete=False)
+        self.add_image_button_out = DoSomething("", 'Add another image', self.add_image_out)
+
+        self.add_directory = Text("What variable in your macro defines the folder ImageJ should use?",
+                                  "Directory",
+                                  doc="What variable in your macro defines the folder ImageJ should use?")
+        self.add_variable_button_out = DoSomething("", "Add another variable", self.add_macro_variables)
+
+
+
+    def add_macro_variables(self, can_delete=True):
+        group = SettingsGroup()
+        if can_delete:
+            group.append("divider", Divider(line=False))
+        group.append(
+            "variable_name",
+            Text(
+                'What variable name is your macro expecting?',
+                "None",
+                doc='What variable name is your macro expecting?'
+            )
+        )
+        group.append(
+            "variable_value",
+            Text(
+                "What value should this variable have?",
+                "None",
+                doc="What value should this variable have?"),
+        )
+        if len(self.macro_variables_list) == 0:  # Insert space between 1st two images for aesthetics
+            group.append("extra_divider", Divider(line=False))
+
+        if can_delete:
+            group.append("remover", RemoveSettingButton("", "Remove this variable", self.macro_variables_list, group))
+
+        self.macro_variables_list.append(group)
+
+
+    def add_image_in(self, can_delete=True):
+        """Add an image to the image_groups collection
+        can_delete - set this to False to keep from showing the "remove"
+                     button for images that must be present.
+        """
+        group = SettingsGroup()
+        if can_delete:
+            group.append("divider", Divider(line=False))
+        group.append(
+            "image_name",
+            ImageSubscriber(
+                'Select an image to send to your macro',
+                "None",
+                doc='Select an image to send to your macro'
+            )
+        )
+        group.append(
+            "output_filename",
+            Text(
+                "What should this image temporarily saved as?",
+                "None.tiff",
+                doc="What should this image temporarily saved as?"),
+        )
+        if len(self.image_groups_in) == 0:  # Insert space between 1st two images for aesthetics
+            group.append("extra_divider", Divider(line=False))
+
+        if can_delete:
+            group.append("remover", RemoveSettingButton("", "Remove this image",  self.image_groups_in, group))
+
+        self.image_groups_in.append(group)
+
+    def add_image_out(self, can_delete=True):
+        """Add an image to the image_groups collection
+        can_delete - set this to False to keep from showing the "remove"
+                     button for images that must be present.
+        """
+        group = SettingsGroup()
+        if can_delete:
+            group.append("divider", Divider(line=False))
+        group.append(
+            "input_filename",
+            Text(
+                "What is the image name CellProfiler should load?",
+                "None.tiff",
+                doc="What is the image name CellProfiler should load?"),
+        )
+
+        group.append(
+            "image_name",
+            ImageName(
+                r'What should CellProfiler call the loaded image?',
+                "None",
+                doc='What should CellProfiler call the loaded image?'
+            )
+        )
+
+        if len(self.image_groups_out) == 0:  # Insert space between 1st two images for aesthetics
+            group.append("extra_divider", Divider(line=False))
+
+        if can_delete:
+            group.append("remover", RemoveSettingButton("", "Remove this image",  self.image_groups_out, group))
+
+        self.image_groups_out.append(group)
+
+    def settings(self):
+        result = [self.executable_directory, self.executable_file, self.macro_directory, self.macro_file]
+        for image_group_in in self.image_groups_in:
+            result += [image_group_in.image_name, image_group_in.output_filename]
+        for image_group_out in self.image_groups_out:
+            result += [image_group_out.input_filename, image_group_out.image_name]
+        result += [self.add_directory]
+        for macro_variable in self.macro_variables_list:
+            result +=[macro_variable.variable_name, macro_variable.variable_value]
+        return result
+
+    def visible_settings(self):
+        visible_settings = [self.executable_directory, self.executable_file, self.macro_directory, self.macro_file]
+        for image_group_in in self.image_groups_in:
+            visible_settings += image_group_in.visible_settings()
+        visible_settings += [self.add_image_button_in]
+        for image_group_out in self.image_groups_out:
+            visible_settings += image_group_out.visible_settings()
+        visible_settings += [self.add_image_button_out]
+        visible_settings += [self.add_directory]
+        for macro_variable in self.macro_variables_list:
+            visible_settings += macro_variable.visible_settings()
+        visible_settings += [self.add_variable_button_out]
+        return visible_settings
+
+    def stringify_metadata(self, dir):
+        met_string = self.add_directory.value + "='" + dir +  "', "
+        for var in self.macro_variables_list:
+            met_string += var.variable_name.value + "='" + var.variable_value.value + "', "
+        return met_string[:-2]
+
+    def run(self, workspace):
+
+        # Making a temp directory
+        tag = str(random.randint(100000, 999999))
+        tempdir = os.path.join(DEFAULT_OUTPUT_FOLDER_NAME, tag)
+        os.makedirs(tempdir, exist_ok=True)
+        # Save image to the temp directory
+        for image_group in self.image_groups_in:
+            image = workspace.image_set.get_image(image_group.image_name.value)
+            image_pixels = image.pixel_data
+            skimage.io.imsave(os.path.join(tempdir, image_group.output_filename.value), image_pixels)
+
+        # Execute the macro
+        if self.executable_file.value[:-4] == ".app":
+            executable = os.path.join(self.executable_directory.value, self.executable_file.value, "Contents/MacOS/ImageJ-macosx")
+        else:
+            executable = os.path.join(self.executable_directory.value, self.executable_file.value)
+        cmd = [executable, "--headless", "console", "--run", os.path.join(self.macro_directory.value, self.macro_file.value)]
+        cmd += self.stringify_metadata(tempdir)
+
+        subp = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+        # Load images from the temp directory
+
+        # Delete the temp directory
+
+
+
+    # ./ImageJ-win64.exe --headless --console -macro ./RunBatch.ijm 'folder=../folder1 parameters=a.properties output=../samples/Output'

--- a/cellprofiler/modules/runimagejmacro.py
+++ b/cellprofiler/modules/runimagejmacro.py
@@ -25,7 +25,8 @@ class RunImageJMacro(Module):
 
         self.executable_directory = Directory(
             "Executable directory", allow_metadata=False, doc="""\
-Select the folder containing the executable. {IO_FOLDER_CHOICE_HELP_TEXT}
+Select the folder containing the executable. MacOS users should select the directory where Fiji.app lives. Windows users 
+should select the directory containing ImageJ-win64.exe (usually corresponding to the Fiji.app folder).  {IO_FOLDER_CHOICE_HELP_TEXT}
 """.format(**{
                 "IO_FOLDER_CHOICE_HELP_TEXT": _help.IO_FOLDER_CHOICE_HELP_TEXT
             }))
@@ -35,7 +36,8 @@ Select the folder containing the executable. {IO_FOLDER_CHOICE_HELP_TEXT}
             self.executable_directory.join_parts(dir_choice, custom_path)
 
         self.executable_file = Filename(
-            "Executable", "ImageJ.exe", doc="Select your executable. MacOS users should select the Fiji.app application.",
+            "Executable", "ImageJ.exe", doc="Select your executable. MacOS users should select the Fiji.app "
+                                            "application. Windows user should select the ImageJ-win64.exe executable",
             get_directory_fn=self.executable_directory.get_absolute_path,
             set_directory_fn=set_directory_fn_executable,
             browse_msg="Choose executable file"
@@ -225,7 +227,7 @@ Select the folder containing the executable. {IO_FOLDER_CHOICE_HELP_TEXT}
 
     def stringify_metadata(self, dir):
         met_string = ""
-        met_string += self.add_directory.value + "=\"" + dir +  "\", "
+        met_string += self.add_directory.value + "='" + dir + "', "
         for var in self.macro_variables_list:
             met_string += var.variable_name.value + "='" + var.variable_value.value + "', "
         return met_string[:-2]
@@ -242,9 +244,9 @@ Select the folder containing the executable. {IO_FOLDER_CHOICE_HELP_TEXT}
             skimage.io.imsave(os.path.join(tempdir, image_group.output_filename.value), image_pixels)
 
         if self.executable_file.value[-4:] == ".app":
-            executable = os.path.join(self.executable_directory.value.split("|")[1], self.executable_file.value, "Contents/MacOS/ImageJ-macosx")
+            executable = os.path.join(default_output_directory, self.executable_directory.value.split("|")[1], self.executable_file.value, "Contents/MacOS/ImageJ-macosx")
         else:
-            executable = os.path.join(self.executable_directory.value.split("|")[1], self.executable_file.value)
+            executable = os.path.join(default_output_directory, self.executable_directory.value.split("|")[1], self.executable_file.value)
         cmd = [executable, "--headless", "console", "--run", os.path.join(default_output_directory, self.macro_directory.value.split("|")[1], self.macro_file.value)]
 
         cmd += [self.stringify_metadata(tempdir)]

--- a/cellprofiler/modules/runimagejmacro.py
+++ b/cellprofiler/modules/runimagejmacro.py
@@ -7,6 +7,7 @@ then loads resulting image(s) back into CellProfiler.
 
 To operate, this module requires that the user has installed ImageJ (or FIJI)
 elsewhere on their system. It can be downloaded `here`_.
+
 You should point the module to the ImageJ executable in it's installation folder.
 
 The ImageJ macro itself should specify which input images and variables are needed.
@@ -25,9 +26,9 @@ Supports 2D? Supports 3D? Respects masks?
 YES          NO           NO
 ============ ============ ===============
 
-
 .. _here: https://imagej.nih.gov/ij/download.html
 .. _this guide: https://github.com/CellProfiler/CellProfiler/wiki/RunImageJMacro
+
 """
 
 import itertools
@@ -58,7 +59,9 @@ class RunImageJMacro(Module):
         self.executable_directory = Directory(
             "Executable directory", allow_metadata=False, doc="""\
 Select the folder containing the executable. MacOS users should select the directory where Fiji.app lives. Windows users 
-should select the directory containing ImageJ-win64.exe (usually corresponding to the Fiji.app folder).  {IO_FOLDER_CHOICE_HELP_TEXT}
+should select the directory containing ImageJ-win64.exe (usually corresponding to the Fiji.app folder).
+
+{IO_FOLDER_CHOICE_HELP_TEXT}
 """.format(**{
                 "IO_FOLDER_CHOICE_HELP_TEXT": _help.IO_FOLDER_CHOICE_HELP_TEXT
             }))
@@ -76,11 +79,8 @@ should select the directory containing ImageJ-win64.exe (usually corresponding t
         )
 
         self.macro_directory = Directory(
-            "Macro directory", allow_metadata=False, doc="""\
-        Select the folder containing the macro. {IO_FOLDER_CHOICE_HELP_TEXT}
-        """.format(**{
-                "IO_FOLDER_CHOICE_HELP_TEXT": _help.IO_FOLDER_CHOICE_HELP_TEXT
-            }))
+            "Macro directory", allow_metadata=False, doc=f"""Select the folder containing the macro.
+{_help.IO_FOLDER_CHOICE_HELP_TEXT}""")
 
 
         def set_directory_fn_macro(path):
@@ -94,13 +94,14 @@ should select the directory containing ImageJ-win64.exe (usually corresponding t
             browse_msg="Choose macro file"
         )
 
-        self.add_directory = Text("What variable in your macro defines the folder ImageJ should use?",
-                                  "Directory",
-                                  doc="Because CellProfiler will save the output images in a temporary directory, "
-                                      "this directory should be specified as a variable in the macro script. It is "
-                                      "assumed that the macro will use this directory variable to obtain the full path"
-                                      "to the inputted image. Enter the variable name here. CellProfiler will create "
-                                      "a temporary directory and assign its path as a value to this variable. ")
+        self.add_directory = Text(
+            "What variable in your macro defines the folder ImageJ should use?",
+            "Directory",
+            doc="""Because CellProfiler will save the output images in a temporary directory, this directory should be 
+specified as a variable in the macro script. It is assumed that the macro will use this directory variable 
+to obtain the full path to the inputted image. Enter the variable name here. CellProfiler will create a 
+temporary directory and assign its path as a value to this variable."""
+        )
 
         self.image_groups_in = []
         self.image_groups_out = []

--- a/cellprofiler/modules/runimagejmacro.py
+++ b/cellprofiler/modules/runimagejmacro.py
@@ -264,6 +264,7 @@ Select the folder containing the executable. {IO_FOLDER_CHOICE_HELP_TEXT}
         # Display results
         pixel_data = []
         image_names = []
+
         if self.show_window:
             for x in itertools.chain(self.image_groups_in, self.image_groups_out):
                 pixel_data.append(workspace.image_set.get_image(x.image_name.value).pixel_data)


### PR DESCRIPTION
This is the beginning of a RunImageJMacro module in its simplest form. The way it currently works is the following:

- First, it is assumed that the macro expects a "directory" variable. This is the mechanism we chose to transfer images from CellProfiler to Fiji, and vice versa. The macro should use this "directory" variable when specifying the full path of an image to be read. It is also in this "directory" that the macro will write out images, which are then to be read by CellProfiler. The value of this variable is automatically assigned to a temporary directory created by CellProfiler.

- The user can select one or more images in the current workspace. For each of these images, the user inputs a filename expected by the macro. These image files are saved in the temporary directory created by CellProfiler. The macro expects these images to live in that directory and reads them under the specified filenames. 

- The user specifies the filename of the image(s) outputted by the macro. These are the filenames used by the macro when writing output images to the "directory" variable. Once ready, CellProfiler looks for these images in the created directory, reads them, and adds them to the workspace. 

- User can assign variable names and corresponding values expected from the macro script.

This module was tested on MacOS but still needs to be tested on other OS. 

This module's current functionality is a bit basic, but we expect to add more exciting features in the future!