### PR TITLE
ExportToDatabase bug fixes

### DIFF
--- a/cellprofiler/modules/exporttodatabase.py
+++ b/cellprofiler/modules/exporttodatabase.py
@@ -3833,7 +3833,8 @@ CREATE TABLE %s (
                         count = measurements.get_measurement(
                             "Image", ftr_count, image_number
                         )
-                        max_count = max(max_count, int(count))
+                        if count:
+                            max_count = max(max_count, int(count))
                     column_values = []
                     for column in columns:
                         object_name, feature, coltype = column[:3]

--- a/cellprofiler/modules/exporttodatabase.py
+++ b/cellprofiler/modules/exporttodatabase.py
@@ -3882,7 +3882,11 @@ CREATE TABLE %s (
 
                         for column, values in zip(columns, column_values):
                             object_name, feature, coltype = column[:3]
-                            object_row.append(values[j])
+                            if coltype == COLTYPE_VARCHAR:
+                                # String values need to be in quotes
+                                object_row.append(f"'{values[j]}'")
+                            else:
+                                object_row.append(values[j])
                         if post_group:
                             object_row.append(object_numbers[j])
                         object_rows.append(object_row)


### PR DESCRIPTION
- Fixed an issue where writing would fail on text columns (newly added by ClassifyObjects). SQL will try to interpret a string within a list of values as a column name, unless you enclose it in quotes.
- Fixed an issue where skipping an image or otherwise failing to capture a measurement would cause writing to fail. (`None` can't be compared in Python 3)