### PR TITLE
Add log transform settings to module help

### DIFF
--- a/cellprofiler/modules/threshold.py
+++ b/cellprofiler/modules/threshold.py
@@ -765,6 +765,7 @@ staining.
             self.manual_threshold,
             self.thresholding_measurement,
             self.two_class_otsu,
+            self.log_transform,
             self.assign_middle_to_foreground,
             self.lower_outlier_fraction,
             self.upper_outlier_fraction,


### PR DESCRIPTION
When we added the log_transform setting to Threshold, we didn't add it to its help_settings, which meant it (and any modules that inherit threshold help_settings from it, like IPO/ISO) didn't include it in the module help.

H/T @norsimon for noticing!