### PR TITLE
Use correct scaler, populate choices

### DIFF
--- a/cellprofiler/gui/module_view/_module_view.py
+++ b/cellprofiler/gui/module_view/_module_view.py
@@ -1822,6 +1822,17 @@ class ModuleView:
         # * panel = None - create the controls
         # * panel != None - find the controls
         #
+        category = v.get_category(self.__pipeline)
+        categories = v.get_category_choices(self.__pipeline)
+        feature_name = v.get_feature_name(self.__pipeline)
+        feature_names = v.get_feature_name_choices(self.__pipeline)
+        image_name = v.get_image_name(self.__pipeline)
+        image_names = v.get_image_name_choices(self.__pipeline)
+        object_name = v.get_object_name(self.__pipeline)
+        object_names = v.get_object_name_choices(self.__pipeline)
+        scale = v.get_scale(self.__pipeline)
+        scales = v.get_scale_choices(self.__pipeline)
+
         if not panel:
             panel = wx.Panel(self.__module_panel, -1, name=edit_control_name(v))
             sizer = wx.BoxSizer(wx.VERTICAL)
@@ -1836,7 +1847,7 @@ class ModuleView:
             )
             sub_sizer.Add(category_text_ctrl, 0, wx.EXPAND | wx.ALL, 2)
             category_ctrl = wx.ComboBox(
-                panel, style=wx.CB_READONLY, name=category_control_name(v)
+                panel, style=wx.CB_READONLY, name=category_control_name(v), choices = categories
             )
             sub_sizer.Add(category_ctrl, 0, wx.EXPAND | wx.ALL, 2)
             #
@@ -1849,7 +1860,7 @@ class ModuleView:
             )
             sub_sizer.Add(feature_text_ctrl, 0, wx.EXPAND | wx.ALL, 2)
             feature_ctrl = wx.ComboBox(
-                panel, style=wx.CB_READONLY, name=feature_control_name(v)
+                panel, style=wx.CB_READONLY, name=feature_control_name(v), choices = feature_names
             )
             sub_sizer.Add(feature_ctrl, 0, wx.EXPAND | wx.ALL, 2)
             #
@@ -1862,7 +1873,7 @@ class ModuleView:
             )
             sub_sizer.Add(object_text_ctrl, 0, wx.EXPAND | wx.ALL, 2)
             object_ctrl = wx.ComboBox(
-                panel, style=wx.CB_READONLY, name=object_control_name(v)
+                panel, style=wx.CB_READONLY, name=object_control_name(v), choices = image_names+object_names
             )
             sub_sizer.Add(object_ctrl, 0, wx.EXPAND | wx.ALL, 2)
             #
@@ -1874,15 +1885,15 @@ class ModuleView:
             )
             sub_sizer.Add(scale_text_ctrl, 0, wx.EXPAND | wx.ALL, 2)
             scale_ctrl = wx.ComboBox(
-                panel, style=wx.CB_READONLY, name=scale_control_name(v)
+                panel, style=wx.CB_READONLY, name=scale_control_name(v), choices = scales
             )
             sub_sizer.Add(scale_ctrl, 0, wx.EXPAND | wx.ALL, 2)
             max_width = 0
             for sub_sizer_item in sizer.GetChildren():
-                static = sub_sizer_item.Sizer.GetChildren()[0].Window
+                static = sub_sizer_item.Sizer.GetChildren()[1].Window
                 max_width = max(max_width, static.Size.GetWidth())
             for sub_sizer_item in sizer.GetChildren():
-                static = sub_sizer_item.Sizer.GetChildren()[0].Window
+                static = sub_sizer_item.Sizer.GetChildren()[1].Window
                 static.Size = wx.Size(max_width, static.Size.GetHeight())
                 static.SetSizeHints(max_width, -1, max_width)
 
@@ -1935,16 +1946,6 @@ class ModuleView:
             object_text_ctrl = panel.FindWindowByName(object_text_control_name(v))
             scale_ctrl = panel.FindWindowByName(scale_control_name(v))
             scale_text_ctrl = panel.FindWindowByName(scale_text_ctrl_name(v))
-        category = v.get_category(self.__pipeline)
-        categories = v.get_category_choices(self.__pipeline)
-        feature_name = v.get_feature_name(self.__pipeline)
-        feature_names = v.get_feature_name_choices(self.__pipeline)
-        image_name = v.get_image_name(self.__pipeline)
-        image_names = v.get_image_name_choices(self.__pipeline)
-        object_name = v.get_object_name(self.__pipeline)
-        object_names = v.get_object_name_choices(self.__pipeline)
-        scale = v.get_scale(self.__pipeline)
-        scales = v.get_scale_choices(self.__pipeline)
 
         def set_up_combobox(ctrl, text_ctrl, choices, value, always_show=False):
             if len(choices):

--- a/cellprofiler/gui/module_view/_module_view.py
+++ b/cellprofiler/gui/module_view/_module_view.py
@@ -1847,7 +1847,7 @@ class ModuleView:
             )
             sub_sizer.Add(category_text_ctrl, 0, wx.EXPAND | wx.ALL, 2)
             category_ctrl = wx.ComboBox(
-                panel, style=wx.CB_READONLY, name=category_control_name(v), choices = categories
+                panel, style=wx.CB_READONLY, name=category_control_name(v), choices=categories
             )
             sub_sizer.Add(category_ctrl, 0, wx.EXPAND | wx.ALL, 2)
             #
@@ -1860,7 +1860,7 @@ class ModuleView:
             )
             sub_sizer.Add(feature_text_ctrl, 0, wx.EXPAND | wx.ALL, 2)
             feature_ctrl = wx.ComboBox(
-                panel, style=wx.CB_READONLY, name=feature_control_name(v), choices = feature_names
+                panel, style=wx.CB_READONLY, name=feature_control_name(v), choices=feature_names
             )
             sub_sizer.Add(feature_ctrl, 0, wx.EXPAND | wx.ALL, 2)
             #
@@ -1873,7 +1873,7 @@ class ModuleView:
             )
             sub_sizer.Add(object_text_ctrl, 0, wx.EXPAND | wx.ALL, 2)
             object_ctrl = wx.ComboBox(
-                panel, style=wx.CB_READONLY, name=object_control_name(v), choices = image_names+object_names
+                panel, style=wx.CB_READONLY, name=object_control_name(v), choices=image_names+object_names
             )
             sub_sizer.Add(object_ctrl, 0, wx.EXPAND | wx.ALL, 2)
             #
@@ -1885,7 +1885,7 @@ class ModuleView:
             )
             sub_sizer.Add(scale_text_ctrl, 0, wx.EXPAND | wx.ALL, 2)
             scale_ctrl = wx.ComboBox(
-                panel, style=wx.CB_READONLY, name=scale_control_name(v), choices = scales
+                panel, style=wx.CB_READONLY, name=scale_control_name(v), choices=scales
             )
             sub_sizer.Add(scale_ctrl, 0, wx.EXPAND | wx.ALL, 2)
             max_width = 0


### PR DESCRIPTION
Resolves #4382 

It looks like there were two issues here contributing to these boxes not scaling correctly. Firstly, the scaler was grabbing the names of the choices (literally "Categories" instead of the actual categories, etc). Secondly, it didn't know what the choices were, because they hadn't yet been populated. By grabbing them earlier, we can populate all the possible options (hence combining images and objects) when we do the sizing, allowing the boxes to be properly scaled. 

We should check that this doesn't break anything on Windows, of course. 