### PR TITLE
Add debug interpreter

### DIFF
--- a/cellprofiler/data/help/other_shell.rst
+++ b/cellprofiler/data/help/other_shell.rst
@@ -1,0 +1,11 @@
+Debug Shell
+===========
+
+CellProfiler contains a debug shell that can be activated for advanced troubleshooting.
+
+To access the shell on Windows, open the 'About' dialog in the 'Help' menu. Then hold shift while closing the About popup with the 'OK' button. 
+To access the shell on Mac, hold down shift while clicking 'About CellProfiler' in the 'Help' menu.
+
+For more information, see the `pull request`_ for this feature.
+
+.. _pull request: https://github.com/CellProfiler/CellProfiler/pull/4458

--- a/cellprofiler/gui/cpframe.py
+++ b/cellprofiler/gui/cpframe.py
@@ -1323,6 +1323,12 @@ class CPFrame(wx.Frame):
 
     pipeline = property(get_pipeline)
 
+    def get_workspace(self):
+        """Get the pipeline - mostly to drive testing"""
+        return self.__workspace
+
+    workspace = property(get_workspace)
+
     def get_module_view(self):
         """Return the module view window"""
         return self.__module_view

--- a/cellprofiler/gui/help/menu.py
+++ b/cellprofiler/gui/help/menu.py
@@ -103,10 +103,19 @@ class Menu(cellprofiler.gui.menu.Menu):
 
         self.append("About CellProfiler", event_fn=lambda _: self.about())
 
-    @staticmethod
-    def about():
+    def about(self):
         info = AboutDialogInfo()
         wx.adv.AboutBox(info)
+        if wx.GetKeyState(wx.WXK_SHIFT):
+            from wx.py.shell import ShellFrame
+            from cellprofiler.__init__ import __version__
+            cpapp = wx.FindWindowByName(f'CellProfiler {__version__}')
+            s = ShellFrame(self.frame,
+                           title="CellProfiler Shell",
+                           locals={'app': cpapp, 'pipeline': cpapp.pipeline, 'workspace': cpapp.workspace},
+                           )
+            s.SetStatusText("CellProfiler Debug Interpeter - Use 'app', 'pipeline' and 'workspace' to inspect objects")
+            s.Show()
 
     def find_update(self, event):
         from cellprofiler.gui.checkupdate import check_update

--- a/cellprofiler/gui/help/menu.py
+++ b/cellprofiler/gui/help/menu.py
@@ -109,10 +109,15 @@ class Menu(cellprofiler.gui.menu.Menu):
         if wx.GetKeyState(wx.WXK_SHIFT):
             from wx.py.shell import ShellFrame
             from cellprofiler.__init__ import __version__
-            cpapp = wx.FindWindowByName(f'CellProfiler {__version__}')
+            cpapp = wx.GetApp()
+            if cpapp:
+                cpapp = cpapp.frame
+                locs = {'app': cpapp, 'pipeline': cpapp.pipeline, 'workspace': cpapp.workspace}
+            else:
+                locs = None
             s = ShellFrame(self.frame,
                            title="CellProfiler Shell",
-                           locals={'app': cpapp, 'pipeline': cpapp.pipeline, 'workspace': cpapp.workspace},
+                           locals=locs,
                            )
             s.SetStatusText("CellProfiler Debug Interpeter - Use 'app', 'pipeline' and 'workspace' to inspect objects")
             s.Show()

--- a/cellprofiler/gui/help/menu.py
+++ b/cellprofiler/gui/help/menu.py
@@ -231,6 +231,11 @@ class Menu(cellprofiler.gui.menu.Menu):
             contents=cellprofiler.gui.help.content.read_content("other_plugins.rst"),
         )
 
+        other_menu.append(
+            "Debug Shell",
+            contents=cellprofiler.gui.help.content.read_content("other_shell.rst"),
+        )
+
         return other_menu
 
     def __output_menu(self):

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -188,6 +188,7 @@ Learn about the other features of CellProfiler.
    help/other_logging
    help/other_omero
    help/other_plugins
+   help/other_shell
 
 `(Jump to top)`_
 


### PR DESCRIPTION
This PR adds a method to access a Python interpreter within CellProfiler, aimed at helping with debugging.

To access the feature, open the 'About' dialog. Then hold `shift` while closing the About popup with the 'OK' button. This grants you the following window:

![image](https://user-images.githubusercontent.com/26802537/131170263-2e56c323-d9f4-4507-8bbf-f5dad12d8d34.png)

I've made it so that some useful objects are mapped into variables for easy access and inspection. All of this is using wx's inbuilt shell tool so there should be no extra dependencies.

With any luck this will allow us to more easily test packages and features within builds, too.