### PR TITLE
Simplify ExpandorShrinkObjects logic

### DIFF
--- a/cellprofiler/modules/expandorshrinkobjects.py
+++ b/cellprofiler/modules/expandorshrinkobjects.py
@@ -75,15 +75,15 @@ O_SKELETONIZE = "Skeletonize each object"
 O_SPUR = "Remove spurs"
 
 library_mapping = {
-    O_EXPAND:'expand_defined_pixels',
-    O_EXPAND_BY_MEASUREMENT:'expand_defined_pixels',
+    O_SHRINK_INF:'shrink_to_point',
     O_EXPAND_INF:'expand_infinite',
+    O_DIVIDE:'add_dividing_lines',
     O_SHRINK:'shrink_defined_pixels',
     O_SHRINK_BY_MEASUREMENT:'shrink_defined_pixels',
-    O_SHRINK_INF:'shrink_to_point',
-    O_DIVIDE:'add_dividing_lines',
-    O_SPUR:'despur',
+    O_EXPAND:'expand_defined_pixels',
+    O_EXPAND_BY_MEASUREMENT:'expand_defined_pixels',
     O_SKELETONIZE:'skeletonize',
+    O_SPUR:'despur',    
 }
 
 O_ALL = list(library_mapping.keys())

--- a/cellprofiler/modules/expandorshrinkobjects.py
+++ b/cellprofiler/modules/expandorshrinkobjects.py
@@ -73,17 +73,6 @@ O_EXPAND = "Expand objects by a specified number of pixels"
 O_EXPAND_BY_MEASUREMENT = "Expand objects by a previous measurement"
 O_SKELETONIZE = "Skeletonize each object"
 O_SPUR = "Remove spurs"
-O_ALL = [
-    O_SHRINK_INF,
-    O_EXPAND_INF,
-    O_DIVIDE,
-    O_SHRINK,
-    O_SHRINK_BY_MEASUREMENT,
-    O_EXPAND,
-    O_EXPAND_BY_MEASUREMENT,
-    O_SKELETONIZE,
-    O_SPUR,
-]
 
 library_mapping = {
     O_EXPAND:'expand_defined_pixels',
@@ -96,6 +85,8 @@ library_mapping = {
     O_SPUR:'despur',
     O_SKELETONIZE:'skeletonize',
 }
+
+O_ALL = list(library_mapping.keys())
 
 class ExpandOrShrinkObjects(Module):
     module_name = "ExpandOrShrinkObjects"


### PR DESCRIPTION
@callum-jpg and I were code-reviewing various library modules yesterday and he pointed out that this first one was in a much less ideal state than some of the later ones, in that essentially in the module-module we were handling a lot of the logic (in terms of which parameters need to be passed to the sub functions and which do not) that is [already handled in the library-module](https://github.com/CellProfiler/CellProfiler/blob/master/cellprofiler/library/modules/_expandorshrinkobjects.py#L4-L17). This PR cleans that up; I think the fact that now the mappings between settings and library functions are now more explicit is a particularly nice bonus!