### PR TITLE
Add convex hull mode to FillObjects

### DIFF
--- a/cellprofiler/modules/fillobjects.py
+++ b/cellprofiler/modules/fillobjects.py
@@ -79,6 +79,9 @@ each object. Size of the holes to be removed can be controlled.
 In {MODE_CHULL} mode, the module will apply the convex hull of each object to fill 
 missing pixels. This can be useful when round objects have partial holes that are 
 not entirely enclosed.
+
+Note: Convex hulls for each object are applied sequentially and may overlap. This means 
+that touching objects may not be perfectly convex if there was a region of overlap. 
 """           
         )
 

--- a/cellprofiler/modules/fillobjects.py
+++ b/cellprofiler/modules/fillobjects.py
@@ -11,6 +11,9 @@ entirely within the boundary of labeled objects are filled with the surrounding 
 **FillObjects** can also be optionally run on a "per-plane" basis working with volumetric data.
 Holes will be filled for each XY plane, rather than on the whole volume.
 
+Alternatively, objects can be filled on the basis of a convex hull.  
+This is the smallest convex polygon that surrounds all pixels in the object.
+
 |
 
 ============ ============ ===============
@@ -67,7 +70,16 @@ are the result of segmentation.
             "Filling method",
             [MODE_HOLES, MODE_CHULL],
             value=MODE_HOLES,
-            doc="Docs go here"
+            doc=f"""\
+Choose the mode for hole filling.
+
+In {MODE_HOLES} mode, the module will search for and fill holes entirely enclosed by
+each object. Size of the holes to be removed can be controlled. 
+
+In {MODE_CHULL} mode, the module will apply the convex hull of each object to fill 
+missing pixels. This can be useful when round objects have partial holes that are 
+not entirely enclosed.
+"""           
         )
 
     def settings(self):

--- a/cellprofiler/modules/fillobjects.py
+++ b/cellprofiler/modules/fillobjects.py
@@ -119,9 +119,12 @@ def fill_convex_hulls(labels):
     output = numpy.zeros_like(labels)
     for prop in data:
         label = prop['label']
-        x, y, x2, y2 = prop['bbox']
+        bbox = prop['bbox']
         cmask = prop['convex_image']
-        output[x:x2, y:y2][cmask] = label
+        if len(bbox) <= 4:
+            output[bbox[0]:bbox[2], bbox[1]:bbox[3]][cmask] = label
+        else:
+            output[bbox[0]:bbox[3], bbox[1]:bbox[4], bbox[2]: bbox[5]][cmask] = label
     return output
 
 

--- a/tests/modules/test_fillobjects.py
+++ b/tests/modules/test_fillobjects.py
@@ -112,6 +112,54 @@ def test_3d_fill_holes(
     numpy.testing.assert_array_equal(actual, expected)
 
 
+def test_2d_fill_chull(
+    image_labels, module, object_set_empty, objects_empty, workspace_empty
+):
+    labels = image_labels.copy()
+    labels[5, 5] = 0
+    labels[2, 15] = 0
+    labels[15, 0] = 0
+    labels[15, 12] = 0
+
+    objects_empty.segmented = labels
+
+    module.x_name.value = "InputObjects"
+    module.y_name.value = "OutputObjects"
+    module.mode.value = "Convex hull"
+
+    module.run(workspace_empty)
+
+    actual = object_set_empty.get_objects("OutputObjects").segmented
+    expected = image_labels
+
+    numpy.testing.assert_array_equal(actual, expected)
+
+
+def test_3d_fill_chull(
+    volume_labels, module, object_set_empty, objects_empty, workspace_empty
+):
+    labels = volume_labels.copy()
+    labels[0, 1, 13] = 0
+    labels[5, 5, 5] = 0
+    labels[5, 5, 7] = 0
+    labels[2, 2, 15] = 0
+    labels[5, 15, 2] = 0
+    labels[5, 15, 15] = 0
+
+    objects_empty.segmented = labels
+
+    module.x_name.value = "InputObjects"
+    module.y_name.value = "OutputObjects"
+    module.mode.value = "Convex hull"
+
+    module.run(workspace_empty)
+
+    actual = object_set_empty.get_objects("OutputObjects").segmented
+    expected = volume_labels
+
+    numpy.testing.assert_array_equal(actual, expected)
+
+
 def test_fail_3d_fill_bowl(
     volume_labels, module, object_set_empty, objects_empty, workspace_empty
 ):

--- a/tests/modules/test_fillobjects.py
+++ b/tests/modules/test_fillobjects.py
@@ -80,6 +80,7 @@ def test_2d_fill_holes(
     module.x_name.value = "InputObjects"
     module.y_name.value = "OutputObjects"
     module.size.value = 2.0
+    module.mode.value = "Holes"
 
     module.run(workspace_empty)
 
@@ -103,6 +104,7 @@ def test_3d_fill_holes(
     module.x_name.value = "InputObjects"
     module.y_name.value = "OutputObjects"
     module.size.value = 2.0
+    module.mode.value = "Holes"
 
     module.run(workspace_empty)
 
@@ -172,6 +174,7 @@ def test_fail_3d_fill_bowl(
     module.x_name.value = "InputObjects"
     module.y_name.value = "OutputObjects"
     module.size.value = 2.0
+    module.mode.value = "Holes"
 
     module.run(workspace_empty)
 
@@ -197,6 +200,7 @@ def test_pass_3d_fill_bowl(
     module.size.value = 3.0
     # Set to planewise so the bowl is "filled" on each plane
     module.planewise.value = True
+    module.mode.value = "Holes"
 
     module.run(workspace_empty)
 


### PR DESCRIPTION
Added convex hull mode to FillObjects and added test cases for convex hull (2D and 3D).

Convex hull might be useful when processing objects that have holes that are not fully enclosed. One thing to note when using the mode is that it might create overlaps between convex hulls. Since the objects are processed sequentially, objects with higher labels will take priority to resolve this.
