### PR TITLE
Fix pipeline savetxt (write in str, not bytes)

### DIFF
--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -1170,8 +1170,8 @@ class PipelineController(object):
         """
         with open(path, mode="w") as fd:
             for url in self.__workspace.file_list.get_filelist():
-                if isinstance(url, str):
-                    url = url.encode()
+                if isinstance(url, bytes):
+                    url = url.decode()
                 fd.write(url + "\n")
 
     def is_running(self):


### PR DESCRIPTION
Just a small fix to exporting of file lists (when the preferences option to save .txt file lists is enabled). Text files are now written with strings, so we don't need to encode URLs. Figured I'd keep in a decoding step just in case a list is passed with bytes in it.