### PR TITLE
Fix library threshold dimension order for volumetric images

### DIFF
--- a/cellprofiler/library/functions/image_processing.py
+++ b/cellprofiler/library/functions/image_processing.py
@@ -223,9 +223,9 @@ def get_adaptive_threshold(
     if volumetric:
         # Array to store threshold values
         thresh_out = numpy.zeros(image.shape)
-        for z in range(image.shape[2]):
-            thresh_out[:, :, z] = get_adaptive_threshold(
-                image[:, :, z],
+        for z in range(image.shape[0]):
+            thresh_out[z, :, :] = get_adaptive_threshold(
+                image[z, :, :],
                 mask=None,  # Mask has already been applied
                 threshold_method=threshold_method,
                 window_size=window_size,

--- a/tests/modules/test_threshold.py
+++ b/tests/modules/test_threshold.py
@@ -1173,6 +1173,51 @@ def test_threshold_otsu3_volume():
     numpy.testing.assert_array_almost_equal(t_local, t_local_expected)
 
 
+def test_threshold_otsu3_oblong_volume():
+    numpy.random.seed(73)
+
+    data = numpy.random.rand(5, 10, 10)
+
+    mask = numpy.zeros_like(data, dtype=bool)
+
+    mask[1:-1, 1:-1, 1:-1] = True
+
+    workspace, module = make_workspace(data, mask=mask, dimensions=3)
+
+    image = workspace.image_set.get_image(INPUT_IMAGE_NAME)
+
+    module.threshold_scope.value = cellprofiler.modules.threshold.TS_ADAPTIVE
+
+    module.local_operation.value = centrosome.threshold.TM_OTSU
+
+    module.two_class_otsu.value = cellprofiler.modules.threshold.O_THREE_CLASS
+
+    module.assign_middle_to_foreground.value = (
+        cellprofiler.modules.threshold.O_FOREGROUND
+    )
+
+    module.adaptive_window_size.value = 3
+
+    t_local, t_global, t_guide, _, _ = module.get_threshold(image, workspace)
+
+    t_guide_expected = skimage.filters.threshold_multiotsu(data[mask], nbins=128)[0]
+
+    t_local_expected = cellprofiler.library.functions.image_processing.get_adaptive_threshold(
+        data,
+        mask = mask,
+        threshold_method = "multiotsu",
+        window_size = 3,
+        volumetric = True,
+        nbins = 128,
+    )
+
+    numpy.testing.assert_almost_equal(t_guide, t_guide_expected)
+
+    assert t_local.ndim == 3
+
+    numpy.testing.assert_array_almost_equal(t_local, t_local_expected)
+
+
 def test_threshold_otsu3_image_log():
     numpy.random.seed(73)
 


### PR DESCRIPTION
Library incorrectly assumed the dimension order was xyz, rather than zxy for volumetric images. This PR fixes that.

Also added a new test for oblong volumetric images, since all of the previous volumetric tests are cubes. 