### PR TITLE
Upgrade to 'faster' Costes automatically when loading CP3 pipelines

### DIFF
--- a/cellprofiler/modules/measurecolocalization.py
+++ b/cellprofiler/modules/measurecolocalization.py
@@ -1606,7 +1606,7 @@ Alternatively, you may want to disable these specific measurements entirely
             variable_revision_number = 4
         if variable_revision_number == 4:
             # Add costes mode switch
-            setting_values += [M_ACCURATE]
+            setting_values += [M_FASTER]
             variable_revision_number = 5
         return setting_values, variable_revision_number
 


### PR DESCRIPTION
A common problem has been people trying to upgrade CP3 CellPainting pipelines to CP4, then finding that MeasureColocalization is impractically slow to run. We previously used 'Accurate' mode as the default when upgrading, but since this is so slow on 16-bit images most users need to change to 'Faster' mode to use their pipelines. Having tested this more thoroughly when benchmarking CP4 and found no difference in results, I think it's safe to have 'faster' mode as the default when upgrading the module. This would save a lot of troubleshooting.