### PR TITLE
Make ExportToDatabase support multichannel images when generating CPA properties files

### DIFF
--- a/cellprofiler/modules/exporttodatabase.py
+++ b/cellprofiler/modules/exporttodatabase.py
@@ -732,7 +732,8 @@ images. This option will do the following:
    **SaveImages** will be included.
 -  The CellProfiler image name will be used for the *image\_name* field.
 -  A channel color listed in the *image\_channel\_colors* field will be
-   assigned to the image by default order.
+   assigned to the image by default order. Multichannel images will be 
+   added as separate R, G and B channels.
 
 Select "*{NO}*" to specify which images should be included or to
 override the automatic values.""".format(
@@ -1405,7 +1406,9 @@ Enter a name for the specified image.""",
                 doc="""\
 *(Used only if creating a properties file and specifying the image information)*
 
-Enter a color to display this channel.""",
+Enter a color to display this channel.
+
+Multichannel images will use this colour for all 3 image components""",
             ),
         )
 

--- a/cellprofiler/modules/exporttodatabase.py
+++ b/cellprofiler/modules/exporttodatabase.py
@@ -2339,6 +2339,12 @@ available:
         if pipeline.test_mode:
             return True
 
+        # Clear out any redundant records from previous runs.
+        if workspace.measurements.hdf5_dict.has_feature("Experiment", "ExportToDb_Images"):
+            workspace.measurements.remove_measurement("Experiment", "ExportToDb_Images")
+        if workspace.measurements.hdf5_dict.has_feature("ExportToDb", "ExportToDb_Channels"):
+            workspace.measurements.remove_measurement("ExportToDb", "ExportToDb_Channels")
+
         needs_close = False
         try:
             # This is necessary to prevent python from thinking cellprofiler doesn't exist in this scope
@@ -2572,6 +2578,8 @@ available:
                 )
         if workspace.pipeline.test_mode:
             return
+        if self.save_cpa_properties.value:
+            self.record_image_channels(workspace)
         if self.db_type == DB_MYSQL and not workspace.pipeline.test_mode:
             try:
                 self.connection, self.cursor = connect_mysql(
@@ -4321,18 +4329,30 @@ CREATE TABLE %s (
                         for name in default_image_names
                     ]
                 )
+                channels_per_image = []
+
+                if workspace.measurements.hdf5_dict.has_feature("ExportToDb", "ExportToDb_Channels"):
+                    # We're in the post-run phase, fetch out the image channel counts
+                    images_list = workspace.measurements.get_experiment_measurement("ExportToDb_Images")
+                    if isinstance(images_list, str):
+                        images_list = [images_list]
+                    channels_list = workspace.measurements.get_measurement("ExportToDb", "ExportToDb_Channels")
+                    channels_dict = dict(zip(images_list, channels_list))
+                else:
+                    channels_dict = {}
+
+                for image in default_image_names:
+                    channels_per_image.append(channels_dict.get(image, 1))
+                num_images = sum(channels_per_image)
 
                 # Provide default colors
-                if len(default_image_names) == 1:
-                    image_channel_colors = "gray,"
+                if num_images == 1:
+                    image_channel_colors = ["gray"]
                 else:
-                    image_channel_colors = (
-                        "red, green, blue, cyan, magenta, yellow, gray, "
-                        + ("none, " * 10)
-                    )
+                    image_channel_colors = ["red", "green", "blue", "cyan", "magenta", "yellow", "gray"]
                     num_images = (
-                        len(default_image_names)
-                        + len(
+                        num_images
+                        + (len(
                             set(
                                 [
                                     name
@@ -4340,15 +4360,22 @@ CREATE TABLE %s (
                                 ]
                             ).difference(default_image_names)
                         )
-                        if self.want_image_thumbnails
-                        else 0
+                           if self.want_image_thumbnails
+                           else 0)
                     )
-                    image_channel_colors = ",".join(
-                        image_channel_colors.split(",")[:num_images]
-                    )
-                image_names_csl = ",".join(
-                    default_image_names
-                )  # Convert to comma-separated list
+                if len(image_channel_colors) > num_images:
+                    image_channel_colors = image_channel_colors[:num_images]
+                elif len(image_channel_colors) < num_images:
+                    image_channel_colors += ["none"] * (num_images - len(image_channel_colors))
+
+                # If we're in pre-run phase, store the image names we'll need
+                if not workspace.measurements.hdf5_dict.has_feature("Experiment", "ExportToDb_Images"):
+                    workspace.measurements.add_experiment_measurement("ExportToDb_Images", default_image_names)
+
+                # Convert to comma-separated lists
+                image_names_csl = ",".join(default_image_names)
+                image_channel_colors = ",".join(image_channel_colors)
+                channels_per_image = ",".join(map(str, channels_per_image))
 
                 if self.want_image_thumbnails:
                     selected_thumbs = [
@@ -4375,13 +4402,32 @@ CREATE TABLE %s (
                 user_image_names = []
                 image_channel_colors = []
                 selected_image_names = []
+                channels_per_image = []
+
+                if workspace.measurements.hdf5_dict.has_feature("Experiment", "ExportToDb_Images"):
+                    # We're in the post-run phase, fetch out the image channel counts
+                    images_list = workspace.measurements.get_experiment_measurement("ExportToDb_Images")
+                    if isinstance(images_list, str):
+                        images_list = [images_list]
+                    channels_list = workspace.measurements.get_measurement("ExportToDb", "ExportToDb_Channels")
+                    channels_dict = dict(zip(images_list, channels_list))
+                else:
+                    channels_dict = {}
+
                 for group in self.image_groups:
                     selected_image_names += [group.image_cols.value]
+                    num_channels = channels_dict.get(group.image_cols.value, 1)
+                    channels_per_image.append(num_channels)
                     if group.wants_automatic_image_name:
                         user_image_names += [group.image_cols.value]
                     else:
                         user_image_names += [group.image_name.value]
-                    image_channel_colors += [group.image_channel_colors.value]
+                    image_channel_colors += [group.image_channel_colors.value] * num_channels
+                channels_per_image = ",".join(map(str, channels_per_image))
+
+                # If we're in pre-run phase, store the image names we'll need
+                if not workspace.measurements.hdf5_dict.has_feature("Experiment", "ExportToDb_Images"):
+                    workspace.measurements.add_experiment_measurement("ExportToDb_Images", selected_image_names)
 
                 image_file_cols = ",".join(
                     [
@@ -4495,19 +4541,19 @@ CREATE TABLE %s (
                 self.get_table_prefix() + self.properties_class_table_name.value
             )
 
-            contents = """#%(date)s
+            contents = f"""#{date}
 # ==============================================
 #
-# CellProfiler Analyst 2.0 properties file
+# CellProfiler Analyst 3.0 properties file
 #
 # ==============================================
 
 # ==== Database Info ====
-%(db_info)s
+{db_info}
 
 # ==== Database Tables ====
-image_table   = %(spot_tables)s
-object_table  = %(cell_tables)s
+image_table   = {spot_tables}
+object_table  = {cell_tables}
 
 # ==== Database Columns ====
 # Specify the database column names that contain unique IDs for images and
@@ -4520,19 +4566,18 @@ object_table  = %(cell_tables)s
 #           tables
 # object_id: the object key column from your per-object table
 
-image_id      = %(unique_id)s
-object_id     = %(object_id)s
-plate_id      = %(plate_id)s
-well_id       = %(well_id)s
+image_id      = {unique_id}
+object_id     = {object_id}
+plate_id      = {plate_id}
+well_id       = {well_id}
 series_id     = Image_Group_Number
 group_id      = Image_Group_Number
 timepoint_id  = Image_Group_Index
 
 # Also specify the column names that contain X and Y coordinates for each
 # object within an image.
-cell_x_loc    = %(cell_x_loc)s
-cell_y_loc    = %(cell_y_loc)s
-
+cell_x_loc    = {cell_x_loc}
+cell_y_loc    = {cell_y_loc}
 # ==== Image Path and File Name Columns ====
 # Classifier needs to know where to find the images from your experiment.
 # Specify the column names from your per-image table that contain the image
@@ -4544,21 +4589,36 @@ cell_y_loc    = %(cell_y_loc)s
 # adding those column names here.
 #
 # Note that these lists must have equal length!
-image_path_cols = %(image_path_cols)s
-image_file_cols = %(image_file_cols)s
+image_path_cols = {image_path_cols}
+image_file_cols = {image_file_cols}
 
 # CellProfiler Analyst will now read image thumbnails directly from the database, if chosen in ExportToDatabase.
-image_thumbnail_cols = %(image_thumbnail_cols)s
+image_thumbnail_cols = {image_thumbnail_cols}
 
 # Give short names for each of the channels (respectively)...
-image_names = %(image_names_csl)s
+image_names = {image_names_csl}
 
 # Specify a default color for each of the channels (respectively)
 # Valid colors are: [red, green, blue, magenta, cyan, yellow, gray, none]
-image_channel_colors = %(image_channel_colors)s
+image_channel_colors = {image_channel_colors}
+
+# Number of channels present in each image file?  If left blank, CPA will expect 
+# to find 1 channel per image.
+# eg: If the image specified by the first image_channel_file field is RGB, but
+# the second image had only 1 channel you would set: channels_per_image = 3, 1
+# Doing this would require that you pass 4 values into image_names,
+# image_channel_colors, and image_channel_blend_modes
+channels_per_image  = {channels_per_image}
+
+# How to blend in each channel into the image. Use: add, subtract, or solid.
+# If left blank all channels are blended additively, this is best for 
+# fluorescent images.
+# Subtract or solid may be desirable when you wish to display outlines over a 
+# brightfield image so the outlines are visible against the light background.
+image_channel_blend_modes =
 
 # ==== Image Accesss Info ====
-image_url_prepend = %(image_url)s
+image_url_prepend = {image_url}
 
 # ==== Dynamic Groups ====
 # Here you can define groupings to choose from when classifier scores your experiment.  (e.g., per-well)
@@ -4571,7 +4631,7 @@ image_url_prepend = %(image_url)s
 #   group_SQL_Gene       =  SELECT Per_Image_Table.TableNumber, Per_Image_Table.ImageNumber, Well_ID_Table.gene FROM Per_Image_Table, Well_ID_Table WHERE Per_Image_Table.well=Well_ID_Table.well
 #   group_SQL_Well+Gene  =  SELECT Per_Image_Table.TableNumber, Per_Image_Table.ImageNumber, Well_ID_Table.well, Well_ID_Table.gene FROM Per_Image_Table, Well_ID_Table WHERE Per_Image_Table.well=Well_ID_Table.well
 
-%(group_statements)s
+{group_statements}
 
 # ==== Image Filters ====
 # Here you can define image filters to let you select objects from a subset of your experiment when training the classifier.
@@ -4582,7 +4642,7 @@ image_url_prepend = %(image_url)s
 #   filter_SQL_EMPTY  =  SELECT TableNumber, ImageNumber FROM CPA_per_image, Well_ID_Table WHERE CPA_per_image.well=Well_ID_Table.well AND Well_ID_Table.Gene="EMPTY"
 #   filter_SQL_CDKs   =  SELECT TableNumber, ImageNumber FROM CPA_per_image, Well_ID_Table WHERE CPA_per_image.well=Well_ID_Table.well AND Well_ID_Table.Gene REGEXP 'CDK.*'
 
-%(filter_statements)s
+{filter_statements}
 
 # ==== Meta data ====
 # What are your objects called?
@@ -4591,7 +4651,7 @@ image_url_prepend = %(image_url)s
 object_name  =  cell, cells,
 
 # What size plates were used?  96, 384 or 5600?  This is for use in the PlateViewer. Leave blank if none
-plate_type  = %(plate_type)s
+plate_type  = {plate_type}
 
 # ==== Excluded Columns ====
 # OPTIONAL
@@ -4636,7 +4696,7 @@ image_size =
 # If left blank or set to "object", then Classifier will fetch objects (default).
 # If set to "image", then Classifier will fetch whole images instead of objects.
 
-classification_type  = %(classification_type)s
+classification_type  = {classification_type}
 
 # ======== Auto Load Training Set ========
 # OPTIONAL
@@ -4659,21 +4719,59 @@ area_scoring_column =
 # Classifier to write out class information for each object in the
 # object_table
 
-class_table  = %(class_table)s
+class_table  = {class_table}
 
 # ======== Check Tables ========
 # OPTIONAL
 # [yes/no]  You can ask classifier to check your tables for anomalies such
-# as orphaned objects or missing column indices.  Default is on.
+# as orphaned objects or missing column indices.  Default is off.
 # This check is run when Classifier starts and may take up to a minute if
 # your object_table is extremely large.
 
-check_tables = yes
+check_tables = no
+
+
+# ======== Force BioFormats ========
+# OPTIONAL
+# [yes/no]  By default, CPA will try to use the imageio library to load images
+# which are in supported formats, then fall back to using the older BioFormats
+# loader if something goes wrong. ImageIO is faster but some unusual file
+# compression formats can cause errors when loading. This option forces CPA to
+# always use the BioFormats reader. Try this if images aren't displayed correctly.
+
+force_bioformats = no
+
+
+# ======== Use Legacy Fetcher ========
+# OPTIONAL
+# [yes/no]  In CPA 3.0 the object fetching system has been revised to be more
+# efficient. In the vast majority of cases it should be faster than the previous
+# versions. However, some complex object filters can still cause problems. If you
+# encounter slowdowns this setting allows you to switch back to the old method of
+# fetching and randomisation.
+
+use_legacy_fetcher = no
+
     """ % (
                 locals()
             )
             result.append(Properties(properties_object_name, file_name, contents))
         return result
