### PR TITLE
Make sure required columns for GCTs are exported

### DIFF
--- a/cellprofiler/modules/exporttospreadsheet.py
+++ b/cellprofiler/modules/exporttospreadsheet.py
@@ -677,34 +677,17 @@ desired.
                     )
       
         """Check if image features are exported if GCTs are being made"""
-        if self.wants_genepattern_file.value and self.pick_columns.value:
-            measurement_columns = pipeline.get_measurement_columns()
-            image_features = self.filter_columns([x[1] for x in measurement_columns if x[0]==IMAGE],IMAGE)
-            description_feature = [
-                x for x in image_features if x.startswith(C_PATH_NAME + "_")
-            ]
-            if self.how_to_specify_gene_name == GP_NAME_METADATA:
-                name_feature = [self.gene_name_column.value]
-                if name_feature not in image_features:
-                    name_feature = []
-            elif self.how_to_specify_gene_name == GP_NAME_FILENAME:
-                name_feature = [
-                    x
-                    for x in image_features
-                    if x.startswith(
-                        "_".join(
-                            (
-                                C_FILE_NAME,
-                                self.use_which_image_for_gene_name.value,
-                            )
+        measurement_columns = pipeline.get_measurement_columns()
+        image_features = self.filter_columns([x[1] for x in measurement_columns if x[0]==IMAGE],IMAGE)
+        name_feature, _ = self.validate_image_features_exist(
+                        image_features,
                         )
-                    )
-                ]
-            if len(name_feature) == 0 or len(description_feature) == 0: 
-                raise ValidationError(
-                    "At least one path measurement plus the feature selected in 'Select source of sample row name' must be enabled for GCT file creation. Use 'Press button to select measurements' to enable these measurements, or set 'Select measurements to export' to No.",
-                    self.wants_genepattern_file
-                )
+
+        if name_feature == []:
+            raise ValidationError(
+                "At least one path measurement plus the feature selected in 'Select source of sample row name' must be enabled for GCT file creation. Use 'Press button to select measurements' to enable these measurements, or set 'Select measurements to export' to No.",
+                self.wants_genepattern_file
+            )
 
     def validate_module_warnings(self, pipeline):
         """Warn user re: Test mode """
@@ -1191,6 +1174,34 @@ desired.
         finally:
             fd.close()
 
+    def validate_image_features_exist(self,image_features):
+        # Place the one of the paths and desired info column up front in image feature list
+        description_feature = [
+            x for x in image_features if x.startswith(C_PATH_NAME + "_")
+        ]
+        if self.how_to_specify_gene_name == GP_NAME_METADATA:
+            name_feature = [self.gene_name_column.value]
+            print(name_feature,image_features,name_feature in image_features)
+            if name_feature[0] not in image_features:
+                name_feature = []
+        elif self.how_to_specify_gene_name == GP_NAME_FILENAME:
+            name_feature = [
+                x
+                for x in image_features
+                if x.startswith(
+                    "_".join(
+                        (
+                            C_FILE_NAME,
+                            self.use_which_image_for_gene_name.value,
+                        )
+                    )
+                )
+            ]
+        if len(name_feature) == 0 or len(description_feature) == 0:
+            return [],[]
+        else: 
+            return name_feature, description_feature
+
     def make_gct_file(self, image_set_numbers, workspace, settings_group):
         """Make a GenePattern file containing image measurements
         Format specifications located at http://www.broadinstitute.org/cancer/software/genepattern/tutorial/gp_fileformats.html?gct
@@ -1275,29 +1286,13 @@ desired.
                     ] + measurement_feature_names
                     writer.writerow(written_image_names)
 
-                    # Place the one of the paths and desired info column up front in image feature list
-                    description_feature = [
-                        x for x in image_features if x.startswith(C_PATH_NAME + "_")
-                    ]
-                    if self.how_to_specify_gene_name == GP_NAME_METADATA:
-                        name_feature = [self.gene_name_column.value]
-                        if name_feature not in image_features:
-                            name_feature = []
-                    elif self.how_to_specify_gene_name == GP_NAME_FILENAME:
-                        name_feature = [
-                            x
-                            for x in image_features
-                            if x.startswith(
-                                "_".join(
-                                    (
-                                        C_FILE_NAME,
-                                        self.use_which_image_for_gene_name.value,
-                                    )
-                                )
-                            )
-                        ]
-                    if len(name_feature) == 0 or len(description_feature) == 0:
+                    name_feature, description_feature = self.validate_image_features_exist(
+                        image_features
+                        )
+
+                    if name_feature == []:
                         return
+
                     image_features = [
                         name_feature[0],
                         description_feature[0],

--- a/cellprofiler/modules/exporttospreadsheet.py
+++ b/cellprofiler/modules/exporttospreadsheet.py
@@ -675,6 +675,36 @@ desired.
                         % undefined_tags[0],
                         group.file_name,
                     )
+      
+        """Check if image features are exported if GCTs are being made"""
+        if self.wants_genepattern_file.value and self.pick_columns.value:
+            measurement_columns = pipeline.get_measurement_columns()
+            image_features = self.filter_columns([x[1] for x in measurement_columns if x[0]==IMAGE],IMAGE)
+            description_feature = [
+                x for x in image_features if x.startswith(C_PATH_NAME + "_")
+            ]
+            if self.how_to_specify_gene_name == GP_NAME_METADATA:
+                name_feature = [self.gene_name_column.value]
+                if name_feature not in image_features:
+                    name_feature = []
+            elif self.how_to_specify_gene_name == GP_NAME_FILENAME:
+                name_feature = [
+                    x
+                    for x in image_features
+                    if x.startswith(
+                        "_".join(
+                            (
+                                C_FILE_NAME,
+                                self.use_which_image_for_gene_name.value,
+                            )
+                        )
+                    )
+                ]
+            if len(name_feature) == 0 or len(description_feature) == 0: 
+                raise ValidationError(
+                    "At least one path measurement plus the feature selected in 'Select source of sample row name' must be enabled for GCT file creation. Use 'Press button to select measurements' to enable these measurements, or set 'Select measurements to export' to No.",
+                    self.wants_genepattern_file
+                )
 
     def validate_module_warnings(self, pipeline):
         """Warn user re: Test mode """
@@ -1251,6 +1281,8 @@ desired.
                     ]
                     if self.how_to_specify_gene_name == GP_NAME_METADATA:
                         name_feature = [self.gene_name_column.value]
+                        if name_feature not in image_features:
+                            name_feature = []
                     elif self.how_to_specify_gene_name == GP_NAME_FILENAME:
                         name_feature = [
                             x
@@ -1264,6 +1296,8 @@ desired.
                                 )
                             )
                         ]
+                    if len(name_feature) == 0 or len(description_feature) == 0:
+                        return
                     image_features = [
                         name_feature[0],
                         description_feature[0],


### PR DESCRIPTION
Resolves #4548 

So this was a corner case - the user had used the "Select the measurements to export" setting to only select object features for one class (no image features at all were selected), but GCTs require a couple specific Image features for the file to get created (and you would in general want to export them all!). I've added a check so that it doesn't actively error if the user hasn't selected the right things, but also a validation error to tell the user what they need to do in order for this to work.