### PR TITLE
Fill readers

### DIFF
--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -53,7 +53,7 @@ from cellprofiler_core.utilities.zmq import join_to_the_boundary
 from cellprofiler_core.worker import aw_parse_args
 from cellprofiler_core.worker import main as worker_main
 from cellprofiler_core.workspace import Workspace
-from cellprofiler_core.reader import fill_readers
+from cellprofiler_core.reader import activate_readers
 
 if hasattr(sys, "frozen"):
     if sys.platform == "darwin":
@@ -128,7 +128,7 @@ def main(args=None):
     if any([any([arg.startswith(switch) for switch in switches]) for arg in args]):
         set_headless()
         aw_parse_args()
-        fill_readers()
+        activate_readers()
         worker_main()
         return exit_code
 
@@ -149,7 +149,7 @@ def main(args=None):
         options.show_gui = False
 
     # must be run after last possible invocation of set_headless()
-    fill_readers()
+    activate_readers()
 
     if options.temp_dir is not None:
         if not os.path.exists(options.temp_dir):

--- a/cellprofiler/__main__.py
+++ b/cellprofiler/__main__.py
@@ -53,6 +53,7 @@ from cellprofiler_core.utilities.zmq import join_to_the_boundary
 from cellprofiler_core.worker import aw_parse_args
 from cellprofiler_core.worker import main as worker_main
 from cellprofiler_core.workspace import Workspace
+from cellprofiler_core.reader import fill_readers
 
 if hasattr(sys, "frozen"):
     if sys.platform == "darwin":
@@ -127,6 +128,7 @@ def main(args=None):
     if any([any([arg.startswith(switch) for switch in switches]) for arg in args]):
         set_headless()
         aw_parse_args()
+        fill_readers()
         worker_main()
         return exit_code
 
@@ -145,6 +147,9 @@ def main(args=None):
         set_headless()
         options.run_pipeline = False
         options.show_gui = False
+
+    # must be run after last possible invocation of set_headless()
+    fill_readers()
 
     if options.temp_dir is not None:
         if not os.path.exists(options.temp_dir):


### PR DESCRIPTION
Requires CellProfiler/core#130, invokes ~`fill_readers()`~ `activate_readers(check_config=True)` **after** headless mode is determined. This is especially important when running tests (which use headless mode) in github actions since the `get_config()` function in CellProfiler/core/cellprofiler_core/preferences/__init__.py will import `wx` if it does not detect headless mode, and therefore cause the tests to exit prematurely because a framework build of python is required.