### PR TITLE
Move mysqlclient to an optional dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setuptools.setup(
     extras_require={
         "build": ["black", "pre-commit", "pyinstaller", "twine"],
         "docs": ["Sphinx>=3.1.1", "sphinx-rtd-theme>=0.5.0"],
+        "mysql": ["mysqlclient==1.4.6"],
         "test": ["pytest>=3.3.2,<4"],
     },
     install_requires=[
@@ -73,7 +74,6 @@ setuptools.setup(
         "joblib>=0.13",
         "mahotas>=1.4",
         "matplotlib==3.1.3",
-        "mysqlclient==1.4.6",
         "numpy>=1.20.1",
         "Pillow>=7.1.0",
         "pyzmq~=22.3",
@@ -86,7 +86,6 @@ setuptools.setup(
         "six",
         "tifffile<2022.4.22",
         "wxPython==4.2.0",
-
     ],
     license="BSD",
     name="CellProfiler",


### PR DESCRIPTION
The mysqlclient package is "tricky" to install (requires a compiler + mysql and python dev headers) and is only used for the ExportToDatabase functionality, which already guards against a missing `mysqlclient` installation:
https://github.com/CellProfiler/CellProfiler/blob/4bd869eef9b347a92e731f78b2269bf604ca4d27/cellprofiler/modules/exporttodatabase.py#L155-L163

Since the package is tricky to install and isn't _required_ at runtime, this PR proposes we move it to an optional dependency (installed via `pip3 install "CellProfiler[mysql]"`), easing installation for users who don't use mysql.
