### PR TITLE
Catch "no objects of any type"

### DIFF
--- a/cellprofiler/modules/exporttospreadsheet.py
+++ b/cellprofiler/modules/exporttospreadsheet.py
@@ -1408,16 +1408,13 @@ desired.
                 writer.writerow([x[i] for x in features])
 
             for img_number in image_set_numbers:
-                try:
-                    object_count = numpy.max(
-                        [
-                            m.get_measurement(IMAGE, "Count_%s" % name, img_number)
-                            for name in object_names
-                        ]
-                    )
-                except TypeError:
-                    #If no objects are found in the image, we can't find the max of nan's - 4653
-                    object_count = 0
+                object_count = numpy.max(
+                    [
+                        # If no objects are found in the image, we can't find the max of None - 4653
+                        m.get_measurement(IMAGE, "Count_%s" % name, img_number) or 0
+                        for name in object_names
+                    ]
+                )
                 object_count = int(object_count) if object_count and not numpy.isnan(object_count) else 0
                 columns = [
                     numpy.repeat(img_number, object_count)

--- a/cellprofiler/modules/exporttospreadsheet.py
+++ b/cellprofiler/modules/exporttospreadsheet.py
@@ -1408,12 +1408,16 @@ desired.
                 writer.writerow([x[i] for x in features])
 
             for img_number in image_set_numbers:
-                object_count = numpy.max(
-                    [
-                        m.get_measurement(IMAGE, "Count_%s" % name, img_number)
-                        for name in object_names
-                    ]
-                )
+                try:
+                    object_count = numpy.max(
+                        [
+                            m.get_measurement(IMAGE, "Count_%s" % name, img_number)
+                            for name in object_names
+                        ]
+                    )
+                except TypeError:
+                    #If no objects are found in the image, we can't find the max of nan's - 4653
+                    object_count = 0
                 object_count = int(object_count) if object_count and not numpy.isnan(object_count) else 0
                 columns = [
                     numpy.repeat(img_number, object_count)


### PR DESCRIPTION
Resolves #4653 

ExportToSpreadsheet gets mad trying to say "what is the biggest number objects that I have in this image" if there are object creation modules that are skipped.