### PR TITLE
Adding FillObjects to library

### DIFF
--- a/cellprofiler/library/functions/object_processing.py
+++ b/cellprofiler/library/functions/object_processing.py
@@ -221,7 +221,7 @@ def segment_objects(labels_x, labels_y, dimensions):
 
     return output
 
-def fill_object_holes(labels, diameter, planewise):
+def fill_object_holes(labels, diameter, planewise=False):
     array = labels.copy()
     # Calculate radius from diameter
     radius = diameter / 2.0
@@ -236,11 +236,20 @@ def fill_object_holes(labels, diameter, planewise):
     
     min_obj_size = numpy.pi * factor
 
-    for obj in numpy.unique(array):
-        if obj == 0:
-            continue
-        filled_mask = skimage.morphology.remove_small_holes(array == obj, min_obj_size)
-        array[filled_mask] = obj
+    if planewise and labels.ndim != 2 and labels.shape[-1] not in (3, 4):
+        for plane in array:
+            for obj in numpy.unique(plane):
+                if obj == 0:
+                    continue
+                filled_mask = skimage.morphology.remove_small_holes(plane == obj, min_obj_size)
+                plane[filled_mask] = obj    
+        return array
+    else:
+        for obj in numpy.unique(array):
+            if obj == 0:
+                continue
+            filled_mask = skimage.morphology.remove_small_holes(array == obj, min_obj_size)
+            array[filled_mask] = obj
     return array
 
 def fill_convex_hulls(labels):

--- a/cellprofiler/library/modules/__init__.py
+++ b/cellprofiler/library/modules/__init__.py
@@ -1,3 +1,4 @@
 from ._medialaxis import medialaxis
 from ._combineobjects import combineobjects
 from ._expandorshrinkobjects import expand_or_shrink_objects
+from ._fillobjects import fillobjects

--- a/cellprofiler/library/modules/_fillobjects.py
+++ b/cellprofiler/library/modules/_fillobjects.py
@@ -1,0 +1,12 @@
+import skimage
+import numpy
+from cellprofiler.library.functions.object_processing import fill_object_holes, fill_convex_hulls
+
+def fillobjects(labels, mode="holes", diameter=64.0, planewise=False):
+    if mode.casefold() == "holes":
+        return fill_object_holes(labels, diameter, planewise)
+    elif mode.casefold() in ("convex hull", "convex_hull"):
+        return fill_convex_hulls(labels)
+    else:
+        raise ValueError(f"Mode '{mode}' is not supported. Available modes are: 'holes' and 'convex_hull'.")
+

--- a/cellprofiler/modules/fillobjects.py
+++ b/cellprofiler/modules/fillobjects.py
@@ -31,6 +31,7 @@ from cellprofiler_core.module.image_segmentation import ObjectProcessing
 from cellprofiler_core.setting import Binary
 from cellprofiler_core.setting.choice import Choice
 from cellprofiler_core.setting.text import Float
+from cellprofiler.library.functions.object_processing import fill_object_holes, fill_convex_hulls
 
 MODE_HOLES = "Holes"
 MODE_CHULL = "Convex hull"
@@ -112,45 +113,3 @@ that touching objects may not be perfectly convex if there was a region of overl
             setting_values.append(MODE_HOLES)
             variable_revision_number = 2
         return setting_values, variable_revision_number
-
-
-def fill_convex_hulls(labels):
-    data = skimage.measure.regionprops(labels)
-    output = numpy.zeros_like(labels)
-    for prop in data:
-        label = prop['label']
-        bbox = prop['bbox']
-        cmask = prop['convex_image']
-        if len(bbox) <= 4:
-            output[bbox[0]:bbox[2], bbox[1]:bbox[3]][cmask] = label
-        else:
-            output[bbox[0]:bbox[3], bbox[1]:bbox[4], bbox[2]: bbox[5]][cmask] = label
-    return output
-
-
-def _fill_holes(labels, min_obj_size):
-    array = labels.copy()
-    # Iterate through each label as a mask, fill holes on the mask, and reapply to original image
-    for n in numpy.unique(array):
-        if n == 0:
-            continue
-
-        filled_mask = skimage.morphology.remove_small_holes(array == n, min_obj_size)
-        array[filled_mask] = n
-    return array
-
-
-def fill_object_holes(labels, diameter, planewise):
-    radius = diameter / 2.0
-
-    if labels.ndim == 2 or labels.shape[-1] in (3, 4) or planewise:
-        factor = radius ** 2
-    else:
-        factor = (4.0 / 3.0) * (radius ** 3)
-
-    min_obj_size = numpy.pi * factor
-
-    # Only operate planewise if image is 3D and planewise requested
-    if planewise and labels.ndim != 2 and labels.shape[-1] not in (3, 4):
-        return numpy.array([_fill_holes(x, min_obj_size) for x in labels])
-    return _fill_holes(labels, min_obj_size)

--- a/cellprofiler/modules/fillobjects.py
+++ b/cellprofiler/modules/fillobjects.py
@@ -31,7 +31,7 @@ from cellprofiler_core.module.image_segmentation import ObjectProcessing
 from cellprofiler_core.setting import Binary
 from cellprofiler_core.setting.choice import Choice
 from cellprofiler_core.setting.text import Float
-from cellprofiler.library.functions.object_processing import fill_object_holes, fill_convex_hulls
+from cellprofiler.library.modules import fillobjects
 
 MODE_HOLES = "Holes"
 MODE_CHULL = "Convex hull"
@@ -99,12 +99,12 @@ that touching objects may not be perfectly convex if there was a region of overl
         return __settings__
 
     def run(self, workspace):
-        if self.mode.value == MODE_CHULL:
-            self.function = lambda labels, d, p, m: fill_convex_hulls(labels)
-        else:
-            self.function = lambda labels, diameter, planewise, mode: fill_object_holes(
-                labels, diameter, planewise
-            )
+        self.function = lambda labels, diameter, planewise, mode: fillobjects(
+            labels, 
+            mode=self.mode.value,
+            diameter=self.size.value, 
+            planewise=self.planewise.value
+        )
 
         super(FillObjects, self).run(workspace)
 


### PR DESCRIPTION
Adding FillObjects to the library. This one works in a way that is slightly different to the other modules added so far due to `FillObjects` class inheriting from the `ObjectProcessing`. Basically, the library function needs to be passed as a lambda function to the `self.function` attribute and allows us to keep everything that `ObjectProcessing` does. 