### PR TITLE
Correctly handle multichannel stacked images

### DIFF
--- a/cellprofiler/modules/graytocolor.py
+++ b/cellprofiler/modules/graytocolor.py
@@ -515,6 +515,7 @@ pixel values are multiplied by this weight before assigning the color.
         rgb_pixel_data = None
         input_image_names = []
         channel_names = []
+        channelstack =  self.scheme_choice == SCHEME_STACK
         if self.scheme_choice not in (SCHEME_STACK, SCHEME_COMPOSITE):
             for color_scheme_setting in self.color_scheme_settings:
                 if color_scheme_setting.image_name.is_blank:
@@ -590,7 +591,7 @@ pixel values are multiplied by this weight before assigning the color.
         ##############
         # Save image #
         ##############
-        rgb_image = Image(rgb_pixel_data, parent_image=parent_image)
+        rgb_image = Image(rgb_pixel_data, parent_image=parent_image, channelstack=channelstack)
         rgb_image.channel_names = channel_names
         imgset.add(self.rgb_image_name.value, rgb_image)
 

--- a/cellprofiler/modules/saveimages.py
+++ b/cellprofiler/modules/saveimages.py
@@ -367,7 +367,8 @@ Choose whether or not to use lossless compression when saving
 images. This will lead to smaller file sizes, but somewhat longer 
 module execution time.  Note that the value of this setting will
 be ignored when saving 3D tiff images, which have been saved by
-default with compression since CellProfiler 3.1."""
+default with compression since CellProfiler 3.1. Do not use for
+multichannel tiff images"""
         )
 
         self.stack_axis = Choice(
@@ -737,6 +738,7 @@ store images in the subfolder, "*date*\/*plate-name*".""",
         if self.file_format == FF_NPY:
             numpy.save(filename, pixels)
         else:
+            save_kwargs = {}
             if self.get_bit_depth() == BIT_DEPTH_8:
                 pixels = skimage.util.img_as_ubyte(pixels)
             elif self.get_bit_depth() == BIT_DEPTH_16:
@@ -751,12 +753,11 @@ store images in the subfolder, "*date*\/*plate-name*".""",
             if (
                 not image.volumetric
                 and len(pixels.shape) > 2
-                and pixels.shape[2] > 4
-                and self.file_format.value != FF_H5
+                and pixels.shape[2] != 3
+                and self.file_format.value == FF_TIFF
             ):
                 pixels = numpy.transpose(pixels, (2, 0, 1))
-
-            save_kwargs = {}
+                save_kwargs.update({'imagej':True})
 
             if (image.volumetric or self.tiff_compress.value) and self.file_format.value == FF_TIFF:
                 save_kwargs.update({"compress": 6})

--- a/cellprofiler/modules/saveimages.py
+++ b/cellprofiler/modules/saveimages.py
@@ -753,7 +753,7 @@ store images in the subfolder, "*date*\/*plate-name*".""",
             if (
                 not image.volumetric
                 and len(pixels.shape) > 2
-                and pixels.shape[2] != 3
+                and image.channelstack
                 and self.file_format.value == FF_TIFF
             ):
                 pixels = numpy.transpose(pixels, (2, 0, 1))

--- a/cellprofiler/modules/saveimages.py
+++ b/cellprofiler/modules/saveimages.py
@@ -368,7 +368,7 @@ images. This will lead to smaller file sizes, but somewhat longer
 module execution time.  Note that the value of this setting will
 be ignored when saving 3D tiff images, which have been saved by
 default with compression since CellProfiler 3.1. Do not use for
-multichannel tiff images"""
+multichannel tiff images created as Stacks in GrayToColor."""
         )
 
         self.stack_axis = Choice(


### PR DESCRIPTION
Resolves #4401 .  Requires https://github.com/CellProfiler/core/pull/80.

This allows 2-4 stacked channel images saved to be correctly saved as multichannel (vs RGB(A)) tiffs, and >4 channel tiffs to be correctly interpreted by ImageJ as multichannel rather than multistack.

Right now the only module which sets the `channelstack` property is GrayToColor, but I could definitely imagine it being useful in other modules such as the Overlay modules. 