### PR TITLE
Add plugin menu

### DIFF
--- a/cellprofiler/gui/cpframe.py
+++ b/cellprofiler/gui/cpframe.py
@@ -23,6 +23,7 @@ from cellprofiler_core.utilities.core.modules import instantiate_module
 import cellprofiler
 import cellprofiler.gui
 import cellprofiler.gui.utilities.icon
+from .plugins_menu import PLUGIN_MENU_ENTRIES
 from ._workspace_model import Workspace
 from .utilities.figure import close_all
 from .help.content import read_content
@@ -843,6 +844,14 @@ class CPFrame(wx.Frame):
         if sys.platform == "win32":
             self.__menu_window.AppendSeparator()
 
+        self.__menu_plugins = None
+        if PLUGIN_MENU_ENTRIES:
+            # Only show the plugins menu if a plugin is using it
+            self.__menu_plugins = wx.Menu()
+            for callback_fn, wx_id, name, tooltip in PLUGIN_MENU_ENTRIES:
+                self.__menu_plugins.Append(wx_id, name, tooltip)
+                self.Bind(wx.EVT_MENU, callback_fn, id=wx_id)
+
         self.__menu_help = Menu(self)
 
         self.__menu_bar = wx.MenuBar()
@@ -857,6 +866,8 @@ class CPFrame(wx.Frame):
                 "Initialize sampling up to current module",
             )
             self.__menu_bar.Append(self.__menu_sample, "&Sample")
+        if PLUGIN_MENU_ENTRIES:
+            self.__menu_bar.Append(self.__menu_plugins, "&Plugins")
         self.__menu_bar.Append(self.__menu_window, "&Windows")
         if wx.VERSION <= (2, 8, 10, 1, "") and wx.Platform == "__WXMAC__":
             self.__menu_bar.Append(self.__menu_help, "CellProfiler Help")

--- a/cellprofiler/gui/plugins_menu.py
+++ b/cellprofiler/gui/plugins_menu.py
@@ -1,0 +1,14 @@
+"""
+Use this container to store extra entries which should be added to 'Plugins' menu by
+CellProfiler plugin modules.
+
+Each entry should be a tuple containing (callback_fn, wx_id, name, tooltip).
+callback_fn - A callback function to be triggered when the menu item is activated.
+              Will receive a wx.Event object as an argument.
+wx_id - a unique wx.NewId() which will be bound to a GUI function related to your plugin.
+name - The label associated with the option in the menu.
+tooltip - Expanded help message (not displayed on all platforms).
+
+"""
+
+PLUGIN_MENU_ENTRIES = []


### PR DESCRIPTION
This PR adds a container which plugins can place custom menu entries into during loading. If entries were added, a new "Plugins" menu will appear in the main menubar (after "Test").

This is intended to allow plugin authors to add extra functionality to the GUI. For example with the OMERO reader we'll have a menu entry to let the user open up the server connection dialog.