### PR TITLE
Fix "Open default output folder" button in analysis complete dialog

### DIFF
--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -3947,13 +3947,7 @@ class PipelineController(object):
                     )
                 elif sys.platform == "win32":
                     subprocess.call(
-                        [
-                            "cmd",
-                            "/C",
-                            "start",
-                            "explorer",
-                            get_default_output_directory(),
-                        ]
+                        ["explorer", os.path.abspath(get_default_output_directory())]
                     )
 
             open_default_output_folder_button.Bind(


### PR DESCRIPTION
Fixes #4330

Turns out `\\` path separators, while valid in Python, need to be cleaned up to `\` before we pass the path to Windows Explorer. Otherwise Windows just opens the user's home directory.