### PR TITLE
Fix interpolation functions

### DIFF
--- a/cellprofiler/gui/artist.py
+++ b/cellprofiler/gui/artist.py
@@ -35,6 +35,8 @@ NORMALIZE_LINEAR = "linear"
 INTERPOLATION_NEAREST = "nearest"
 INTERPOLATION_BILINEAR = "bilinear"
 INTERPOLATION_BICUBIC = "bicubic"
+# Map MPL interpolation modes to skimage order values
+INTERPOLATION_MAP = {INTERPOLATION_NEAREST: 0, INTERPOLATION_BILINEAR: 1, INTERPOLATION_BICUBIC: 3}
 
 MODE_OUTLINES = "outlines"
 MODE_LINES = "lines"
@@ -782,7 +784,7 @@ class CPImageArtist(matplotlib.artist.Artist):
             target, out_range=numpy.uint8
         )
 
-        image = skimage.transform.rescale(image, (sx, sy, 1))
+        image = skimage.transform.rescale(image, (sx, sy, 1), order=INTERPOLATION_MAP[self.mp_interpolation])
 
         image = skimage.img_as_ubyte(image)
 

--- a/cellprofiler/gui/figure/_figure.py
+++ b/cellprofiler/gui/figure/_figure.py
@@ -1208,6 +1208,9 @@ class Figure(wx.Frame):
             elif evt.Id == MENU_INTERPOLATION_BICUBIC:
                 params["interpolation"] = "bicubic"
             axes = self.subplot(x, y)
+            if hasattr(axes, 'displayed') and hasattr(axes.displayed, "_interpolation"):
+                # Directly update interpolation if the subplot is an image object
+                axes.displayed._interpolation = params["interpolation"]
             for artist in axes.artists:
                 if isinstance(artist, CPImageArtist):
                     artist.interpolation = params["interpolation"]
@@ -1636,7 +1639,7 @@ class Figure(wx.Frame):
 
         image = self.normalize_image(self.images[(x, y)], **kwargs)
 
-        self.subplot(x, y).displayed = subplot.imshow(image)
+        self.subplot(x, y).displayed = subplot.imshow(image, interpolation=interpolation)
 
         self.update_line_labels(subplot, kwargs)
 


### PR DESCRIPTION
Fixes #4453

In 4.0 we switched the workspace viewer to resizing the preview image using skimage functions instead of native MPL. Because of this the interpolation settings weren't applied and skimage defaulted to bilinear mode, which looks confusing when zoomed in.

I also found that the 'normal' figure interpolation settings didn't apply properly either, so I fixed those too. Figure windows will now also initialize with the correct default interpolation mode as determined by user preferences.