### PR TITLE
Add option to disable bit depth conversion in SaveImages

### DIFF
--- a/tests/modules/test_saveimages.py
+++ b/tests/modules/test_saveimages.py
@@ -374,7 +374,7 @@ def test_save_image_tiff_float32_no_conversion(tmpdir, image, module, workspace)
     numpy.testing.assert_array_equal(data, skimage.util.img_as_float(image.pixel_data))
 
 
-def test_save_image_tiff_float32_large_ints(tmpdir, module, workspace):
+def test_save_image_tiff_int32(tmpdir, module, workspace):
 
     image = cellprofiler_core.image.Image(image = numpy.array(range(257**2)).reshape([257,257]),convert=False)
 

--- a/tests/modules/test_saveimages.py
+++ b/tests/modules/test_saveimages.py
@@ -344,6 +344,70 @@ def test_save_image_tiff_float32(tmpdir, image, module, workspace):
 
     numpy.testing.assert_array_equal(data, skimage.util.img_as_float(image.pixel_data))
 
+def test_save_image_tiff_float32_no_conversion(tmpdir, image, module, workspace):
+    directory = str(tmpdir.mkdir("images"))
+
+    module.save_image_or_figure.value = cellprofiler.modules.saveimages.IF_IMAGE
+
+    module.image_name.value = "example"
+
+    module.file_name_method.value = cellprofiler.modules.saveimages.FN_SINGLE_NAME
+
+    module.single_file_name.value = "example"
+
+    module.pathname.value = "{}|{}".format(
+        cellprofiler_core.preferences.ABSOLUTE_FOLDER_NAME, directory
+    )
+
+    module.file_format.value = cellprofiler.modules.saveimages.FF_TIFF
+
+    module.bit_depth.value = cellprofiler.modules.saveimages.BIT_DEPTH_RAW
+
+    module.run(workspace)
+
+    assert os.path.exists(os.path.join(directory, "example.tiff"))
+
+    data = skimage.io.imread(os.path.join(directory, "example.tiff"))
+
+    assert data.dtype == numpy.float32
+
+    numpy.testing.assert_array_equal(data, skimage.util.img_as_float(image.pixel_data))
+
+
+def test_save_image_tiff_float32_large_ints(tmpdir, module, workspace):
+
+    image = cellprofiler_core.image.Image(image = numpy.array(range(257**2)).reshape([257,257]),convert=False)
+
+    workspace.image_set.add("example_image", image)
+
+    directory = str(tmpdir.mkdir("images"))
+
+    module.save_image_or_figure.value = cellprofiler.modules.saveimages.IF_IMAGE
+
+    module.image_name.value = "example_image"
+
+    module.file_name_method.value = cellprofiler.modules.saveimages.FN_SINGLE_NAME
+
+    module.single_file_name.value = "example_large_int_values"
+
+    module.pathname.value = "{}|{}".format(
+        cellprofiler_core.preferences.ABSOLUTE_FOLDER_NAME, directory
+    )
+
+    module.file_format.value = cellprofiler.modules.saveimages.FF_TIFF
+
+    module.bit_depth.value = cellprofiler.modules.saveimages.BIT_DEPTH_RAW
+
+    module.run(workspace)
+
+    assert os.path.exists(os.path.join(directory, "example_large_int_values.tiff"))
+
+    data = skimage.io.imread(os.path.join(directory, "example_large_int_values.tiff"))
+
+    assert data.dtype == numpy.int64
+
+    numpy.testing.assert_array_equal(data, image.pixel_data)
+
 
 def test_save_image_npy(tmpdir, image, module, workspace):
     directory = str(tmpdir.mkdir("images"))
@@ -466,6 +530,38 @@ def test_save_volume_tiff_float32(tmpdir, volume, module, workspace):
 
     numpy.testing.assert_array_equal(data, skimage.util.img_as_float(volume.pixel_data))
 
+def test_save_volume_tiff_float32_no_conversion(tmpdir, volume, module, workspace):
+    directory = str(tmpdir.mkdir("images"))
+
+    workspace.image_set.add("example_volume", volume)
+
+    module.save_image_or_figure.value = cellprofiler.modules.saveimages.IF_IMAGE
+
+    module.image_name.value = "example_volume"
+
+    module.file_name_method.value = cellprofiler.modules.saveimages.FN_SINGLE_NAME
+
+    module.single_file_name.value = "example_volume"
+
+    module.pathname.value = "{}|{}".format(
+        cellprofiler_core.preferences.ABSOLUTE_FOLDER_NAME, directory
+    )
+
+    module.file_format.value = cellprofiler.modules.saveimages.FF_TIFF
+
+    module.bit_depth.value = cellprofiler.modules.saveimages.BIT_DEPTH_RAW
+
+    module.run(workspace)
+
+    assert os.path.exists(os.path.join(directory, "example_volume.tiff"))
+
+    data = skimage.io.imread(os.path.join(directory, "example_volume.tiff"))
+
+    assert data.dtype == numpy.float32
+
+    numpy.testing.assert_array_equal(data, skimage.util.img_as_float(volume.pixel_data))
+
+#def test_save_large_numbes_of_values_volume(d)
 
 def test_save_volume_npy(tmpdir, volume, module, workspace):
     directory = str(tmpdir.mkdir("images"))


### PR DESCRIPTION
Per a request on the forum, someone wanted to save out a label array with more than 65536 objects. ConvertObjectsToImage creates an int32 array just fine, but SaveImages' Float32 mode rescales all values to be between 0 and 1. There was no easy way to save out such an image without the rescaling. Similarly, the 8- and 16-bit modes both scale floats to integers, so you couldn't export a float image without Float32 mode's 0-1 scaling.

I've added a "No conversion" mode to the bit depth options, which tries to save the image without applying a skimage img_as_type function. I figure this gives the user a bit more flexibility in saving, with the caveat that we can't guarantee that every possible array will save properly in this mode.

While I was in there, Skimage now has a native `img_as_float32` function, so I've replaced the previous implementation which called `as_float` followed by `astype` to get the same result.