### PR TITLE
Fix an error introduced in 7fd8c1c

### DIFF
--- a/cellprofiler/gui/figure/_figure.py
+++ b/cellprofiler/gui/figure/_figure.py
@@ -2097,7 +2097,7 @@ class Figure(wx.Frame):
                     if image.max() < 255:
                         norm = matplotlib.colors.Normalize(vmin=0, vmax=255)
                     else:
-                        norm = matplotlib.colors.Normalize(vmin=0, vmax=orig_image_max)
+                        norm = matplotlib.colors.Normalize(vmin=0, vmax=image.max())
             else:
                 norm = None
             mappable = matplotlib.cm.ScalarMappable(cmap=colormap, norm=norm)


### PR DESCRIPTION
orig_image_max should only be used when a 3D image has been loaded. Prior to this fix, orig_image_max could be referenced in 2D images if the image.max() exceeded 255, resulting in an error.