### PR TITLE
Measure orientation in degrees rather than radians

### DIFF
--- a/cellprofiler/modules/measureobjectsizeshape.py
+++ b/cellprofiler/modules/measureobjectsizeshape.py
@@ -672,7 +672,7 @@ module.""".format(
                 F_MAJOR_AXIS_LENGTH: props["major_axis_length"],
                 F_MINOR_AXIS_LENGTH: props["minor_axis_length"],
                 F_ECCENTRICITY: props["eccentricity"],
-                F_ORIENTATION: props["orientation"],
+                F_ORIENTATION: props["orientation"] * (180 / numpy.pi),
                 F_CENTER_X: props["centroid-1"],
                 F_CENTER_Y: props["centroid-0"],
                 F_BBOX_AREA: props["bbox_area"],


### PR DESCRIPTION
Fixes #4363. CP3 and earlier were in degrees and people seem to expect degrees as the unit.