### PR TITLE
Handle skipped images in object-containing spreadsheets

### DIFF
--- a/cellprofiler/modules/exporttospreadsheet.py
+++ b/cellprofiler/modules/exporttospreadsheet.py
@@ -1383,7 +1383,7 @@ desired.
                         for name in object_names
                     ]
                 )
-                object_count = int(object_count) if object_count else 0
+                object_count = int(object_count) if object_count and not numpy.isnan(object_count) else 0
                 columns = [
                     numpy.repeat(img_number, object_count)
                     if feature_name == IMAGE_NUMBER


### PR DESCRIPTION
Resolves #4467 

If the user skips an image, and that image is not either the first or the last image (hence the weird behavior the user was seeing about needing all 3 images), ExportToSpreadsheet was unhappy because the object count for that image was NaN. Before we only checked if it was missing, I'm not sure if ie FlagImage's behavior changed or something deeper in the stack, but it's worth checking for both. I've also added a test for this condition. 