### PR TITLE
Add NGFF reader support

### DIFF
--- a/cellprofiler/gui/pipelinecontroller.py
+++ b/cellprofiler/gui/pipelinecontroller.py
@@ -71,7 +71,7 @@ from cellprofiler_core.constants.pipeline import (
     DIRECTION_DOWN,
     DIRECTION_UP,
 )
-from cellprofiler_core.constants.reader import all_readers
+from cellprofiler_core.constants.reader import all_readers, ZARR_FILETYPE
 from cellprofiler_core.constants.workspace import DISPOSITION_SKIP
 from cellprofiler_core.image import ImageSetList
 from cellprofiler_core.measurement import Measurements
@@ -2191,13 +2191,23 @@ class PipelineController(object):
                         break
 
                     message[0] = "\nProcessing " + pathname
-                    if os.path.isfile(pathname):
+                    if ZARR_FILETYPE.search(pathname):
+                        pathname, _ = ZARR_FILETYPE.split(pathname)
+                        urls.append(pathname2url(pathname))
+                        if len(urls) > 100:
+                            queue.put(urls)
+                            urls = []
+                    elif os.path.isfile(pathname):
                         urls.append(pathname2url(pathname))
                         if len(urls) > 100:
                             queue.put(urls)
                             urls = []
                     elif os.path.isdir(pathname):
                         for dirpath, dirnames, files in os.walk(pathname):
+                            if ZARR_FILETYPE.search(dirpath):
+                                zarr_dir, _ = ZARR_FILETYPE.split(dirpath)
+                                urls.append(pathname2url(zarr_dir))
+                                continue
                             for filename in files:
                                 if not interrupt or interrupt[0]:
                                     break


### PR DESCRIPTION
Requires CellProfiler/core#124

OME-NGFF (.zarr) files are something of an unusual case as the operating system views them as a directory rather than a file container.

This PR modifies the file list GUI so that dropped .zarr directories are intercepted and considered as a file object for reading.

Dropping a file within the zarr will instead be treated as dropping the root. Users should currently index single images within a zarr container using the input modules or loaddata parameters, rather than trying to point to a specific group.

