### PR TITLE
Improve ErodeObjects performance

### DIFF
--- a/cellprofiler/modules/erodeobjects.py
+++ b/cellprofiler/modules/erodeobjects.py
@@ -102,10 +102,13 @@ label numbers.""",
 
         if self.preserve_midpoints.value:
             missing_labels = numpy.setxor1d(x_data, y_data)
-            for label in missing_labels:
-                binary = x_data == label
-                midpoint = scipy.ndimage.morphology.distance_transform_edt(binary)
-                y_data[midpoint == numpy.max(midpoint)] = label
+            if self.structuring_element.value_text == "Disk,1":
+                y_data += x_data * numpy.isin(x_data, missing_labels)
+            else:
+                for label in missing_labels:
+                    binary = x_data == label
+                    midpoint = scipy.ndimage.morphology.distance_transform_edt(binary)
+                    y_data[midpoint == numpy.max(midpoint)] = label
 
         if self.relabel_objects.value:
             y_data = skimage.morphology.label(y_data)

--- a/cellprofiler/utilities/morphology.py
+++ b/cellprofiler/utilities/morphology.py
@@ -3,6 +3,7 @@ Shared mophology methods used by multiple modules
 """
 
 import numpy
+import scipy.ndimage
 import skimage.morphology
 
 
@@ -76,5 +77,30 @@ def binary_erosion(x_data, structuring_element):
         )
 
     y_data = skimage.morphology.binary_erosion(x_data, structuring_element)
+
+    return y_data
+
+
+def morphological_gradient(x_data, structuring_element):
+    is_strel_2d = structuring_element.ndim == 2
+
+    is_img_2d = x_data.ndim == 2
+
+    if is_strel_2d and not is_img_2d:
+        y_data = numpy.zeros_like(x_data)
+
+        for index, plane in enumerate(x_data):
+            y_data[index] = scipy.ndimage.morphological_gradient(
+                plane, footprint=structuring_element
+            )
+
+        return y_data
+
+    if not is_strel_2d and is_img_2d:
+        raise NotImplementedError(
+            "A 3D structuring element cannot be applied to a 2D image."
+        )
+
+    y_data = scipy.ndimage.morphological_gradient(x_data, footprint=structuring_element)
 
     return y_data


### PR DESCRIPTION
## Motivation

`ErodeObjects` module feels particularly slow when there are many objects in the mask.  The current implementation is a for-loop on each object coupled with an erosion applied on the whole mask. Consequently, there is a lot of redundancy. 

## Improvement

It is actually possible to replace this for-loop/erosion implementation by a single morphological operation. The morphological gradient (i.e. dilate - erosion) captures the contour of individual connected components, with a width and shape dependent on the kernel size and shape. It is possible to get the eroded objects by setting to 0 the contour pixels of the original mask.

There is a second improvement in the midpoints preservation algorithm. When the kernel is "Disk,1", the midpoint of a removed object is the original objects itself. In this trivial case, the costly distance transform can be skipped.

## Tests

The 3 tests currently implemented work just fine. It could be useful to test for other structural elements shapes. I only checked the "Disk,1" setting.