### PR TITLE
Catch case where in local thresholding, image is mixture of nan and 0

### DIFF
--- a/cellprofiler/modules/threshold.py
+++ b/cellprofiler/modules/threshold.py
@@ -932,6 +932,10 @@ staining.
         elif numpy.all(image_data == image_data[0]):
             local_threshold = numpy.full_like(image_data, image_data[0])
 
+        elif numpy.unique(numpy.where(numpy.isnan(image_data),0,image_data)).shape == (1,):
+            #test if all values are a mixture of 0 or nan
+            local_threshold = numpy.zeros_like(image_data)
+
         elif self.threshold_operation == TM_LI:
             local_threshold = self._run_local_threshold(
                 image_data,

--- a/cellprofiler/modules/threshold.py
+++ b/cellprofiler/modules/threshold.py
@@ -932,7 +932,7 @@ staining.
         elif numpy.all(image_data == image_data[0]):
             local_threshold = numpy.full_like(image_data, image_data[0])
 
-        elif numpy.unique(numpy.where(numpy.isnan(image_data),0,image_data)).shape == (1,):
+        elif numpy.all((image_data == 0) | numpy.isnan(image_data)):
             #test if all values are a mixture of 0 or nan
             local_threshold = numpy.zeros_like(image_data)
 


### PR DESCRIPTION
@gnodar01 , this is the least-messy way I could think of to do that (because stuff like `unique` has weird behavior with nan's present, but `nan`'s also evaluate to true, so...), but if you can think of something more elegant and performant (likely), let me know and I'm happy to switch the implementation. Will hold off making a PR to main until we decide how to efficiently implement.