### PR TITLE
Fix missing exception reports in error dialog

### DIFF
--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -1702,7 +1702,7 @@ class PipelineController(object):
             except:
                 pass
             if error_msg is None:
-                if isinstance(event.error, EnvironmentError):
+                if isinstance(event.error, EnvironmentError) and event.error.strerror is not None:
                     error_msg = event.error.strerror
                 else:
                     error_msg = str(event.error)


### PR DESCRIPTION
I found an issue wherein the error dialog fails to properly display an exception message.

![image](https://user-images.githubusercontent.com/26802537/124661528-9a86d680-de75-11eb-9248-a844caa661c2.png)

This primarily occurs when the input modules trigger an OSError. The handler is set up to display the EnvironmentError-specific parameter which represents the exception as a string, but this does not exist for absolutely all possible OSErrors. It defaults to None if that parameter is absent. To better handle this, I've now made it so that if that string is not defined it'll just use the default string representation of the exception, which produces a normal error message.