### PR TITLE
Update wxPython to 4.1.1?

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setuptools.setup(
         "scikit-learn>=0.20",
         "scipy>=1.4.1",
         "six",
-        "wxPython==4.1.0",
+        "wxPython==4.1.1",
     ],
     license="BSD",
     name="CellProfiler",


### PR DESCRIPTION
On MacOS wxPython 4.1.0 runs into some issues:

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x000000012ed78d0f, pid=73123, tid=0x0000000000000307
#
# JRE version: OpenJDK Runtime Environment (8.0_242-b08) (build 1.8.0_242-b08)
# Java VM: OpenJDK 64-Bit Server VM (25.242-b08 mixed mode bsd-amd64 compressed oops)
# Problematic frame:
# C  [libwx_osx_cocoau_core-3.1.4.0.0.dylib+0x6ad0f]  _ZN33wxMacCoreGraphicsPenBrushDataBase22CalculateShadingValuesEPvPKdPd+0x11f
#
# Failed to write core dump. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# An error report file with more information is saved as:
# /Users/emil/Git/CellProfiler/CellProfiler-glencoe/hs_err_pid73123.log
#
# If you would like to submit a bug report, please visit:
#   http://bugreport.java.com/bugreport/crash.jsp
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
#
Abort trap: 6
```
This particular error is triggered after successful login to OMERO.

The error is fixed after upgrading wxPython to 4.1.1:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/2600663/109400801-14003c80-794b-11eb-8b61-1dc655e66d4a.png">

Together with https://github.com/CellProfiler/CellProfiler/pull/4361 and https://github.com/CellProfiler/prokaryote/pull/50 it should be possible to use CellProfiler 4.x with the latest OMERO.server versions.