### PR TITLE
Improve java detection in builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,5 +112,7 @@ jobs:
 name: create-release
 on:
   push:
-    tags:
-      - "v*"
+#    tags:
+#      - "v*"
+    branches:
+      - java_detection

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,5 @@ jobs:
 name: create-release
 on:
   push:
-#    tags:
-#      - "v*"
-    branches:
-      - java_detection
+    tags:
+      - "v*"

--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -79,7 +79,7 @@ if hasattr(sys, "frozen"):
                     print(f"Failed to detect java automatically. Searched in: {test_dir}.")
             assert "JAVA_HOME" in os.environ and os.path.exists(os.environ['JAVA_HOME'])
             # Ensure we start in the correct directory when launching a build.
-            print(f"Startup params: {sys.prefix=}, {os.getcwd()=}")
+            # Opening a file directly may end up with us starting on the wrong drive.
             os.chdir(sys.prefix)
         except AssertionError:
             print(

--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -74,7 +74,7 @@ if hasattr(sys, "frozen"):
                 # Use built-in java
                 test_dir = os.path.abspath(os.path.join(sys.prefix, "java"))
                 if os.path.exists(test_dir):
-                    os.environ["JAVA_HOME"] = os.path.abspath(os.path.join(sys.prefix, "java"))
+                    os.environ["JAVA_HOME"] = test_dir
                 else:
                     print(f"Failed to detect java automatically. Searched in: {test_dir}.")
             assert "JAVA_HOME" in os.environ and os.path.exists(os.environ['JAVA_HOME'])

--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -78,6 +78,9 @@ if hasattr(sys, "frozen"):
                 else:
                     print(f"Failed to detect java automatically. Searched in: {test_dir}.")
             assert "JAVA_HOME" in os.environ and os.path.exists(os.environ['JAVA_HOME'])
+            # Ensure we start in the correct directory when launching a build.
+            print(f"Startup params: {sys.prefix=}, {os.getcwd()=}")
+            os.chdir(sys.prefix)
         except AssertionError:
             print(
                 "CellProfiler Startup ERROR: Could not find path to Java environment directory.\n"


### PR DESCRIPTION
We've still been having some issues with javabridge finding the java environment packaged into Windows builds. This should hopefully set things up correctly if the user didn't have any environment variables set at all.

I've also ported over the automatic java-finding from CPA for MacOS. Not sure if this is redundant, but it should avoid the need to manually set environment variables or have java installed elsewhere when running a build.