+
+    def record_image_channels(self, workspace):
+        # We only have access to the image details during the run itself.
+        # Fetch out the images we want in the properties file and log their channel counts.
+        image_list = workspace.measurements.get_experiment_measurement("ExportToDb_Images")
+        channel_list = []
+        if isinstance(image_list, str):
+            image_list = [image_list]
+        for image_name in image_list:
+            img = workspace.image_set.get_image(image_name)
+            if img.multichannel:
+                channel_list.append(img.image.shape[-1])
+            else:
+                channel_list.append(1)
+        workspace.measurements.add_measurement("ExportToDb", "ExportToDb_Channels", channel_list)
 
     def write_workspace_file(self, workspace):
         """If requested, write a workspace file with selected measurements"""

--- a/cellprofiler/modules/exporttodatabase.py
+++ b/cellprofiler/modules/exporttodatabase.py
@@ -1408,7 +1408,7 @@ Enter a name for the specified image.""",
 
 Enter a color to display this channel.
 
-Multichannel images will use this colour for all 3 image components""",
+Multichannel images will use this color for all 3 image components""",
             ),
         )
 

--- a/tests/modules/test_exporttodatabase.py
+++ b/tests/modules/test_exporttodatabase.py
@@ -5732,7 +5732,9 @@ class TestExportToDatabase(unittest.TestCase):
             cursor.execute(how_many)
             assert cursor.fetchall()[0][0] == 0
         finally:
-            self.drop_tables(module)
+            cursor.close()
+            connection.close()
+            finally_fn()
 
     def test_dbcontext_mysql(self):
         if not self.test_mysql:


### PR DESCRIPTION
Fixes #3991

This PR updates the ExportToDatabase CPA properties file template for CPA 3, so generated files will now contain all the new optional parameters (set to defaults).

I've also put together a system to automatically figure out appropriate channel number and colour settings when generating a properties file for multichannel images.

This proved to be a little complicated due to the way the files are generated. The CPA properties file contents are actually generated twice for some reason, in both the pre-run and post-run phases. In the former it looks like this is sometimes logged into the database itself as the Experiment_Properties table. We have no access to image information before the run starts so that'll default to assuming 1 channel per image as before. However, during the pre-run phase we do now have access to the list of images we want the properties file to reference, so we store that as an experiment measurement for later. During the run we then call back that list and store the number of channels we see in each image as a hidden measurement in the HDF5 file. Because of how measurements work I couldn't find an effective way to only determine that list once per run - image data isn't available in the post run phase, so it'll currently generate the list for every image set. It's quick so I doubt that's too much of a problem. We can call the stored channels list back during the post run and use it to populate the properties file properly.

In effect, the generated .properties file will now include `channels_per_image` and a correct list of `image_channel_colors`, but the properties table in a database will retain the old system of assuming 1 channel per image. Hopefully this is workable enough to make use of anyway, since we primarily use .properties files.

I've also switched the properties file generator to use f-strings, since it's easier to read and a bit faster.