### PR TITLE
Don't convert images after masking

### DIFF
--- a/cellprofiler/modules/maskimage.py
+++ b/cellprofiler/modules/maskimage.py
@@ -185,6 +185,7 @@ This option reverses the foreground/background relationship of the mask.
             parent_image=orig_image,
             masking_objects=objects,
             dimensions=orig_image.dimensions,
+            convert=False
         )
 
         image_set.add(self.masked_image_name.value, masked_image)


### PR DESCRIPTION
Resolves #4466 

Working with @rsenft1, we realized the issue was is that when we make a new image after masking, the default behavior in creating a new image is trying to rescale it 0-1, but that really isn't appropriate here. If someone wants a particular scaling out, that's the scaling that they should be putting in, or they can rescale it afterward.