### PR TITLE
Update a module name to allow import without type errors

### DIFF
--- a/cellprofiler/knime_bridge.py
+++ b/cellprofiler/knime_bridge.py
@@ -693,7 +693,7 @@ class KnimeBridgeServer(threading.Thread):
         return pixel_data
 
 
-__all__ = [KnimeBridgeServer]
+__all__ = ['KnimeBridgeServer']
 #
 # For testing only
 #


### PR DESCRIPTION
In file: knime_bridge.py, the list named `__all__` contains undefined names which can result in errors when this module is imported. The module name should be of string type. I created a string for the module name. For more information regarding `__all__`, please read about [importing fields from a package](https://docs.python.org/3/tutorial/modules.html#importing-from-a-package).  

Here is a [video](https://drive.google.com/file/d/1nOyQuHKcrDVAkIitdZS4O3g5hZLw6jV7/view?usp=sharing) that demonstrates the type error that happens during import when the module name is not represented as a string. Here when `foo` is exported, it is not done as a string. So, when this is imported and used, we get an error.

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the Open Source Security Foundation (OpenSSF)(https://openssf.org/): Project Alpha-Omega(https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.