### PR TITLE
fixed 3d cmap

### DIFF
--- a/cellprofiler/gui/figure/_figure.py
+++ b/cellprofiler/gui/figure/_figure.py
@@ -2029,6 +2029,7 @@ class Figure(wx.Frame):
         in_range = (image.min(), image.max())
         image = image.astype(numpy.float32)
         if self.dimensions == 3:
+            orig_image_max = image.max()
             image = image[self.current_plane, :, :]
         if isinstance(colormap, matplotlib.cm.ScalarMappable):
             colormap = colormap.cmap
@@ -2087,12 +2088,16 @@ class Figure(wx.Frame):
             # Apply display bounds
             if vmin is not None and vmax is not None:
                 image = skimage.exposure.rescale_intensity(image, in_range=(vmin, vmax))
+        
         if not self.is_color_image(image):
             if not normalize:
-                if image.max() < 255:
-                    norm = matplotlib.colors.Normalize(vmin=0, vmax=255)
+                if self.dimensions == 3:
+                    norm = matplotlib.colors.Normalize(vmin=0, vmax=orig_image_max)
                 else:
-                    norm = matplotlib.colors.Normalize(vmin=0, vmax=image.max())
+                    if image.max() < 255:
+                        norm = matplotlib.colors.Normalize(vmin=0, vmax=255)
+                    else:
+                        norm = matplotlib.colors.Normalize(vmin=0, vmax=orig_image_max)
             else:
                 norm = None
             mappable = matplotlib.cm.ScalarMappable(cmap=colormap, norm=norm)


### PR DESCRIPTION
Fixes #4506

Originally, when an image is detected to have >255 objects a new matplotlib normalization is calculated up to the image.max(). However, for 3d images this leads to a new normalization to be calculated for each plane that has >255 objects and is plane specific, meaning that each plane has a different colormap applied. These changing colormaps are purely cosmetic, but can be seen in any module that uses the 3d viewer.

This fix first determines the maximum object value for an entire 3d stack. Then, it checks whether the image is 3d and if so will normalize based on the entire 3d image maximum rather than each individual plane maximum. 2d colormap generation remains unchanged.