### PR TITLE
fixes related to core #77

### DIFF
--- a/cellprofiler/modules/identifysecondaryobjects.py
+++ b/cellprofiler/modules/identifysecondaryobjects.py
@@ -1019,10 +1019,10 @@ segmentation.""",
 
             if category == C_CHILDREN:
                 if object_name == self.x_name.value:
-                    measurements += [FF_COUNT % self.new_primary_objects_name.value]
+                    measurements += ["%s_Count" % self.new_primary_objects_name.value]
 
                 if object_name == self.new_primary_objects_name.value:
-                    measurements += [FF_COUNT % self.y_name.value]
+                    measurements += ["%s_Count" % self.y_name.value]
 
         return measurements
 

--- a/cellprofiler/modules/relateobjects.py
+++ b/cellprofiler/modules/relateobjects.py
@@ -916,7 +916,7 @@ parents or children of the parent object.""",
 
                 return measurements
             elif category == "Children":
-                return ["{}_Count".format(self.y_name.value)]
+                return ["%s_Count" % self.y_name.value]
         elif object_name == self.y_name.value and category == "Parent":
             return [self.x_name.value]
         elif object_name == self.y_name.value and category == C_DISTANCE:

--- a/tests/modules/test_identifysecondaryobjects.py
+++ b/tests/modules/test_identifysecondaryobjects.py
@@ -691,7 +691,7 @@ def test_measurements_no_new_primary():
         features = module.get_measurements(None, INPUT_OBJECTS_NAME, "Children")
         assert len(features) == 1
         assert (
-            features[0] == FF_COUNT % OUTPUT_OBJECTS_NAME
+            features[0] == "%s_Count" % OUTPUT_OBJECTS_NAME
         )
 
         features = module.get_measurements(None, OUTPUT_OBJECTS_NAME, "Parent")
@@ -826,8 +826,8 @@ def test_measurements_new_primary():
         [
             any([x == y for x in features])
             for y in (
-                FF_COUNT % OUTPUT_OBJECTS_NAME,
-                FF_COUNT % NEW_OBJECTS_NAME,
+                "%s_Count" % OUTPUT_OBJECTS_NAME,
+                "%s_Count" % NEW_OBJECTS_NAME,
             )
         ]
     )


### PR DESCRIPTION
Requires https://github.com/CellProfiler/core/pull/77 ; see also discussion in that PR.
Object processing modules it turns out were inconsistent in how their get_measurements show Children measurements to the user- some (RelateObjects (which explicitly declares its `get_measurements`) and MaskObjects (which inherits its `get_measurements` from `cellprofiler_core/module/_identify.py` returned `ChildObjName_Count`, which is indeed the actual measurement name, others that inherited from the ObjectProcessing module (`cellprofiler_core/module/image_segmentation/_object_processing`) (such as FilterObjects) returned `Count_ChildObjName`, which is wrong.  

IDSecondary explicitly did the wrong behavior, so fixing it here and in its tests; RelateObjects behavior was already correct, but here I'm normalizing its implementation to match the way it is implemented elsewhere, since we may want to change the implementation to Count_ChildObjName in the future, and this will make it easier to do so.