### PR TITLE
Fix handling of pipelines/projects supplied at startup

### DIFF
--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -522,19 +522,11 @@ def parse_args(args):
     )
 
     options, result_args = parser.parse_args(args[1:])
-
-    if sys.platform == "darwin" and len(args) == 2:
-        if args[1].lower().endswith(".cpproj"):
-            # Assume fakey open of .cpproj and OS can't be configured to
-            # add the switch as it can in Windows.
-            options.project_filename = args[1]
-
-            result_args = []
-        elif args[1].lower().endswith(".cpproj"):
+    if len(args) == 2:
+        if args[1].lower().endswith((".cpproj", ".cppipe")):
+            # Opening a file with CellProfiler will supply the file as an argument
             options.pipeline_filename = args[1]
-
             result_args = []
-
     return options, result_args
 
 


### PR DESCRIPTION
Towards fixing #4400

The system for opening a workspace or pipeline on startup seems to work just fine, but our handling of incoming arguments was incomplete.

It sounds like at some point in time the Windows installer was set up to register an "opened with" file with a specific flag. If that's the case the setup for this is long gone, so we might as well unify Windows and MacOS handling of incoming files.

I'm going to make some revisions to the Windows installer to properly setup filetype associations. Something similar might be needed on MacOS, but I'm not sure how to approach that case.