### PR TITLE
Fix OMERO login dialog for wxPython>=4.1.0

### DIFF
--- a/cellprofiler/gui/omerologin.py
+++ b/cellprofiler/gui/omerologin.py
@@ -45,24 +45,20 @@ class OmeroLoginDlg(wx.Dialog):
             max_width = max(w, max_width)
             max_height = max(h, max_height)
 
-        lsize = wx.Size(max_width, max_height)
+        # Add extra padding
+        lsize = wx.Size(max_width + 5, max_height)
         sub_sizer.Add(
             wx.StaticText(self, label="Server:", size=lsize),
-            0,
-            wx.ALIGN_RIGHT | wx.ALIGN_BOTTOM,
-        )
-        sub_sizer.AddSpacer(2)
+            0, wx.ALIGN_CENTER_VERTICAL)
         self.omero_server_ctrl = wx.TextCtrl(self, value=self.server)
         sub_sizer.Add(self.omero_server_ctrl, 1, wx.EXPAND)
 
-        sizer.AddSpacer(2)
+        sizer.AddSpacer(5)
         sub_sizer = wx.BoxSizer(wx.HORIZONTAL)
         sizer.Add(sub_sizer, 0, wx.EXPAND)
         sub_sizer.Add(
             wx.StaticText(self, label="Port:", size=lsize),
-            0,
-            wx.ALIGN_RIGHT | wx.ALIGN_BOTTOM,
-        )
+            0, wx.ALIGN_CENTER_VERTICAL)
         self.omero_port_ctrl = wx.TextCtrl(self, value=str(self.port))
         sub_sizer.Add(self.omero_port_ctrl, 1, wx.EXPAND)
 
@@ -71,9 +67,7 @@ class OmeroLoginDlg(wx.Dialog):
         sizer.Add(sub_sizer, 0, wx.EXPAND)
         sub_sizer.Add(
             wx.StaticText(self, label="User:", size=lsize),
-            0,
-            wx.ALIGN_RIGHT | wx.ALIGN_BOTTOM,
-        )
+            0, wx.ALIGN_CENTER_VERTICAL)
         self.omero_user_ctrl = wx.TextCtrl(self, value=self.user)
         sub_sizer.Add(self.omero_user_ctrl, 1, wx.EXPAND)
 
@@ -82,9 +76,7 @@ class OmeroLoginDlg(wx.Dialog):
         sizer.Add(sub_sizer, 0, wx.EXPAND)
         sub_sizer.Add(
             wx.StaticText(self, label="Password:", size=lsize),
-            0,
-            wx.ALIGN_RIGHT | wx.ALIGN_BOTTOM,
-        )
+            0, wx.ALIGN_CENTER_VERTICAL)
         self.omero_password_ctrl = wx.TextCtrl(self, value="", style=wx.TE_PASSWORD)
         sub_sizer.Add(self.omero_password_ctrl, 1, wx.EXPAND)
 


### PR DESCRIPTION
wxPython 4.1.0 introduces stricter checks for alignment flags, this causes the OMERO login dialog to fail:

<img width="254" alt="image" src="https://user-images.githubusercontent.com/2600663/109400270-1319db80-7948-11eb-82b5-eab96ee2b803.png">

Full error:

```
Traceback (most recent call last):
  File ".../cellprofiler/gui/pipelinecontroller.py", line 3365, in do_step
    self.__pipeline.run_module(module, workspace_model)
  File ".../CellProfiler4.venv/lib/python3.8/site-packages/cellprofiler_core/pipeline/_pipeline.py", line 1298, in run_module
    module.run(workspace)
  File ".../CellProfiler4.venv/lib/python3.8/site-packages/cellprofiler_core/modules/loaddata.py", line 1092, in run
    image = image_set.get_image(image_name)
  File ".../CellProfiler4.venv/lib/python3.8/site-packages/cellprofiler_core/measurement/_measurements.py", line 1557, in get_image
    image = matching_providers[0].provide_image(self)
  File ".../CellProfiler4.venv/lib/python3.8/site-packages/cellprofiler_core/image/abstract_image/file/_file_image.py", line 327, in provide_image
    self.__set_image()
  File ".../CellProfiler4.venv/lib/python3.8/site-packages/cellprofiler_core/image/abstract_image/file/_file_image.py", line 264, in __set_image
    self.cache_file()
  File ".../CellProfiler4.venv/lib/python3.8/site-packages/cellprofiler_core/image/abstract_image/file/_file_image.py", line 182, in cache_file
    rdr = get_image_reader(id(self), url=url)
  File ".../CellProfiler4.venv/lib/python3.8/site-packages/bioformats/formatreader.py", line 961, in get_image_reader
    rdr = ImageReader(path=path, url=url)
  File ".../CellProfiler4.venv/lib/python3.8/site-packages/bioformats/formatreader.py", line 580, in __init__
    self.rdr = get_omero_reader()
  File ".../CellProfiler4.venv/lib/python3.8/site-packages/bioformats/formatreader.py", line 522, in get_omero_reader
    omero_login()
  File ".../CellProfiler4.venv/lib/python3.8/site-packages/bioformats/formatreader.py", line 472, in omero_login
    __omero_login_fn()
  File ".../cellprofiler/gui/pipelinecontroller.py", line 790, in omero_login
    with cellprofiler.gui.omerologin.OmeroLoginDlg(
  File ".../cellprofiler/gui/omerologin.py", line 50, in __init__
    sub_sizer.Add(
wx._core.wxAssertionError: C++ assertion "!(flags & wxALIGN_RIGHT)" failed at /Users/robind/projects/bb2/dist-osx-py38/build/ext/wxWidgets/src/common/sizer.cpp(2098) in DoInsert(): Horizontal alignment flags are ignored in horizontal sizers
```

Issue discussed also here: https://github.com/wxWidgets/Phoenix/issues/1270 and here: https://github.com/wxWidgets/Phoenix/issues/1635

With the fixes proposed here the login dialog should render properly:
<img width="394" alt="image" src="https://user-images.githubusercontent.com/2600663/109400473-3729ec80-7949-11eb-9fc5-a3093b180901.png">
