### PR TITLE
FilterObjects CPA classifier support and 'keep removed objects' option.

### DIFF
--- a/cellprofiler/modules/filterobjects.py
+++ b/cellprofiler/modules/filterobjects.py
@@ -649,6 +649,27 @@ value will be retained.""".format(
                     % self.rules_file_name.value,
                     self.rules_file_name,
                 )
+            features = []
+            for feature_name in self.get_classifier_features():
+                feature_name = feature_name.split("_", 1)[1]
+                if feature_name == "x_loc":
+                    feature_name = M_LOCATION_CENTER_X
+                elif feature_name == "y_loc":
+                    feature_name = M_LOCATION_CENTER_Y
+                features.append(feature_name)
+            available_features = set([col[1] for col in pipeline.get_measurement_columns(self) if col[0] == self.x_name.value])
+            for feature in features:
+                if feature not in available_features:
+                    raise ValidationError(
+                        (
+                            "The classifier %s, requires the measurement, %s "
+                            "for object %s, but that measurement is not available "
+                            "at this stage of the pipeline. Consider adding "
+                            "modules to produce the measurement."
+                        )
+                        % (self.rules_file_name, feature, self.x_name.value),
+                        self.rules_file_name,
+                    )
 
     def run(self, workspace):
         """Filter objects for this image set, display results"""

--- a/cellprofiler/modules/filterobjects.py
+++ b/cellprofiler/modules/filterobjects.py
@@ -1197,7 +1197,7 @@ value will be retained.""".format(
             additional_objects=[
                 (x.object_name.value, x.target_name.value)
                 for x in self.additional_objects
-            ] + ([self.removed_objects_name.value] if self.keep_removed_objects.value else []),
+            ] + [(self.x_name.value,self.removed_objects_name.value)] if self.keep_removed_objects.value else [],
         )
 
     def get_categories(self, pipeline, object_name):

--- a/cellprofiler/modules/filterobjects.py
+++ b/cellprofiler/modules/filterobjects.py
@@ -1077,6 +1077,8 @@ value will be retained.""".format(
                 for feature_name in features
             ]
         )
+        if hasattr(classifier, 'scaler') and classifier.scaler is not None:
+            feature_vector = classifier.scaler.transform(feature_vector)
         predicted_classes = classifier.predict(feature_vector)
         hits = predicted_classes == target_class
         indexes = numpy.argwhere(hits) + 1

--- a/cellprofiler/modules/filterobjects.py
+++ b/cellprofiler/modules/filterobjects.py
@@ -138,7 +138,7 @@ PO_ALL = [PO_BOTH, PO_PARENT_WITH_MOST_OVERLAP]
 class FilterObjects(ObjectProcessing):
     module_name = "FilterObjects"
 
-    variable_revision_number = 8
+    variable_revision_number = 9
 
     def create_settings(self):
         super(FilterObjects, self).create_settings()
@@ -369,13 +369,32 @@ with data processed as 3D.
             ),
         )
 
+
+        self.keep_removed_objects = Binary(
+            "Keep removed objects as a seperate set?",
+            False,
+            doc="""
+Select *Yes* to create an object set from objects that did not pass your filter.
+            
+This may be useful if you want to make use of the negative (filtered out) population as well."""
+        )
+
+        self.removed_objects_name = LabelName(
+            "Name the objects removed by the filter",
+            "RemovedObjects",
+            doc="Enter the name you want to call the objects removed by the filter.",
+
+        )
+
         self.additional_objects = []
 
         self.additional_object_count = HiddenCount(
             self.additional_objects, "Additional object count"
         )
 
-        self.spacer_3 = Divider(line=False)
+        self.spacer_3 = Divider(line=True)
+
+        self.spacer_4 = Divider(line=False)
 
         self.additional_object_button = DoSomething(
             "Relabel additional objects to match the filtered object?",
@@ -522,6 +541,8 @@ value will be retained.""".format(
             self.measurement_count,
             self.additional_object_count,
             self.per_object_assignment,
+            self.keep_removed_objects,
+            self.removed_objects_name,
         ]
 
         for x in self.measurements:
