### PR TITLE
Allow users to run without stopping for errors in GUI and headless mode.

### DIFF
--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -32,6 +32,7 @@ from cellprofiler_core.preferences import get_omero_server
 from cellprofiler_core.preferences import get_omero_session_id
 from cellprofiler_core.preferences import get_omero_user
 from cellprofiler_core.preferences import set_allow_schema_write
+from cellprofiler_core.preferences import set_always_continue
 from cellprofiler_core.preferences import set_awt_headless
 from cellprofiler_core.preferences import set_data_file
 from cellprofiler_core.preferences import set_default_image_directory
@@ -219,6 +220,8 @@ def main(args=None):
     if options.conserve_memory is not None:
         set_conserve_memory(options.conserve_memory, globally=False)
 
+    if options.always_continue is not None:
+        set_always_continue(options.always_continue, globally=False)
 
     if not options.allow_schema_write:
         set_allow_schema_write(False)
@@ -539,6 +542,14 @@ def parse_args(args):
             + ("%d or %s for fatal." % (logging.FATAL, "FATAL"))
             + " Otherwise, the argument is interpreted as the file name of a log configuration file (see http://docs.python.org/library/logging.config.html for file format)"
         ),
+    )
+
+    parser.add_option(
+        "--always-continue",
+        dest="always_continue",
+        default=None,
+        action="store_true",
+        help="Keep running after an image set throws an error"
     )
 
     options, result_args = parser.parse_args(args[1:])

--- a/cellprofiler/gui/preferences_dialog/_preferences_dialog.py
+++ b/cellprofiler/gui/preferences_dialog/_preferences_dialog.py
@@ -4,6 +4,7 @@ import sys
 import matplotlib.cm
 import wx
 import wx.lib.scrolledpanel
+from cellprofiler_core.preferences import ALWAYS_CONTINUE_HELP
 from cellprofiler_core.preferences import CONSERVE_MEMORY_HELP
 from cellprofiler_core.preferences import DEFAULT_COLORMAP_HELP
 from cellprofiler_core.preferences import DEFAULT_IMAGE_FOLDER_HELP
@@ -37,6 +38,7 @@ from cellprofiler_core.preferences import TEMP_DIR_HELP
 from cellprofiler_core.preferences import TERTIARY_OUTLINE_COLOR_HELP
 from cellprofiler_core.preferences import UPDATER_HELP
 from cellprofiler_core.preferences import default_max_workers
+from cellprofiler_core.preferences import get_always_continue
 from cellprofiler_core.preferences import get_check_update_bool
 from cellprofiler_core.preferences import get_conserve_memory
 from cellprofiler_core.preferences import get_default_colormap
@@ -65,6 +67,7 @@ from cellprofiler_core.preferences import get_tertiary_outline_color
 from cellprofiler_core.preferences import get_title_font_name
 from cellprofiler_core.preferences import get_title_font_size
 from cellprofiler_core.preferences import get_wants_pony
+from cellprofiler_core.preferences import set_always_continue
 from cellprofiler_core.preferences import set_check_update
 from cellprofiler_core.preferences import set_conserve_memory
 from cellprofiler_core.preferences import set_default_colormap
@@ -475,6 +478,13 @@ class PreferencesDialog(wx.Dialog):
                 set_conserve_memory,
                 CHOICE,
                 CONSERVE_MEMORY_HELP,
+            ],
+            [
+                'Always skip failing images',
+                get_always_continue,
+                set_always_continue,
+                CHOICE,
+                ALWAYS_CONTINUE_HELP,
             ],
 
             ["Pony", get_wants_pony, set_wants_pony, CHOICE, "The end is neigh.",],


### PR DESCRIPTION
Requires https://github.com/CellProfiler/core/pull/105

Resolves #4486 , Resolves #4527 

The change to `__main__` allows you to do this when executing the pipeline headlessly (by passing `--always-continue`) as a flag in your execution command; the change to the preferences menu allows a user running in GUI to set this preference. 