### PR TITLE
Numpy123support

### DIFF
--- a/cellprofiler/modules/filterobjects.py
+++ b/cellprofiler/modules/filterobjects.py
@@ -976,7 +976,9 @@ measurement is not available at this stage of the pipeline. Consider adding modu
             #
             # Get the label of the pixel at each location
             #
-            indexes = src_labels[best_pos.transpose().tolist()]
+            # Multidimensional indexing with non-tuple values is not allowed as of numpy 2.23
+            best_pos = tuple(map(tuple, best_pos.transpose()))
+            indexes = src_labels[best_pos]
             indexes = set(indexes)
             indexes = list(indexes)
             indexes.sort()

--- a/cellprofiler/modules/filterobjects.py
+++ b/cellprofiler/modules/filterobjects.py
@@ -976,7 +976,7 @@ measurement is not available at this stage of the pipeline. Consider adding modu
             #
             # Get the label of the pixel at each location
             #
-            # Multidimensional indexing with non-tuple values is not allowed as of numpy 2.23
+            # Multidimensional indexing with non-tuple values is not allowed as of numpy 1.23
             best_pos = tuple(map(tuple, best_pos.transpose()))
             indexes = src_labels[best_pos]
             indexes = set(indexes)

--- a/cellprofiler/modules/measureimagequality.py
+++ b/cellprofiler/modules/measureimagequality.py
@@ -1240,8 +1240,12 @@ to the foreground pixels or the background pixels.
                 value = centrosome.haralick.Haralick(
                     pixel_data, image_labels, 0, scale
                 ).H3()
-                if not numpy.isfinite(value):
+
+                if len(value) != 1 or not numpy.isfinite(value[0]):
                     value = 0.0
+                else:
+                    value = float(value)
+                    
                 workspace.add_measurement(
                     "Image",
                     "{}_{}_{}_{:d}".format(

--- a/cellprofiler/modules/relateobjects.py
+++ b/cellprofiler/modules/relateobjects.py
@@ -614,7 +614,7 @@ parents or children of the parent object.""",
             perim_loc = numpy.argwhere(pperim != 0)
 
             # Get the label # for each point
-            # multidimensional indexing with non-tuple values not allowed as of numpy 2.23
+            # multidimensional indexing with non-tuple values not allowed as of numpy 1.23
             perim_loc_t = tuple(map(tuple, perim_loc.transpose()))
             perim_idx = pperim[perim_loc_t]
 

--- a/cellprofiler/modules/relateobjects.py
+++ b/cellprofiler/modules/relateobjects.py
@@ -614,7 +614,9 @@ parents or children of the parent object.""",
             perim_loc = numpy.argwhere(pperim != 0)
 
             # Get the label # for each point
-            perim_idx = pperim[perim_loc.transpose().tolist()]
+            # multidimensional indexing with non-tuple values not allowed as of numpy 2.23
+            perim_loc_t = tuple(map(tuple, perim_loc.transpose()))
+            perim_idx = pperim[perim_loc_t]
 
             # Sort the points by label #
             reverse_column_order = list(range(children.dimensions))[::-1]


### PR DESCRIPTION
non-tuple multidimensional index was deprecated in numpy v1.15, and finally dropped [here](https://github.com/numpy/numpy/pull/21029). This patch addresses that, and all tests pass using numpy v1.23.1 now.

We are however still receiving a 9 or 10 warnings on numpy features that were deprecated in numpy v1.20. We should probably resolve them sooner rather than later, and we may as well on this PR.