### PR TITLE
Change fail-fast to false on builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,7 @@ jobs:
       matrix:
         os: [macos-10.15, windows-2019]
         python-version: ["3.8"]
+      fail-fast: false
   upload:
     name: upload
     needs: build


### PR DESCRIPTION
It can be nice to see if even if one OS build is failing, if the other succeeds; we can always cancel a run we want to stop if we do actually want it to stop.