### PR TITLE
Issues/4436 rsctc

### DIFF
--- a/cellprofiler/modules/threshold.py
+++ b/cellprofiler/modules/threshold.py
@@ -1039,7 +1039,10 @@ staining.
                     # Can't run 3-class otsu on only 2 values.
                     threshold_out = skimage.filters.threshold_otsu(block)
                 else:
-                    threshold_out = threshold_method(block, **kwargs)
+                    try: 
+                        threshold_out = threshold_method(block, **kwargs)
+                    except ValueError:
+                        threshold_out = threshold_method(block)
                 if isinstance(threshold_out, numpy.ndarray):
                     # Select correct bin if running multiotsu
                     threshold_out = threshold_out[bin_wanted]

--- a/cellprofiler/modules/threshold.py
+++ b/cellprofiler/modules/threshold.py
@@ -1042,6 +1042,7 @@ staining.
                     try: 
                         threshold_out = threshold_method(block, **kwargs)
                     except ValueError:
+                        # Drop nbins kwarg when multi-otsu fails. See issue #6324 scikit-image
                         threshold_out = threshold_method(block)
                 if isinstance(threshold_out, numpy.ndarray):
                     # Select correct bin if running multiotsu


### PR DESCRIPTION
Fixes #4436. This covers an edge case in skimage.filters.threshold_multiotsu that causes a ValueError when images have few values and they are very close together and thus cannot be separated into 3 classes. This issue is referenced [here](https://github.com/scikit-image/scikit-image/issues/6324). This works by catching the ValueError and re-thresholding without the nbins argument. nbins are kept for all other cases to maintain previous CellProfiler thresholding behavior and to affect as few images as possible.

Co-authored-by: Callum Tromans-Coia <callumtc.jpg@gmail.com>
Co-authored-by: Rebecca Senft <senftrebecca@gmail.com>