### PR TITLE
Fix setting duplication bug in RelateObjects

### DIFF
--- a/cellprofiler/modules/relateobjects.py
+++ b/cellprofiler/modules/relateobjects.py
@@ -112,7 +112,7 @@ FF_CENTROID = "%s_%s_%%s" % (C_DISTANCE, FEAT_CENTROID)
 """Minimum distance measurement (FF_MINIMUM % parent)"""
 FF_MINIMUM = "%s_%s_%%s" % (C_DISTANCE, FEAT_MINIMUM)
 
-FIXED_SETTING_COUNT = 5
+FIXED_SETTING_COUNT = 7
 VARIABLE_SETTING_COUNT = 1
 
 


### PR DESCRIPTION
As found on the forum, a pipeline using RelateObjects with "Calculate distances to other parents" enabled has the option to add multiple object sets. When such a pipeline is loaded it will create 2 extra phantom object sets. This is because the number of object groups is determined by inspecting the length of the settings list and subtracting a constant number of fixed settings, but that number failed to include the default settings from the module's parent class. There are 7 fixed settings, not 5. Correcting this seems to stop the duplication bug.

Looks like this might have been a bug for a long time.