### PR TITLE
Ensure rescaled GrayToColor images remain within float range

### DIFF
--- a/cellprofiler/modules/graytocolor.py
+++ b/cellprofiler/modules/graytocolor.py
@@ -588,6 +588,10 @@ pixel values are multiplied by this weight before assigning the color.
                         image = image / numpy.max(image)
                     rgb_pixel_data = rgb_pixel_data + image[:, :, numpy.newaxis] * color
 
+        if self.scheme_choice != SCHEME_STACK and self.wants_rescale.value:
+            # If we rescaled, clip values that went out of range after multiplication
+            rgb_pixel_data[rgb_pixel_data > 1] = 1
+
         ##############
         # Save image #
         ##############


### PR DESCRIPTION
This has popped up a few times on the forum. When using SaveImages the image to export must be in float 0-1 range despite the data type supporting higher values. We recently added a rescaling function to GrayToColor that independently rescales each channel before overlay. However, when working with multiple channels in composite mode, or applying a multiplier to the image before overlay, the resulting RGB image can exceed the 0-1 range and would crash SaveImages. I had assumed that out-of-range values would be clipped when generating an image object, but apparently this only happens with values below 0.

In this PR I've added a step which clips values >1 if the user enabled rescaling. This makes the multipliers correctly "blow out" intensity with the rescaling option enabled, and ensures that the resulting image is always a valid SaveImages target.