### PR TITLE
Reduce the memory usage of MeasureObjectNeighbors

### DIFF
--- a/cellprofiler/modules/measureobjectneighbors.py
+++ b/cellprofiler/modules/measureobjectneighbors.py
@@ -393,7 +393,7 @@ previously discarded objects.""".format(
             # order[:,1] should be the nearest neighbor
             # order[:,2] should be the next nearest neighbor
             #
-            order = numpy.zeros((nobjects, min(nobjects, 3)), dtype=numpy.uint32)
+            order = numpy.zeros((nobjects, min(nneighbors, 3)), dtype=numpy.uint32)
             j = numpy.arange(nneighbors)
             # (0, 1, 2) unless there are less than 3 neighbors
             partition_keys = tuple(range(min(nneighbors, 3)))

--- a/cellprofiler/modules/measureobjectneighbors.py
+++ b/cellprofiler/modules/measureobjectneighbors.py
@@ -393,13 +393,13 @@ previously discarded objects.""".format(
             # order[:,1] should be the nearest neighbor
             # order[:,2] should be the next nearest neighbor
             #
-            order = np.zeros((nobjects, min(nobjects, 3)), dtype=np.uint32)
-            j = np.arange(nneighbors)
+            order = numpy.zeros((nobjects, min(nobjects, 3)), dtype=numpy.uint32)
+            j = numpy.arange(nneighbors)
             # (0, 1, 2) unless there are less than 3 neighbors
             partition_keys = tuple(range(min(nneighbors, 3)))
             for i in range(nobjects):
-                dr = np.sqrt((ocenters[i, 0] - ncenters[j, 0])**2 + (ocenters[i, 1] - ncenters[j, 1])**2)
-                order[i, :] = np.argpartition(dr, partition_keys)[:3]
+                dr = numpy.sqrt((ocenters[i, 0] - ncenters[j, 0])**2 + (ocenters[i, 1] - ncenters[j, 1])**2)
+                order[i, :] = numpy.argpartition(dr, partition_keys)[:3]
 
             first_neighbor = 1 if self.neighbors_are_objects else 0
             first_object_index = order[:, first_neighbor]

--- a/cellprofiler/modules/measureobjectneighbors.py
+++ b/cellprofiler/modules/measureobjectneighbors.py
@@ -388,22 +388,19 @@ previously discarded objects.""".format(
                 )
             )
 
-            i, j = numpy.mgrid[0:nobjects, 0:nneighbors]
-            distance_matrix = numpy.sqrt(
-                (ocenters[i, 0] - ncenters[j, 0]) ** 2
-                + (ocenters[i, 1] - ncenters[j, 1]) ** 2
-            )
             #
             # order[:,0] should be arange(nobjects)
             # order[:,1] should be the nearest neighbor
             # order[:,2] should be the next nearest neighbor
             #
-            if distance_matrix.shape[1] == 1:
-                # a little buggy, lexsort assumes that a 2-d array of
-                # second dimension = 1 is a 1-d array
-                order = numpy.zeros(distance_matrix.shape, int)
-            else:
-                order = numpy.lexsort([distance_matrix])
+            order = np.zeros((nobjects, min(nobjects, 3)), dtype=np.uint32)
+            j = np.arange(nneighbors)
+            # (0, 1, 2) unless there are less than 3 neighbors
+            partition_keys = tuple(range(min(nneighbors, 3)))
+            for i in range(nobjects):
+                dr = np.sqrt((ocenters[i, 0] - ncenters[j, 0])**2 + (ocenters[i, 1] - ncenters[j, 1])**2)
+                order[i, :] = np.argpartition(dr, partition_keys)[:3]
+
             first_neighbor = 1 if self.neighbors_are_objects else 0
             first_object_index = order[:, first_neighbor]
             first_x_vector = ncenters[first_object_index, 1] - ocenters[:, 1]


### PR DESCRIPTION
Hi!

In using CellProfiler for large images (~8GB) we've found we run out of memory even on our cluster's 1.5TB nodes. The cause of the problem is in MeasureObjectNeighbors. Specifically at the point of the code modified in this PR, the original allocates 4 arrays: i, j, distance_matrix and order. Each of these arrays is of size nobjects*nneighbors. For us we have ~200000 objects. For 8 byte elements, this results in memory usage on the order of 4 * 200000 * 200000 * 8 * 10^-9 = 1280GB. But of these four arrays, the remaining code only makes use of the first three columns of order (the nearest neighbors). We have modified the code to only allocate the memory that is needed, which for the data mentioned above should not need to allocate over 1GB.

This code also runs faster than the original as we don't do a full sort on the distances, and instead find just the closest three with argpartition (N^2 rather than N^2*logN complexity). One might worry the explicit Python loop would slow things down, but in testing with random arrays of various sizes we've found about a 10x speed improvement.

The replacement code should be functionally equivalent to the original and in testing on our pipelines we are now able to segment much larger images.
