### PR TITLE
Handle boolean guide images in manual object annotation modules

### DIFF
--- a/cellprofiler/gui/editobjectsdlg.py
+++ b/cellprofiler/gui/editobjectsdlg.py
@@ -763,6 +763,8 @@ class EditObjectsDialog(wx.Dialog):
             image, _ = size_similarly(self.orig_labels[0], self.guide_image)
             if image.ndim == 2:
                 image = numpy.dstack((image, image, image))
+            if image.dtype == bool:
+                image = image.astype(int)
             if self.scaling_mode == self.SM_RAW:
                 cimage = image.copy()
             elif self.scaling_mode in (self.SM_NORMALIZED, self.SM_LOG_NORMALIZED):

--- a/cellprofiler/modules/editobjectsmanually.py
+++ b/cellprofiler/modules/editobjectsmanually.py
@@ -231,6 +231,8 @@ supplied by a previous module.
         if self.wants_image_display:
             guide_image = workspace.image_set.get_image(self.image_name.value)
             guide_image = guide_image.pixel_data
+            if guide_image.dtype == bool:
+                guide_image = guide_image.astype(int)
             if numpy.any(guide_image != numpy.min(guide_image)):
                 guide_image = (guide_image - numpy.min(guide_image)) / (
                     numpy.max(guide_image) - numpy.min(guide_image)


### PR DESCRIPTION
Fixes #4383

I think this is the most straightforward fix - we convert boolean images into integers, then let the default scaling parameters do the rest as normal. These images are only used for display, so there should be no consequences of changing dtype here.