### PR TITLE
Add error catching to subprocess for RunImageJMacro

### DIFF
--- a/cellprofiler/modules/runimagejmacro.py
+++ b/cellprofiler/modules/runimagejmacro.py
@@ -292,7 +292,7 @@ temporary directory and assign its path as a value to this variable."""
 
             cmd += [self.stringify_metadata(tempdir)]
 
-            result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+            result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, errors='backslashreplace')
             for image_group in self.image_groups_out:
                 if not os.path.exists(os.path.join(tempdir, image_group.input_filename.value)):
                     # Cleanup the error logs for display, we want to remove less-useful lines to keep it succinct.


### PR DESCRIPTION
May, or may not, resolve #4858 . It only happened in 4.2.6 built, so possibly we need not do anything, but this seems safe enough. Did not happen in 5 built, so no companion PR.