### PR TITLE
Add "Keep Removed Objects" option to FilterObjects, support CPA3 classifiers

### DIFF
--- a/cellprofiler/modules/filterobjects.py
+++ b/cellprofiler/modules/filterobjects.py
@@ -1075,6 +1075,8 @@ value will be retained.""".format(
                 for feature_name in features
             ]
         )
+        if hasattr(classifier, 'scaler') and classifier.scaler is not None:
+            feature_vector = classifier.scaler.transform(feature_vector)
         predicted_classes = classifier.predict(feature_vector)
         hits = predicted_classes == target_class
         indexes = numpy.argwhere(hits) + 1

--- a/cellprofiler/modules/filterobjects.py
+++ b/cellprofiler/modules/filterobjects.py
@@ -649,6 +649,27 @@ value will be retained.""".format(
                     % self.rules_file_name.value,
                     self.rules_file_name,
                 )
+            features = []
+            for feature_name in self.get_classifier_features():
+                feature_name = feature_name.split("_", 1)[1]
+                if feature_name == "x_loc":
+                    feature_name = M_LOCATION_CENTER_X
+                elif feature_name == "y_loc":
+                    feature_name = M_LOCATION_CENTER_Y
+                features.append(feature_name)
+            available_features = set([col[1] for col in pipeline.get_measurement_columns(self) if col[0] == self.x_name.value])
+            for feature in features:
+                if feature not in available_features:
+                    raise ValidationError(
+                        (
+                            "The classifier %s, requires the measurement, %s "
+                            "for object %s, but that measurement is not available "
+                            "at this stage of the pipeline. Consider adding "
+                            "modules to produce the measurement."
+                        )
+                        % (self.rules_file_name, feature, self.x_name.value),
+                        self.rules_file_name,
+                    )
 
     def run(self, workspace):
         """Filter objects for this image set, display results"""

--- a/cellprofiler/modules/filterobjects.py
+++ b/cellprofiler/modules/filterobjects.py
@@ -1336,6 +1336,9 @@ value will be retained.""".format(
 
         return setting_values, variable_revision_number
 
+    def get_dictionary_for_worker(self):
+        # Sklearn models can't be serialized, so workers will need to read them from disk.
+        return {}
 
 #
 # backwards compatibility


### PR DESCRIPTION
This PR adds a new setting to FilterObjects, "Keep removed objects", which makes the module generate an object set from any objects which were excluded by the user's defined filter.

The rationale behind this is that users often want to group objects into positive and negative groups, but in the current release a second copy of the module is needed if the user wants to carry forward a set of objects that didn't pass the filter.

At least in this version, "removed" sets aren't generated from additional sets which the user has asked the module to relabel - it's only operating on the input objects. We could add this relatively easily, but I fear it might make the settings a bit too complicated if the user has to provide two names for each group. Thoughts appreciated.

I've also added support for CPA3-style classifiers and scalers. In doing so I've put in some proper validation when loading classifiers, previously we had no check for whether the necessary measurements were available in this mode.