### PR TITLE
Update test_save_image_tiff_int32 expected data type

### DIFF
--- a/tests/modules/test_saveimages.py
+++ b/tests/modules/test_saveimages.py
@@ -404,7 +404,7 @@ def test_save_image_tiff_int32(tmpdir, module, workspace):
 
     data = skimage.io.imread(os.path.join(directory, "example_large_int_values.tiff"))
 
-    assert data.dtype == numpy.int64
+    assert data.dtype == numpy.int_
 
     numpy.testing.assert_array_equal(data, image.pixel_data)
 


### PR DESCRIPTION
According to https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.int64, numpy.int64 can have many different aliases. This can lead to test failures on some platforms (Windows).

However, numpy.int_ appears to consistent with the expected results for test_save_image_tiff_int32