### PR TITLE
Don't kill other tests if one fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ jobs:
       matrix:
         os: [macos-11]
         python-version: [ 3.8, 3.9 ]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     env:
       CP_MYSQL_TEST_HOST: "127.0.0.1"


### PR DESCRIPTION
Right now, if any version in our matrix fails, the others are cancelled; I'd argue for letting them continue, this will allow us to pinpoint version specific issues.