### PR TITLE
Fix ExportToDatabase CPA properties file generation

### DIFF
--- a/cellprofiler/modules/exporttodatabase.py
+++ b/cellprofiler/modules/exporttodatabase.py
@@ -4266,6 +4266,11 @@ CREATE TABLE %s (
             "image" if self.properties_classification_type.value == CT_IMAGE else ""
         )
 
+        if not object_names:
+            # If we're in pre-run phase, store the image names we'll need
+            if not workspace.measurements.hdf5_dict.has_feature("Experiment", "ExportToDb_Images"):
+                workspace.measurements.add_experiment_measurement("ExportToDb_Images", default_image_names)
+
         for object_name in object_names:
             if object_name:
                 if self.objects_choice != O_NONE:


### PR DESCRIPTION
Turns out there's a very specific scenario where ExportToDatabase's new colour detection system fails and crashes the module. If you're in "1 table per object type" mode, without custom groups defined, and exporting all objects, the pre-run phase generates an empty objects list and therefore fails to run the image list measurement writing step.

I've added an extra call that'll ensure that write takes place if there are no objects during pre-run.