### PR TITLE
Switch CorrectIlluminationCalculate median filter back to "rank" method

### DIFF
--- a/cellprofiler/modules/correctilluminationcalculate.py
+++ b/cellprofiler/modules/correctilluminationcalculate.py
@@ -989,7 +989,7 @@ fewer iterations, but less accuracy.
             rescaled_pixel_data = pixel_data * 65535
             rescaled_pixel_data = rescaled_pixel_data.astype(numpy.uint16)
             rescaled_pixel_data *= mask
-            output_pixels = skimage.filters.median(rescaled_pixel_data, strel)
+            output_pixels = skimage.filters.median(rescaled_pixel_data, strel, behavior="rank")
         elif self.smoothing_method == SM_TO_AVERAGE:
             mean = numpy.mean(pixel_data[mask])
             output_pixels = numpy.ones(pixel_data.shape, pixel_data.dtype) * mean


### PR DESCRIPTION
It looks like in Skimage 0.16 (so CP4) the median filter implementation was switched from the `skimage.filters.rank` method to `scipy.ndimage`. This seems to be causing problems because the ndimage implementation is substantially slower when using a large structuring element.

The two methods produce slightly different results around the borders of images due to the different handling of pixels at the edge (ndimage fills out "missing" pixels to complete the window, rank doesn't). Otherwise the results match across the rest of the image.

Considering that large window sizes are common in many workflows, I think we really need to revert to using the rank filter.

Fixes #4369