### PR TITLE
Force per-parent labels to be consecutive

### DIFF
--- a/cellprofiler/modules/splitormergeobjects.py
+++ b/cellprofiler/modules/splitormergeobjects.py
@@ -383,6 +383,18 @@ above):
                     ijv = centrosome.cpmorphology.fill_convex_hulls(ch_pts, n_pts)
                     output_labels[ijv[:, 0], ijv[:, 1]] = ijv[:, 2]
 
+                #Renumber to be consecutive
+                ## Create an array that maps label indexes to their new values
+                ## All labels to be deleted have a value in this array of zero
+                indexes = numpy.unique(output_labels)[1:]
+                new_object_count = len(indexes)
+                max_label = numpy.max(output_labels)
+                label_indexes = numpy.zeros((max_label + 1,), int)
+                label_indexes[indexes] = numpy.arange(1, new_object_count + 1)
+
+                # Reindex the labels of the old source image
+                output_labels = label_indexes[output_labels]
+
         output_objects = Objects()
         output_objects.segmented = output_labels
         if objects.has_small_removed_segmented:
@@ -721,7 +733,7 @@ def copy_labels(labels, segmented):
     labels - labels matrix similarly segmented to "segmented"
     segmented - the newly numbered labels matrix (a subset of pixels are labeled)
     """
-    max_labels = numpy.max(segmented)
+    max_labels = len(numpy.unique(segmented))
     seglabel = scipy.ndimage.minimum(labels, segmented, numpy.arange(1, max_labels + 1))
     labels_new = labels.copy()
     labels_new[segmented != 0] = seglabel[segmented[segmented != 0] - 1]

--- a/tests/modules/test_splitormergeobjects.py
+++ b/tests/modules/test_splitormergeobjects.py
@@ -468,3 +468,18 @@ def test_unify_nothing():
             parents_of=numpy.zeros(0, int),
         )
         assert numpy.all(labels_out == 0)
+
+def test_unify_per_parent_non_consecutive():
+    labels = numpy.zeros((10, 20), int)
+    labels[2:5, 3:8] = 1
+    labels[2:5, 13:18] = 2
+    labels[7:9, 13:18] = 3
+
+    labels_out, workspace = rruunn(
+        labels,
+        cellprofiler.modules.splitormergeobjects.OPTION_MERGE,
+        merge_option=cellprofiler.modules.splitormergeobjects.UNIFY_PARENT,
+        parent_object="Parent_object",
+        parents_of=numpy.array([1, 1, 3]),
+    )
+    assert numpy.max(labels_out == 2)


### PR DESCRIPTION
Resolves #4586 

CellProfiler objects didn't use to be require being consecutively numbered, but now they do. SplitOrMergeObjects, when unifying objects per-parent, still just gave the parent's number, which made labels sometimes non-consecutive if parents didn't have any children. This (which is basically copied wholesale from #3799) fixes that.