### PR TITLE
Improve file list loader performance

### DIFF
--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -2076,7 +2076,7 @@ class PipelineController(object):
             self.__workspace.invalidate_image_set()
 
     def on_pathlist_drop_files(self, x, y, filenames):
-        self.add_paths_to_pathlist(filenames)
+        wx.CallAfter(self.add_paths_to_pathlist, filenames)
 
     def add_paths_to_pathlist(self, filenames):
         t0 = datetime.datetime.now()

--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -2103,6 +2103,46 @@ class PipelineController(object):
                 filenames=filenames, interrupt=[True], message=["Default"], queue=queue
             ):
                 urls = []
+                if len(filenames) > 100:
+                    # If we have many files to process, it's faster to just scan the whole parent folder.
+                    desired = set(filenames)
+                    # All files added in 1 operation should come from the same parent directory.
+                    parent = os.path.dirname(filenames[0])
+                    # Scandir produces a generator that'll automatically distinguish files from folders
+                    options = os.scandir(parent)
+                    for path in options:
+                        if not interrupt or interrupt[0]:
+                            break
+                        if path.path in desired:
+                            message[0] = "\nProcessing " + path.path
+                            desired.remove(path.path)
+                            if path.is_file():
+                                urls.append(pathname2url(path.path))
+                                if len(urls) > 100:
+                                    queue.put(urls)
+                                    urls = []
+                            elif path.is_dir():
+                                for dirpath, dirnames, filenames in os.walk(path.path):
+                                    for filename in filenames:
+                                        if not interrupt or interrupt[0]:
+                                            break
+                                        path = os.path.join(dirpath, filename)
+                                        urls.append(pathname2url(path))
+                                        message[0] = "\nProcessing " + path
+                                        if len(urls) > 100:
+                                            queue.put(urls)
+                                            urls = []
+                                    else:
+                                        continue
+                                    break
+                            if not desired:
+                                # Stop the generator once all paths are found
+                                break
+                    queue.put(urls)
+                    urls = []
+                    # In case of missing files or mixed parent directories, we'll use the old method to fetch the rest.
+                    filenames = list(desired)
+
                 for pathname in filenames:
                     if not interrupt or interrupt[0]:
                         break
@@ -2114,8 +2154,8 @@ class PipelineController(object):
                             queue.put(urls)
                             urls = []
                     elif os.path.isdir(pathname):
-                        for dirpath, dirnames, filenames in os.walk(pathname):
-                            for filename in filenames:
+                        for dirpath, dirnames, files in os.walk(pathname):
+                            for filename in files:
                                 if not interrupt or interrupt[0]:
                                     break
                                 path = os.path.join(dirpath, filename)

--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -2107,16 +2107,6 @@ class PipelineController(object):
                     if not interrupt or interrupt[0]:
                         break
 
-                    # Hack - convert drive names to lower case in
-                    #        Windows to normalize them.
-                    isWindows = (
-                        sys.platform == "win32"
-                        and pathname[0].isalpha()
-                        and pathname[1] == ":"
-                    )
-                    if isWindows:
-                        pathname = os.path.normpath(pathname[:2]) + pathname[2:]
-
                     message[0] = "\nProcessing " + pathname
                     if os.path.isfile(pathname):
                         urls.append(pathname2url(pathname))


### PR DESCRIPTION
A consistent problem when populating the file list (at least in Windows) has been it taking a very long time to add large lists of files. If you drop a directory the result is fast because we scan subfolders with `os.walk`, but if we select the actual contents of a folder and drop 1000 files, CellProfiler would call `os.path.isfile` on every entry. On a fast local drive this isn't a massive issue, but over a network this can end up taking around 0.25s per file.

To resolve this, I've added another strategy which kicks in if the dropped file list has over 100 entries. In the new mode, we detect and call `os.scandir` on the source directory which the files came from. This produces a generator which automatically determines whether each entry is a file or folder, so we can avoid calling `os.path.isfile`. In my testing this generator is a lot faster once you're adding more than ~100 files.

Alongside this, I've also modified the loading sequence so that the OS's drag and drop functionality is released before we try to add the files to the list. Previously you couldn't perform any other drag-drop operations on your system until CellProfiler had finished processing the path list. That was particularly annoying if it'd take 30 mins to test all the files.

There was also some code to convert Windows drive letters to lower case, but it seems entirely redundant. I expect this was to work around issues in an older Python version so I've removed this for now.