### PR TITLE
Display SeriesName in Images file list (imagesetctrl)

### DIFF
--- a/cellprofiler/gui/cpframe.py
+++ b/cellprofiler/gui/cpframe.py
@@ -252,7 +252,6 @@ class CPFrame(wx.Frame):
         #
         self.__path_list_ctrl = PathListCtrl(self.__path_list_sash, style=wx.TR_HIDE_ROOT | wx.TR_HAS_BUTTONS |
                                              wx.TR_MULTIPLE | wx.TR_FULL_ROW_HIGHLIGHT | wx.TR_LINES_AT_ROOT)
-        self.__path_list_ctrl.SetBackgroundColour(wx.WHITE)
         sizer.Add(self.__path_list_ctrl, 1, wx.EXPAND | wx.ALL)
         #
         # Path list tools horizontal sizer

--- a/cellprofiler/gui/imagesetctrl.py
+++ b/cellprofiler/gui/imagesetctrl.py
@@ -12,10 +12,9 @@ import wx
 import wx.adv
 import wx.grid
 import wx.lib.mixins.gridlabelrenderer
-from cellprofiler_core.constants.image import C_FRAME, CT_GRAYSCALE, CT_COLOR, CT_MASK, CT_OBJECTS, CT_FUNCTION, \
-    C_SERIES_NAME
+from cellprofiler_core.constants.image import C_FRAME, CT_GRAYSCALE, CT_COLOR, CT_MASK, CT_OBJECTS, CT_FUNCTION
 from cellprofiler_core.constants.image import C_SERIES
-from cellprofiler_core.constants.measurement import C_FILE_NAME, C_CHANNEL, C_Z, C_T
+from cellprofiler_core.constants.measurement import C_FILE_NAME, C_CHANNEL, C_Z, C_T, C_SERIES_NAME
 from cellprofiler_core.constants.measurement import C_METADATA
 from cellprofiler_core.constants.measurement import C_OBJECTS_FILE_NAME
 from cellprofiler_core.constants.measurement import C_OBJECTS_PATH_NAME

--- a/cellprofiler/gui/imagesetctrl.py
+++ b/cellprofiler/gui/imagesetctrl.py
@@ -954,7 +954,7 @@ class ImageSetCtrl(wx.grid.Grid, cellprofiler.gui.cornerbuttonmixin.CornerButton
             if col == wx.NOT_FOUND:
                 col = None
         bottom = self.GetGridWindow().GetVirtualSize()[1]
-        if y <= self.GetRowSize(0) / 2:
+        if not self.GetNumberRows() or y <= self.GetRowSize(0) / 2:
             row = 0
         elif y >= bottom - self.GetRowSize(self.GetNumberRows() - 1):
             row = self.GetNumberRows()

--- a/cellprofiler/gui/imagesetctrl.py
+++ b/cellprofiler/gui/imagesetctrl.py
@@ -12,9 +12,10 @@ import wx
 import wx.adv
 import wx.grid
 import wx.lib.mixins.gridlabelrenderer
-from cellprofiler_core.constants.image import C_FRAME, CT_GRAYSCALE, CT_COLOR, CT_MASK, CT_OBJECTS, CT_FUNCTION
+from cellprofiler_core.constants.image import C_FRAME, CT_GRAYSCALE, CT_COLOR, CT_MASK, CT_OBJECTS, CT_FUNCTION, \
+    C_SERIES_NAME
 from cellprofiler_core.constants.image import C_SERIES
-from cellprofiler_core.constants.measurement import C_FILE_NAME
+from cellprofiler_core.constants.measurement import C_FILE_NAME, C_CHANNEL, C_Z, C_T
 from cellprofiler_core.constants.measurement import C_METADATA
 from cellprofiler_core.constants.measurement import C_OBJECTS_FILE_NAME
 from cellprofiler_core.constants.measurement import C_OBJECTS_PATH_NAME
@@ -261,9 +262,18 @@ class ImageSetGridTable(wx.grid.GridTableBase):
                 and self.display_mode == DISPLAY_MODE_ALTERNATE
                 and value is not None
         ):
-            keys = ["Series", "Channel", "ZPlane", "Timepoint"]
+            # Check for and add a series name to the plane label
+            meas = f"{C_SERIES_NAME}_{column.channel}"
+            if self.measurements.has_measurements(
+                    IMAGE, meas, image_set_number=image_set):
+                res = self.measurements.get_measurement(
+                    IMAGE, meas, image_set_number=image_set)
+                if res:
+                    value += f" ({res})"
+            # Now check for and add CZT indexes
+            keys = [C_SERIES, C_CHANNEL, C_Z, C_T]
             for key in keys:
-                meas = f"{key}{column.channel}"
+                meas = f"{key}_{column.channel}"
                 if self.measurements.has_measurements(
                         IMAGE, meas, image_set_number=image_set):
                     res = self.measurements.get_measurement(


### PR DESCRIPTION
Companion PR to CellProfiler/core#119

This will display series names in the plane details view (if present). SeriesName field will appear in brackets as below:

<img width="629" alt="Screenshot 2022-08-26 at 09 31 46" src="https://user-images.githubusercontent.com/26802537/188160824-8b132b8b-9cd8-4674-b711-8ee72c8c7edd.png">

This is using zarrs with a custom reader, but the same should result from any reader which supports the new parameter.

While I was in there I also fixed the path list in MacOS dark mode and fixed a drag-drop bug.
