### PR TITLE
Fix issue with downsampling when advanced watershed features are on

### DIFF
--- a/cellprofiler/modules/watershed.py
+++ b/cellprofiler/modules/watershed.py
@@ -456,6 +456,10 @@ the image is not downsampled.
                 )
 
                 y_data = numpy.rint(y_data).astype(numpy.uint16)
+                x_data = skimage.transform.resize(
+                    x_data, original_shape, mode="edge", order=0, preserve_range=True
+                )
+                x_data = numpy.rint(x_data).astype(numpy.uint16)
 
         # watershed algorithm for marker-based method:
         else:


### PR DESCRIPTION
In watershed.py, resize x_data back up on line 459 to fix mismatch later (line 565) when watershed is generated from distance and downsampling is on (>1).