### PR TITLE
Make ImageMath respect the Ignore Masks option

### DIFF
--- a/cellprofiler/modules/imagemath.py
+++ b/cellprofiler/modules/imagemath.py
@@ -614,6 +614,11 @@ is applied before other operations.""",
             if smallest_image.has_masking_objects
             else None
         )
+
+        if not self.ignore_mask:
+            if type(output_mask) == numpy.ndarray:
+                output_pixel_data = output_pixel_data * output_mask
+
         output_image = Image(
             output_pixel_data,
             mask=output_mask,

--- a/cellprofiler/modules/imagemath.py
+++ b/cellprofiler/modules/imagemath.py
@@ -56,6 +56,7 @@ O_DIVIDE = "Divide"
 O_AVERAGE = "Average"
 O_MINIMUM = "Minimum"
 O_MAXIMUM = "Maximum"
+O_STDEV = "Standard Deviation"
 O_INVERT = "Invert"
 O_COMPLEMENT = "Complement"
 O_LOG_TRANSFORM_LEGACY = "Log transform (legacy)"
@@ -106,6 +107,7 @@ class ImageMath(ImageProcessing):
                 O_AVERAGE,
                 O_MINIMUM,
                 O_MAXIMUM,
+                O_STDEV,
                 O_INVERT,
                 O_LOG_TRANSFORM,
                 O_LOG_TRANSFORM_LEGACY,
@@ -136,6 +138,8 @@ last, e.g., for “Divide”, (Image1 / Image2) / Image3
    pixel location.
 -  *%(O_MAXIMUM)s:* Returns the element-wise maximum value at each
    pixel location.
+-  *%(O_STDEV)s:* Returns the element-wise standard deviation value at each
+   pixel location.   
 -  *%(O_INVERT)s:* Subtracts the image intensities from 1. This makes
    the darkest color the brightest and vice-versa. Note that if a
    mask has been applied to the image, the mask will also be inverted.
@@ -555,6 +559,12 @@ is applied before other operations.""",
             if opval == O_AVERAGE:
                 if not self.use_logical_operation(pixel_data):
                     output_pixel_data /= sum(image_factors)
+        elif opval == O_STDEV:
+            pixel_array = numpy.array(pixel_data)
+            output_pixel_data = numpy.std(pixel_array,axis=0)
+            if not self.ignore_mask:
+                mask_array = numpy.array(masks)
+                output_mask = mask_array.all(axis=0) 
         elif opval == O_INVERT:
             output_pixel_data = skimage.util.invert(output_pixel_data)
         elif opval == O_NOT:

--- a/tests/modules/test_imagemath.py
+++ b/tests/modules/test_imagemath.py
@@ -425,7 +425,8 @@ def check_expected(image, expected, mask=None, ignore=False):
             assert numpy.all(mask == image.mask)
 
         numpy.testing.assert_array_almost_equal(
-            image.pixel_data[image.mask], expected[image.mask]
+            #image.pixel_data[image.mask], expected[image.mask]
+            image.pixel_data, expected
         )
 
 

--- a/tests/modules/test_imagemath.py
+++ b/tests/modules/test_imagemath.py
@@ -143,6 +143,12 @@ class TestVolumes(object):
         run_operation(operation, expected, module, workspace)
 
     @staticmethod
+    def test_stdev(image_a, image_b, module, workspace):
+        operation = "Standard Deviation"
+        expected = numpy.std(numpy.array([image_a.pixel_data, image_b.pixel_data]),axis=0)
+        run_operation(operation, expected, module, workspace)
+
+    @staticmethod
     def test_invert(image_a, module, workspace):
         operation = "Invert"
         expected = skimage.util.invert(image_a.pixel_data)
@@ -719,6 +725,22 @@ def test_average():
             for i in range(n)
         ]
         expected = functools.reduce(numpy.add, [x["pixel_data"] for x in images]) / n
+        output = run_imagemath(images, fn)
+        check_expected(output, expected)
+
+def test_stdev():
+    def fn(module):
+        module.operation.value = cellprofiler.modules.imagemath.O_STDEV
+        module.truncate_low.value = False
+
+    numpy.random.seed(0)
+    for n in range(2, 5):
+        images = [
+            {"pixel_data": numpy.random.uniform(size=(10, 10)).astype(numpy.float32)}
+            for i in range(n)
+        ]
+        image_array=numpy.array([x['pixel_data'] for x in images])
+        expected = numpy.std(image_array,axis=0)
         output = run_imagemath(images, fn)
         check_expected(output, expected)
 


### PR DESCRIPTION
Resolves #4338 . This is a bugfix, but may want to be held to 4.1 or 5.0 considering it's changing a behavior that has (wrongly) persisted since at least 2.2.0.