### PR TITLE
Enable 3D display in MeasureImageOverlap

### DIFF
--- a/src/frontend/cellprofiler/modules/measureimageoverlap.py
+++ b/src/frontend/cellprofiler/modules/measureimageoverlap.py
@@ -346,6 +346,9 @@ the two images. Set this setting to “No” to assess no penalty.""",
             )
 
         if self.show_window:
+           
+            workspace.display_data.dimensions = test_image.dimensions
+           
             workspace.display_data.true_positives = data["true_positives"]
 
             workspace.display_data.true_negatives = data["true_negatives"]
@@ -376,7 +379,7 @@ the two images. Set this setting to “No” to assess no penalty.""",
 
     def display(self, workspace, figure):
         """Display the image confusion matrix & statistics"""
-        figure.set_subplots((3, 2))
+        figure.set_subplots((3, 2), dimensions=workspace.display_data.dimensions)
 
         for x, y, image, label in (
             (0, 0, workspace.display_data.true_positives, "True positives"),

--- a/src/subpackages/library/cellprofiler_library/functions/measurement.py
+++ b/src/subpackages/library/cellprofiler_library/functions/measurement.py
@@ -30,8 +30,11 @@ def measure_image_overlap_statistics(
     if mask is None:
         mask = np.ones_like(ground_truth_image, bool)
 
+    orig_shape = ground_truth_image.shape
+    
     # Covert 3D image to 2D long
     if ground_truth_image.ndim > 2:
+        
         ground_truth_image = ground_truth_image.reshape(
             -1, ground_truth_image.shape[-1]
         )
@@ -114,10 +117,10 @@ def measure_image_overlap_statistics(
     )
 
     data = {
-        "true_positives": true_positives,
-        "true_negatives": true_negatives,
-        "false_positives": false_positives,
-        "false_negatives": false_negatives,
+        "true_positives": true_positives.reshape(orig_shape),
+        "true_negatives": true_negatives.reshape(orig_shape),
+        "false_positives": false_positives.reshape(orig_shape),
+        "false_negatives": false_negatives.reshape(orig_shape),
         "Ffactor": f_factor,
         "Precision": precision,
         "Recall": recall,


### PR DESCRIPTION
Resolves #4890 

TLDR, we reshape the image to make the measurement easier, and then we never put it back. 