### PR TITLE
Support previewing a series in the Images module

### DIFF
--- a/cellprofiler/gui/pathlist.py
+++ b/cellprofiler/gui/pathlist.py
@@ -417,6 +417,22 @@ class PathListCtrl(wx.TreeCtrl):
             paths.append(item.url)
         return paths
 
+    def get_selected_series(self):
+        if self.GetFocusedItem().ID is not None:
+            idx = self.GetFocusedItem()
+            parent = self.GetItemParent(idx)
+            if not self.is_folder(parent):
+                # This is a series within a file. Find the index.
+                tgt = 0
+                child_idx, cookie = self.GetFirstChild(parent)
+                while child_idx.IsOk():
+                    if child_idx == idx:
+                        # This is the series we are looking at
+                        return tgt
+                    child_idx, cookie = self.GetNextChild(parent, cookie)
+                    tgt += 1
+        return None
+
     def has_selections(self):
         """Return True if there are any selected items"""
         return len(self.GetSelections()) > 0

--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -2057,8 +2057,9 @@ class PipelineController(object):
             if result == wx.YES:
                 self.do_load_pipeline(path)
             return
+        series = self.__path_list_ctrl.get_selected_series()
         show_image(
-            path, self.__frame, dimensions=3 if self.__pipeline.volumetric() else 2
+            path, self.__frame, dimensions=3 if self.__pipeline.volumetric() else 2, series=series
         )
 
     def on_pathlist_file_delete(self, paths):

--- a/cellprofiler/gui/utilities/figure.py
+++ b/cellprofiler/gui/utilities/figure.py
@@ -131,7 +131,7 @@ def format_plate_data_as_array(plate_dict, plate_type):
     return data
 
 
-def show_image(url, parent=None, needs_raise_after=True, dimensions=2):
+def show_image(url, parent=None, needs_raise_after=True, dimensions=2, series=None):
     from ..figure import Figure
 
     filename = url[(url.rfind("/") + 1) :]
@@ -142,6 +142,7 @@ def show_image(url, parent=None, needs_raise_after=True, dimensions=2):
             name=os.path.splitext(filename)[0],
             pathname=os.path.dirname(url),
             volume=True if dimensions == 3 else False,
+            series=series,
         )
         image = provider.provide_image(None).pixel_data
     except IOError:
@@ -165,9 +166,9 @@ def show_image(url, parent=None, needs_raise_after=True, dimensions=2):
     frame.set_subplots(dimensions=dimensions, subplots=(1, 1))
 
     if dimensions == 2 and image.ndim == 3:  # multichannel images
-        frame.subplot_imshow_color(0, 0, image[:, :, :3], title=filename)
+        frame.subplot_imshow_color(0, 0, image[:, :, :3], title=filename, normalize=True)
     else:  # grayscale image or volume
-        frame.subplot_imshow_grayscale(0, 0, image, title=filename)
+        frame.subplot_imshow_grayscale(0, 0, image, title=filename, normalize=True)
 
     frame.panel.draw()
 


### PR DESCRIPTION
In the Images module you can double-click on an image in the file list to attempt to preview it.

Since this module can now display a list of series within an image file, I've made it so that you can double click an entry in the series list to preview that specific series (instead of it always showing the first).

I've also made the display engine normalise the preview data so as to be consistent with how CellProfiler will display the images elsewhere in the UI.