### PR TITLE
Make module search fuzzy

### DIFF
--- a/cellprofiler/utilities/rules.py
+++ b/cellprofiler/utilities/rules.py
@@ -100,7 +100,6 @@ class Rules(Module):
                 cutoff = 1
 
             query = '_'.join((object_name,feature_name))
-            # closest_match = get_close_matches(query,measurement_list,1,cutoff)
             s = SequenceMatcher(b=query)
             closest_match = process.extractOne(
                 query,

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ setuptools.setup(
         "six~=1.16.0",
         "tifffile>=2022.4.8,<2022.4.22",
         "wxPython==4.2.0",
-
+        "rapidfuzz~=3.0.0"
     ],
     license="BSD",
     name="CellProfiler",


### PR DESCRIPTION
Module search uses exact substring matching, which is a bit too strict. We'd like to allow for spelling mistakes and skipping characters but still display sensible results ranked according to closest match.

For instance when searching for "IdentifyTertiaryObjects"

typing: `"zidentifytertiaryobjects"` should still work even with the leading `"z"` character

likewise typing `"idtertiary"` should work, where you type the leading `"id"`, skip over `"entify"`, followed by `"tertiary"`

This PR uses Damerau-Levenshtein distance similarity for fuzzy search. There's **a lot** of other choices, and a whole research field in this subject (eg driven by sequence alignment in genomics) as well as a bunch of custom open source solutions used in various tools (eg `fzf` or VSCode's file search). I was not at all rigorous in my choice, and I chose Damerau-Levenshtein simply because it seemed to match best for the small set of example queries I tried.

I also limited the results to `10` because it seemed "just right" to me. We could make this bigger/smaller, or a variable list by using some thresholding heuristic on the distance score.