### PR TITLE
CombineObjects performance optimisations

### DIFF
--- a/cellprofiler/modules/combineobjects.py
+++ b/cellprofiler/modules/combineobjects.py
@@ -188,16 +188,16 @@ subsequent modules.""",
 
         # Resolve non-conflicting labels first
         undisputed = numpy.logical_xor(labels_x > 0, labels_y > 0)
-        for label in indices_x:
-            mapped = labels_x == label
-            if numpy.all(undisputed[mapped]):
-                output[mapped] = label
-                labels_x[mapped] = 0
-        for label in indices_y:
-            mapped = labels_y == label
-            if numpy.all(undisputed[mapped]):
-                output[mapped] = label
-                labels_y[mapped] = 0
+
+        undisputed_x = numpy.setdiff1d(indices_x, labels_x[~undisputed])
+        mask = numpy.isin(labels_x, undisputed_x)
+        output = numpy.where(mask, labels_x, output)
+        labels_x[mask] = 0
+
+        undisputed_y = numpy.setdiff1d(indices_y, labels_y[~undisputed])
+        mask = numpy.isin(labels_y, undisputed_y)
+        output = numpy.where(mask, labels_y, output)
+        labels_y[mask] = 0
 
         # Resolve conflicting labels
         if method == "Discard":


### PR DESCRIPTION
One thing that's become apparent in daily use is that as image sizes and object counts grow, performance of the CombineObjects module degrades significantly.

In this PR I've revised the system for resolving non-conflicting objects (where the object in question doesn't overlap with anything in the other set). Previously we cycled through each object and added it to the output image. This was fine at a small scale, but large object sets and arrays become both time and memory intensive to run. To improve things I've made it so that we work out a list of which labels are undisputed, then copy those objects over in a single operation.

Trying this with a "heavy" pipeline (2k x 3k images) gives about an 8x speed improvement, completing an image in a few seconds rather than a minute. 