### PR TITLE
Fix composite image test

### DIFF
--- a/tests/modules/test_graytocolor.py
+++ b/tests/modules/test_graytocolor.py
@@ -368,4 +368,6 @@ def test_composite_rescale():
                 for image, color, weight in zip(images, colors, weights)
             ]
         )
+        channel = numpy.where(channel >1, 1, channel)
+
         numpy.testing.assert_array_almost_equal(output[:, :, i], channel)


### PR DESCRIPTION
A bug was fixed in #4445 to clip values to 1, but the test behavior was never updated. Resolves #4498 