### PR TITLE
Support display of text-based measurements

### DIFF
--- a/cellprofiler/gui/workspace_view/_workspace_view.py
+++ b/cellprofiler/gui/workspace_view/_workspace_view.py
@@ -490,7 +490,7 @@ class WorkspaceView:
                     continue
                 height = 0
                 for j, measurement_row in enumerate(measurement_rows):
-                    if len(values[j]) <= i or numpy.isnan(values[j][i]):
+                    if len(values[j]) <= i or (not isinstance(values[j][i], str) and numpy.isnan(values[j][i])):
                         continue
                     value = values[j][i]
                     font = measurement_row.font
@@ -506,10 +506,11 @@ class WorkspaceView:
                             measurement_row.background_color,
                         )
                     ]
-
-                    fmt = "%%.%df" % measurement_row.precision
+                    if not isinstance(value, str):
+                        fmt = "%%.%df" % measurement_row.precision
+                        value = fmt % value
                     a = self.axes.annotate(
-                        fmt % value,
+                        value,
                         (xi, yi),
                         xytext=(0, -height),
                         textcoords="offset points",

--- a/cellprofiler/modules/displaydataonimage.py
+++ b/cellprofiler/modules/displaydataonimage.py
@@ -365,7 +365,12 @@ color map.
                 self.objects_name.value, M_LOCATION_CENTER_Y
             )
             y += self.offset.value * y_offset
-            mask = ~(numpy.isnan(values) | numpy.isnan(x) | numpy.isnan(y))
+            if numpy.issubdtype(values.dtype, str):
+                if self.use_color_map():
+                    raise NotImplementedError("Cannot interpret a text measurement for display with a color scale")
+                mask = ~(numpy.isnan(x) | numpy.isnan(y))
+            else:
+                mask = ~(numpy.isnan(values) | numpy.isnan(x) | numpy.isnan(y))
             values = values[mask]
             x = x[mask]
             y = y[mask]

--- a/tests/modules/test_displaydataonimage.py
+++ b/tests/modules/test_displaydataonimage.py
@@ -246,6 +246,22 @@ def test_display_objects_wrong_size():
         image = workspace.image_set.get_image(OUTPUT_IMAGE_NAME)
 
 
+def test_display_text():
+    labels = numpy.zeros((50, 120), int)
+    labels[10:20, 20:27] = 1
+    labels[30:35, 35:50] = 2
+    labels[5:18, 44:100] = 3
+    for display in (
+        cellprofiler.modules.displaydataonimage.E_AXES,
+        cellprofiler.modules.displaydataonimage.E_FIGURE,
+        cellprofiler.modules.displaydataonimage.E_IMAGE,
+    ):
+        workspace, module = make_workspace(["First", "Second", "Third"], labels)
+        module.saved_image_contents.value = display
+        module.run(workspace)
+        image = workspace.image_set.get_image(OUTPUT_IMAGE_NAME)
+
+
 def test_display_colors():
     labels = numpy.zeros((50, 120), int)
     labels[10:20, 20:27] = 1


### PR DESCRIPTION
Fixes #4446

This PR makes it so that DisplayDataOnImage can display string measurements such as class names determined by ClassifyObjects. This allows you to make images such as this:

![image](https://user-images.githubusercontent.com/26802537/129235214-fb895eb0-1fc1-48e2-9ef0-2e294badcfc6.png)

I've also added similar support for string measurements to the Workspace Viewer.