@@ -542,6 +563,8 @@ value will be retained.""".format(
             self.rules_directory,
             self.rules_file_name,
             self.rules_class,
+            self.keep_removed_objects,
+            self.removed_objects_name,
             self.enclosing_object_name,
             self.additional_object_button,
         ]
@@ -591,7 +614,10 @@ value will be retained.""".format(
                         visible_settings += [group.remover]
                     visible_settings += [group.divider]
                 visible_settings += [self.add_measurement_button]
-        visible_settings.append(self.spacer_3)
+        visible_settings += [self.spacer_3, self.keep_removed_objects]
+        if self.keep_removed_objects.value:
+            visible_settings += [self.removed_objects_name]
+        visible_settings += [self.spacer_4]
         for x in self.additional_objects:
             visible_settings += x.visible_settings()
         visible_settings += [self.additional_object_button]
@@ -736,11 +762,49 @@ value will be retained.""".format(
 
             self.add_measurements(workspace, src_name, target_name)
 
-            if self.show_window and first_set:
-                workspace.display_data.src_objects_segmented = src_objects.segmented
-                workspace.display_data.target_objects_segmented = target_objects.segmented
-                workspace.display_data.dimensions = src_objects.dimensions
-                first_set = False
+        if self.keep_removed_objects.value:
+            # Isolate objects removed by the filter
+            removed_indexes = [x for x in range(1, max_label+1) if x not in indexes]
+            removed_object_count = len(removed_indexes)
+            removed_label_indexes = numpy.zeros((max_label + 1,), int)
+            removed_label_indexes[removed_indexes] = numpy.arange(1, removed_object_count + 1)
+
+            src_objects = workspace.get_objects(self.x_name.value)
+            removed_labels = src_objects.segmented.copy()
+            #
+            # Reindex the labels of the old source image
+            #
+            removed_labels[removed_labels > max_label] = 0
+            removed_labels = removed_label_indexes[removed_labels]
+            #
+            # Make a new set of objects - retain the old set's unedited
+            # segmentation for the new and generally try to copy stuff
+            # from the old to the new.
+            #
+            removed_objects = cellprofiler_core.object.Objects()
+            removed_objects.segmented = removed_labels
+            removed_objects.unedited_segmented = src_objects.unedited_segmented
+            #
+            # Remove the filtered objects from the small_removed_segmented
+            # if present. "small_removed_segmented" should really be
+            # "filtered_removed_segmented".
+            #
+            small_removed = src_objects.small_removed_segmented.copy()
+            small_removed[(removed_labels == 0) & (src_objects.segmented != 0)] = 0
+            removed_objects.small_removed_segmented = small_removed
+            if src_objects.has_parent_image:
+                removed_objects.parent_image = src_objects.parent_image
+            workspace.object_set.add_objects(removed_objects, self.removed_objects_name.value)
+
+            self.add_measurements(workspace, self.x_name.value, self.removed_objects_name.value)
+
+        if self.show_window and first_set:
+            workspace.display_data.src_objects_segmented = src_objects.segmented
+            workspace.display_data.target_objects_segmented = target_objects.segmented
+            if self.keep_removed_objects.value:
+                workspace.display_data.removed_objects_segmented = removed_objects.segmented
+            workspace.display_data.dimensions = src_objects.dimensions
+            first_set = False
 
     def display(self, workspace, figure):
         """Display what was filtered"""
@@ -779,6 +843,17 @@ value will be retained.""".format(
                 "Number of objects post-filtering",
             ),
         )
+
+        if self.keep_removed_objects:
+            removed_objects_segmented = workspace.display_data.removed_objects_segmented
+            figure.subplot_imshow_labels(
+                1,
+                1,
+                removed_objects_segmented,
+                title="Removed: %s" % self.removed_objects_name,
+                sharexy=figure.subplot(0, 0),
+            )
+
 
     def keep_one(self, workspace, src_objects):
         """Return an array containing the single object to keep
@@ -1248,6 +1323,12 @@ value will be retained.""".format(
             )
 
             variable_revision_number = 8
+
+        if variable_revision_number == 8:
+            # Add default values for "keep removed objects".
+            setting_values.insert(11, "No")
+            setting_values.insert(12, "RemovedObjects")
+            variable_revision_number = 9
 
         slot_directory = 5
 

--- a/cellprofiler/modules/filterobjects.py
+++ b/cellprofiler/modules/filterobjects.py
@@ -1338,6 +1338,9 @@ value will be retained.""".format(
 
         return setting_values, variable_revision_number
 
+    def get_dictionary_for_worker(self):
+        # Sklearn models can't be serialized, so workers will need to read them from disk.
+        return {}
 
 #
 # backwards compatibility


### PR DESCRIPTION
Continued and rebased from #4388.

---

This PR adds a new setting to FilterObjects, "Keep removed objects", which makes the module generate an object set from any objects which were excluded by the user's defined filter.

The rationale behind this is that users often want to group objects into positive and negative groups, but in the current release a second copy of the module is needed if the user wants to carry forward a set of objects that didn't pass the filter.

At least in this version, "removed" sets aren't generated from additional sets which the user has asked the module to relabel - it's only operating on the input objects. We could add this relatively easily, but I fear it might make the settings a bit too complicated if the user has to provide two names for each group. Thoughts appreciated.

I've also added support for CPA3-style classifiers and scalers. In doing so I've put in some proper validation when loading classifiers, previously we had no check for whether the necessary measurements were available in this mode.