### PR TITLE
Pin jinja below 3.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setuptools.setup(
         "h5py~=3.6.0",
         "imageio>=2.5",
         "inflect>=2.1",
-        "Jinja2>=2.11.2",
+        "Jinja2>=2.11.2,<3.1",
         "joblib>=0.13",
         "mahotas>=1.4",
         "matplotlib==3.1.3",


### PR DESCRIPTION
When running `make html` in `on docs/Makefile` I got:
```
ImportError: cannot import name 'environmentfilter' from 'jinja2' (/Users/ngogober/opt/anaconda3/envs/cpnewnp/lib/python3.8/site-packages/jinja2/__init__.py)
make: *** [html] Error 1
```

The issue is described [here](https://github.com/sphinx-doc/sphinx/issues/10291), and for now, solved by pinning jinja below 3.1.