### PR TITLE
Fix post_group LAP crash when a frame lacks data

### DIFF
--- a/cellprofiler/modules/trackobjects.py
+++ b/cellprofiler/modules/trackobjects.py
@@ -1917,7 +1917,7 @@ Enter a name to give the color-coded image of tracked labels.""",
         ]
         group_indices, new_object_count, lost_object_count, merge_count, split_count = [
             np.array(
-                [m.get_measurement("Image", feature, i) for i in image_numbers], int,
+                [m.get_measurement("Image", feature, i) or 0 for i in image_numbers], int,
             )
             for feature in (
                 GROUP_INDEX,


### PR DESCRIPTION
Similar errors may still pop up elsewhere in the code, but for now this seems to get post_group running properly. The problem was that if FlagImage skipped a frame (or there were no objects??) the resulting measurements are missing from the hdf5_dict, and thus return `None` when called. In Python 2 this wasn't a problem, but in Python 3 this crashes the script when compare operations are called on the data list (NoneType can no longer be compared to ints).

Substituting 0 in these cases seems to fix it.