### PR TITLE
Core Tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,8 @@ jobs:
         env:
           LC_ALL: "en_US.UTF-8"
         run: |
-          brew install mysql
+          brew install mysql@8.4
+          brew link mysql@8.4 --force
           mysql.server start
           mysql --host=$CP_MYSQL_TEST_HOST --user=$CP_MYSQL_TEST_USER --execute="CREATE DATABASE $CP_MYSQL_TEST_DB;" --skip-password
       - name: Install cellprofiler
@@ -115,7 +116,8 @@ jobs:
         env:
           LC_ALL: "en_US.UTF-8"
         run: |
-          brew install mysql
+          brew install mysql@8.4
+          brew link mysql@8.4 --force
           mysql.server start
           mysql --host=$CP_MYSQL_TEST_HOST --user=$CP_MYSQL_TEST_USER --execute="CREATE DATABASE $CP_MYSQL_TEST_DB;" --skip-password
       - name: Install core

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
         # https://github.com/actions/runner-images/tree/main
         # ensure macos tag uses architecture identical to setup-python (x64 vs arm)
         os: [macos-13]
-        python-version: [ 3.9 ]
+        python-version: [3.9]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     if: github.event.pull_request.draft == false
@@ -45,7 +45,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: '11'
+          java-version: "11"
           java-package: jdk
           architecture: x64
       - name: Mac - Install and setup mysql
@@ -73,7 +73,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [macos-13]
-        python-version: [ 3.9 ]
+        python-version: [3.9]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     if: github.event.pull_request.draft == false
@@ -107,7 +107,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: '11'
+          java-version: "11"
           java-package: jdk
           architecture: x64
       - name: Mac - Install and setup mysql
@@ -127,7 +127,8 @@ jobs:
       - name: Run Tests
         timeout-minutes: 10
         run: |
-          pytest --tb=long --show-capture=all -vvv --color=yes --code-highlight=yes --timeout=300 -k 'not test_load_objects and not test_load_single_object' ${{ github.workspace }}/tests/core
+          # add -rP if you want to see debug for all tests, not just failed ones
+          pytest -v --exitfirst --disable-warnings -o log_cli_level=10 --tb=long --show-capture=all --capture=sys --color=yes --code-highlight=yes --timeout=60 -k 'not test_load_objects and not test_load_single_object' ${{ github.workspace }}/tests/core
 
   test-library:
     name: Install and test Library
@@ -135,7 +136,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [macos-13]
-        python-version: [ 3.9 ]
+        python-version: [3.9]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     if: github.event.pull_request.draft == false
@@ -174,5 +175,5 @@ on:
     types: [opened, reopened, synchronize, ready_for_review, review_requested]
   push:
     branches:
-      - 'main'
+      - "main"
   workflow_dispatch:

--- a/pixi.lock
+++ b/pixi.lock
@@ -109,6 +109,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/cd/a6aa959dca619918ccb55023b4cb151949c64d4d5d55b3f4ffd7eee0c6e8/docutils-0.15.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/61/bf/fd60001b3abc5222d8eaa4a204cd8c0ae78e75adc688f33ce4bf25b7fafa/fasteners-0.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/30/ad4483dfc5a1999f26b7bc5edc311576f433a3e00dd8aea01f2099c3a29f/fonttools-4.53.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/5e/44/73bea497ac69bafde2ee4269292fa3b41f1198f4bb7bbaaabde30ad29d4a/fsspec-2024.6.1-py3-none-any.whl
@@ -125,6 +126,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9b/82/473e452d3f21a9cd7e792a827f8df58bdff614fd2fff33d7bf6c4c128da7/imageio-2.31.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/06/4df55e1b7b112d183f65db9503bff189e97179b256e1ea450a3c365241e0/importlib_resources-6.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/c6/d9feb758be584f729424390af24687d3a4363d968164f94079f83cd536b4/inflect-7.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6c/0c/c29fcd6a59f50d953fd296d10fa5d455a239c84fa74ed8db4913f30d13cc/jgo-1.0.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
@@ -142,6 +144,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/7a/7c/d7b2a0417af6428440c0ad7cb9799073e507b1a465f827d058b826236964/numpy-1.24.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/08/aa/cc0199a5f0ad350994d660967a8efb233fe0416e4639146c089643407ce6/packaging-24.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0a/20/a94a0462495de73e248643fb24667270f2e67f44792456ab7207764e80cc/Pillow-10.0.1-cp39-cp39-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/68/13/2aa1f0e1364feb2c9ef45302f387ac0bd81484e9c9a4c5688a322fbdfd08/platformdirs-4.2.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a8/87/77cc11c7a9ea9fd05503def69e3d18605852cd0d4b0d3b8f15bbeb3ef1d1/pooch-1.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7c/6f/db31f0711c0402aa477257205ce7d29e86a75cb52cd19f7afb585f75cda0/proto_plus-1.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4c/98/db690e43e2f28495c8fc7c997003cbd59a6db342914b404e216c9b6791f0/protobuf-5.27.3-cp38-abi3-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/19/74/f59e7e0d392bc1070e9a70e2f9190d652487ac115bb16e2eff6b22ad1d24/psutil-6.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -150,6 +155,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1f/fa/b7f815b8c9ad021c07f88875b601222ef5e70619391ade4a49234d12d278/pydantic-2.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9b/f1/a006955715be98093d092aa025f604c7c00721e83fe04bf467c49f31a685/pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/9d/ea/6d76df31432a0e6fdf81681a895f009a4bb47b3c39036db3e1b528191d52/pyparsing-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/51/ff/f6e8b8f39e08547faece4bd80f89d5a8de68a38b2d179cc1c4490ffa3286/pytest-7.4.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/23/02/c85ca1e18e0c00d5ee45f4012f241098c8995294e1178367cb638a26b6c8/pytest_timeout-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5a/98/4549479a32972bdfdd5e75e168219e97f4dfaee535a8308efef7291e8398/PyWavelets-1.4.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c9/4b/63f897a96a42c13806e55d36988ea7bb7f86543857dee90f95c707233b38/pyzmq-22.3.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
@@ -165,6 +172,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4b/2c/ffbf7a134b9ab11a67b0cf0726453cedd9c5043a4fe7a35d1cefa9a1bcfb/threadpoolctl-3.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/49/5e/4670f23f4234a1d4dbf6722e2b265ce2efeef334ff3d1d3b725c8d1ca29e/tifffile-2022.4.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ae/6a/99eaaeae8becaa17a29aeb334a18e5d582d873b6f084c11f02581b8d7f7f/urllib3-1.26.19-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/aa/64/d749e767a8ce7bdc3d533334e03bb1106fc4e4803d16f931fada9007ee13/wxPython-4.2.1.tar.gz
@@ -200,6 +208,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/cd/a6aa959dca619918ccb55023b4cb151949c64d4d5d55b3f4ffd7eee0c6e8/docutils-0.15.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/61/bf/fd60001b3abc5222d8eaa4a204cd8c0ae78e75adc688f33ce4bf25b7fafa/fasteners-0.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c4/88/86aba816dc6cc4a296df93fb00f6b1dc1ba495c235ccb4241f14cc1a5872/fonttools-4.53.1-cp39-cp39-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/5e/44/73bea497ac69bafde2ee4269292fa3b41f1198f4bb7bbaaabde30ad29d4a/fsspec-2024.6.1-py3-none-any.whl
@@ -216,6 +225,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9b/82/473e452d3f21a9cd7e792a827f8df58bdff614fd2fff33d7bf6c4c128da7/imageio-2.31.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/06/4df55e1b7b112d183f65db9503bff189e97179b256e1ea450a3c365241e0/importlib_resources-6.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/c6/d9feb758be584f729424390af24687d3a4363d968164f94079f83cd536b4/inflect-7.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6c/0c/c29fcd6a59f50d953fd296d10fa5d455a239c84fa74ed8db4913f30d13cc/jgo-1.0.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
@@ -233,6 +243,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9a/cd/d5b0402b801c8a8b56b04c1e85c6165efab298d2f0ab741c2406516ede3a/numpy-1.24.4-cp39-cp39-macosx_10_9_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/08/aa/cc0199a5f0ad350994d660967a8efb233fe0416e4639146c089643407ce6/packaging-24.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/e4/c955de57d75aa73ebd65dd4cfe56bb3b806de85c1c791ae447af1ac7efc0/Pillow-10.0.1-cp39-cp39-macosx_10_10_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/68/13/2aa1f0e1364feb2c9ef45302f387ac0bd81484e9c9a4c5688a322fbdfd08/platformdirs-4.2.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a8/87/77cc11c7a9ea9fd05503def69e3d18605852cd0d4b0d3b8f15bbeb3ef1d1/pooch-1.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7c/6f/db31f0711c0402aa477257205ce7d29e86a75cb52cd19f7afb585f75cda0/proto_plus-1.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ca/bc/bceb11aa96dd0b2ae7002d2f46870fbdef7649a0c28420f0abb831ee3294/protobuf-5.27.3-cp38-abi3-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/0b/37/f8da2fbd29690b3557cca414c1949f92162981920699cd62095a984983bf/psutil-6.0.0-cp36-abi3-macosx_10_9_x86_64.whl
@@ -241,6 +254,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1f/fa/b7f815b8c9ad021c07f88875b601222ef5e70619391ade4a49234d12d278/pydantic-2.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/17/c3/803028de61ce9a1fe1643f77ff845807c76298bf1995fa216c4ae853c6b9/pydantic_core-2.20.1-cp39-cp39-macosx_10_12_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/9d/ea/6d76df31432a0e6fdf81681a895f009a4bb47b3c39036db3e1b528191d52/pyparsing-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/51/ff/f6e8b8f39e08547faece4bd80f89d5a8de68a38b2d179cc1c4490ffa3286/pytest-7.4.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/23/02/c85ca1e18e0c00d5ee45f4012f241098c8995294e1178367cb638a26b6c8/pytest_timeout-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9f/67/33b37d53da9d225301e30894db5083569aa670b446253b3906fc0e96119e/PyWavelets-1.4.1-cp39-cp39-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/5b/67/a0ecf9404f3b7cb8af234b0a2f842df37ea67cde44df0fc3b30e819779e2/pyzmq-22.3.0-cp39-cp39-macosx_10_15_universal2.whl
@@ -256,6 +271,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4b/2c/ffbf7a134b9ab11a67b0cf0726453cedd9c5043a4fe7a35d1cefa9a1bcfb/threadpoolctl-3.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/49/5e/4670f23f4234a1d4dbf6722e2b265ce2efeef334ff3d1d3b725c8d1ca29e/tifffile-2022.4.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ae/6a/99eaaeae8becaa17a29aeb334a18e5d582d873b6f084c11f02581b8d7f7f/urllib3-1.26.19-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c5/5c/b3c7097ba107b7e699268bf2585c646ad90660789c1ee33f293e3c195a22/wxPython-4.2.1-cp39-cp39-macosx_10_10_universal2.whl
@@ -291,6 +307,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/cd/a6aa959dca619918ccb55023b4cb151949c64d4d5d55b3f4ffd7eee0c6e8/docutils-0.15.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/61/bf/fd60001b3abc5222d8eaa4a204cd8c0ae78e75adc688f33ce4bf25b7fafa/fasteners-0.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f3/d5/bff14bc918cb2f407e336de41f4dc85aa79888c5954a0d9e4ff4c29aebd9/fonttools-4.53.1-cp39-cp39-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/5e/44/73bea497ac69bafde2ee4269292fa3b41f1198f4bb7bbaaabde30ad29d4a/fsspec-2024.6.1-py3-none-any.whl
@@ -307,6 +324,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9b/82/473e452d3f21a9cd7e792a827f8df58bdff614fd2fff33d7bf6c4c128da7/imageio-2.31.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/06/4df55e1b7b112d183f65db9503bff189e97179b256e1ea450a3c365241e0/importlib_resources-6.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/c6/d9feb758be584f729424390af24687d3a4363d968164f94079f83cd536b4/inflect-7.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6c/0c/c29fcd6a59f50d953fd296d10fa5d455a239c84fa74ed8db4913f30d13cc/jgo-1.0.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
@@ -324,6 +342,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/14/27/638aaa446f39113a3ed38b37a66243e21b38110d021bfcb940c383e120f2/numpy-1.24.4-cp39-cp39-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/08/aa/cc0199a5f0ad350994d660967a8efb233fe0416e4639146c089643407ce6/packaging-24.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3c/56/8449d670bae6e8f1b45e12cc2746561e42d3d80e3a432bf6f6e71c260aa1/Pillow-10.0.1-cp39-cp39-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/68/13/2aa1f0e1364feb2c9ef45302f387ac0bd81484e9c9a4c5688a322fbdfd08/platformdirs-4.2.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a8/87/77cc11c7a9ea9fd05503def69e3d18605852cd0d4b0d3b8f15bbeb3ef1d1/pooch-1.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7c/6f/db31f0711c0402aa477257205ce7d29e86a75cb52cd19f7afb585f75cda0/proto_plus-1.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ca/bc/bceb11aa96dd0b2ae7002d2f46870fbdef7649a0c28420f0abb831ee3294/protobuf-5.27.3-cp38-abi3-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/7c/06/63872a64c312a24fb9b4af123ee7007a306617da63ff13bcc1432386ead7/psutil-6.0.0-cp38-abi3-macosx_11_0_arm64.whl
@@ -332,6 +353,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1f/fa/b7f815b8c9ad021c07f88875b601222ef5e70619391ade4a49234d12d278/pydantic-2.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/77/f7/25f1fba7ea1ae052e20b234e4c66d54b129e5b3f4d1e6c0da6534dbf57c3/pydantic_core-2.20.1-cp39-cp39-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/9d/ea/6d76df31432a0e6fdf81681a895f009a4bb47b3c39036db3e1b528191d52/pyparsing-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/51/ff/f6e8b8f39e08547faece4bd80f89d5a8de68a38b2d179cc1c4490ffa3286/pytest-7.4.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/23/02/c85ca1e18e0c00d5ee45f4012f241098c8995294e1178367cb638a26b6c8/pytest_timeout-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/32/eeeaa4de640a84e2cc35c25aea289367059abce0cac84a9987b139a2a25f/PyWavelets-1.4.1-cp39-cp39-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/5b/67/a0ecf9404f3b7cb8af234b0a2f842df37ea67cde44df0fc3b30e819779e2/pyzmq-22.3.0-cp39-cp39-macosx_10_15_universal2.whl
@@ -347,6 +370,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4b/2c/ffbf7a134b9ab11a67b0cf0726453cedd9c5043a4fe7a35d1cefa9a1bcfb/threadpoolctl-3.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/49/5e/4670f23f4234a1d4dbf6722e2b265ce2efeef334ff3d1d3b725c8d1ca29e/tifffile-2022.4.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ae/6a/99eaaeae8becaa17a29aeb334a18e5d582d873b6f084c11f02581b8d7f7f/urllib3-1.26.19-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c5/5c/b3c7097ba107b7e699268bf2585c646ad90660789c1ee33f293e3c195a22/wxPython-4.2.1-cp39-cp39-macosx_10_10_universal2.whl
@@ -378,10 +402,12 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/bb/8f/0db154fb439e4e52573dfe7ebe9c9bb739c43e480d0ae060fa425fb4750e/centrosome-1.2.3-cp39-cp39-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/1c/d5/c84e1a17bf61d4df64ca866a1c9a913874b4e9bdc131ec689a0ad013fb36/certifi-2024.7.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/0e/d7303ccae9735ff8ff01e36705ad6233ad2002962e8668a970fc000c5e1b/charset_normalizer-3.3.2-cp39-cp39-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/87/2b/9b49451f7412cc1a79198e94a771a4e52d65c479aae610b1161c0290ef2c/contourpy-1.1.1-cp39-cp39-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/cd/a6aa959dca619918ccb55023b4cb151949c64d4d5d55b3f4ffd7eee0c6e8/docutils-0.15.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/61/bf/fd60001b3abc5222d8eaa4a204cd8c0ae78e75adc688f33ce4bf25b7fafa/fasteners-0.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f2/d5/f7d2122140848fb7a7bd1d59881b822dd514c19b7648984b7565d9f39d56/fonttools-4.53.1-cp39-cp39-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/5e/44/73bea497ac69bafde2ee4269292fa3b41f1198f4bb7bbaaabde30ad29d4a/fsspec-2024.6.1-py3-none-any.whl
@@ -398,6 +424,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9b/82/473e452d3f21a9cd7e792a827f8df58bdff614fd2fff33d7bf6c4c128da7/imageio-2.31.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/06/4df55e1b7b112d183f65db9503bff189e97179b256e1ea450a3c365241e0/importlib_resources-6.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/c6/d9feb758be584f729424390af24687d3a4363d968164f94079f83cd536b4/inflect-7.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6c/0c/c29fcd6a59f50d953fd296d10fa5d455a239c84fa74ed8db4913f30d13cc/jgo-1.0.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
@@ -415,6 +442,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/63/38/6cc19d6b8bfa1d1a459daf2b3fe325453153ca7019976274b6f33d8b5663/numpy-1.24.4-cp39-cp39-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/08/aa/cc0199a5f0ad350994d660967a8efb233fe0416e4639146c089643407ce6/packaging-24.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/fd/ce5fab4a15f4e38c5f6b86377f2c2ef6c92ec9a48e7296048251057a58ec/Pillow-10.0.1-cp39-cp39-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/68/13/2aa1f0e1364feb2c9ef45302f387ac0bd81484e9c9a4c5688a322fbdfd08/platformdirs-4.2.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a8/87/77cc11c7a9ea9fd05503def69e3d18605852cd0d4b0d3b8f15bbeb3ef1d1/pooch-1.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7c/6f/db31f0711c0402aa477257205ce7d29e86a75cb52cd19f7afb585f75cda0/proto_plus-1.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0f/87/a45a221eede1e311bdb6439c68b98a9a0add74a72d4a2e69ad8ae04e1393/protobuf-5.27.3-cp39-cp39-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/73/44/561092313ae925f3acfaace6f9ddc4f6a9c748704317bad9c8c8f8a36a79/psutil-6.0.0-cp37-abi3-win_amd64.whl
@@ -423,6 +453,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1f/fa/b7f815b8c9ad021c07f88875b601222ef5e70619391ade4a49234d12d278/pydantic-2.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ed/36/67aeb15996618882c5cfe85dbeffefe09e2806cd86bdd37bca40753e82a1/pydantic_core-2.20.1-cp39-none-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/9d/ea/6d76df31432a0e6fdf81681a895f009a4bb47b3c39036db3e1b528191d52/pyparsing-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/51/ff/f6e8b8f39e08547faece4bd80f89d5a8de68a38b2d179cc1c4490ffa3286/pytest-7.4.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/23/02/c85ca1e18e0c00d5ee45f4012f241098c8995294e1178367cb638a26b6c8/pytest_timeout-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/15/89951f559601fb6755f2231558c33c1b9cbba9e8526906cbc258e27eb53d/PyWavelets-1.4.1-cp39-cp39-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/98/a9/8fbd9fd9e802605597f9173814fcf5d759d3ba6e2b0723b6cd5f9371fbfc/pyzmq-22.3.0-cp39-cp39-win_amd64.whl
@@ -438,6 +470,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4b/2c/ffbf7a134b9ab11a67b0cf0726453cedd9c5043a4fe7a35d1cefa9a1bcfb/threadpoolctl-3.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/49/5e/4670f23f4234a1d4dbf6722e2b265ce2efeef334ff3d1d3b725c8d1ca29e/tifffile-2022.4.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ae/6a/99eaaeae8becaa17a29aeb334a18e5d582d873b6f084c11f02581b8d7f7f/urllib3-1.26.19-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ee/c4/dbf0e6696c3bf7b0d24fd9f203107ad27296c81896d7bdb4228e75d400db/wxPython-4.2.1-cp39-cp39-win_amd64.whl
@@ -456,38 +489,9 @@ packages:
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
   md5: d7c89558ba9fa0495403155b64376d81
   license: None
-  size: 2562
-  timestamp: 1578324546067
-- kind: conda
-  name: _libgcc_mutex
-  version: '0.1'
-  build: conda_forge
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
-  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
-  md5: d7c89558ba9fa0495403155b64376d81
-  license: None
   purls: []
   size: 2562
   timestamp: 1578324546067
-- kind: conda
-  name: _openmp_mutex
-  version: '4.5'
-  build: 2_gnu
-  build_number: 16
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
-  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
-  md5: 73aaf86a425cc6e73fcf236a5a46396d
-  depends:
-  - _libgcc_mutex 0.1 conda_forge
-  - libgomp >=7.5.0
-  constrains:
-  - openmp_impl 9999
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 23621
-  timestamp: 1650670423406
 - kind: conda
   name: _openmp_mutex
   version: '4.5'
@@ -558,42 +562,9 @@ packages:
   - vc14_runtime >=14.29.30139
   license: bzip2-1.0.6
   license_family: BSD
-  size: 54927
-  timestamp: 1720974860185
-- kind: conda
-  name: bzip2
-  version: 1.0.8
-  build: h2466b09_7
-  build_number: 7
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
-  sha256: 35a5dad92e88fdd7fc405e864ec239486f4f31eec229e31686e61a140a8e573b
-  md5: 276e7ffe9ffe39688abc665ef0f45596
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: bzip2-1.0.6
-  license_family: BSD
   purls: []
   size: 54927
   timestamp: 1720974860185
-- kind: conda
-  name: bzip2
-  version: 1.0.8
-  build: h4bc722e_7
-  build_number: 7
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
-  sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
-  md5: 62ee74e96c5ebb0af99386de58cf9553
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
-  license: bzip2-1.0.6
-  license_family: BSD
-  size: 252783
-  timestamp: 1720974456583
 - kind: conda
   name: bzip2
   version: 1.0.8
@@ -624,39 +595,9 @@ packages:
   - __osx >=11.0
   license: bzip2-1.0.6
   license_family: BSD
-  size: 122909
-  timestamp: 1720974522888
-- kind: conda
-  name: bzip2
-  version: 1.0.8
-  build: h99b78c6_7
-  build_number: 7
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
-  sha256: adfa71f158cbd872a36394c56c3568e6034aa55c623634b37a4836bd036e6b91
-  md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
-  depends:
-  - __osx >=11.0
-  license: bzip2-1.0.6
-  license_family: BSD
   purls: []
   size: 122909
   timestamp: 1720974522888
-- kind: conda
-  name: bzip2
-  version: 1.0.8
-  build: hfdf4475_7
-  build_number: 7
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
-  sha256: cad153608b81fb24fc8c509357daa9ae4e49dfc535b2cb49b91e23dbd68fc3c5
-  md5: 7ed4301d437b59045be7e051a0308211
-  depends:
-  - __osx >=10.13
-  license: bzip2-1.0.6
-  license_family: BSD
-  size: 134188
-  timestamp: 1720974491916
 - kind: conda
   name: bzip2
   version: 1.0.8
@@ -682,31 +623,9 @@ packages:
   sha256: 7f37bb33c7954de1b4d19ad622859feb4f6c58f751c38b895524cad4e44af72e
   md5: 9caa97c9504072cd060cf0a3142cc0ed
   license: ISC
-  size: 154943
-  timestamp: 1720077592592
-- kind: conda
-  name: ca-certificates
-  version: 2024.7.4
-  build: h56e8100_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.7.4-h56e8100_0.conda
-  sha256: 7f37bb33c7954de1b4d19ad622859feb4f6c58f751c38b895524cad4e44af72e
-  md5: 9caa97c9504072cd060cf0a3142cc0ed
-  license: ISC
   purls: []
   size: 154943
   timestamp: 1720077592592
-- kind: conda
-  name: ca-certificates
-  version: 2024.7.4
-  build: h8857fd0_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.7.4-h8857fd0_0.conda
-  sha256: d16f46c489cb3192305c7d25b795333c5fc17bb0986de20598ed519f8c9cc9e4
-  md5: 7df874a4b05b2d2b82826190170eaa0f
-  license: ISC
-  size: 154473
-  timestamp: 1720077510541
 - kind: conda
   name: ca-certificates
   version: 2024.7.4
@@ -728,31 +647,9 @@ packages:
   sha256: c1548a3235376f464f9931850b64b02492f379b2f2bb98bc786055329b080446
   md5: 23ab7665c5f63cfb9f1f6195256daac6
   license: ISC
-  size: 154853
-  timestamp: 1720077432978
-- kind: conda
-  name: ca-certificates
-  version: 2024.7.4
-  build: hbcca054_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.7.4-hbcca054_0.conda
-  sha256: c1548a3235376f464f9931850b64b02492f379b2f2bb98bc786055329b080446
-  md5: 23ab7665c5f63cfb9f1f6195256daac6
-  license: ISC
   purls: []
   size: 154853
   timestamp: 1720077432978
-- kind: conda
-  name: ca-certificates
-  version: 2024.7.4
-  build: hf0a4a13_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.7.4-hf0a4a13_0.conda
-  sha256: 33a61116dae7f369b6ce92a7f2a1ff361ae737c675a493b11feb5570b89e0e3b
-  md5: 21f9a33e5fe996189e470c19c5354dbe
-  license: ISC
-  size: 154517
-  timestamp: 1720077468981
 - kind: conda
   name: ca-certificates
   version: 2024.7.4
@@ -773,7 +670,7 @@ packages:
   requires_python: '>=3.7'
 - kind: pypi
   name: cellprofiler
-  version: 5.0.0.dev90
+  version: 5.0.0.dev92
   path: ./src/frontend
   sha256: 00c9cdb67c9bc2f942389b9ec259136aed979a749d5cdea3b43cfb70fd4d51b3
   requires_dist:
@@ -815,7 +712,7 @@ packages:
   editable: true
 - kind: pypi
   name: cellprofiler-core
-  version: 5.0.0.dev90
+  version: 5.0.0.dev92
   path: ./src/subpackages/core
   sha256: ac613ccb90cc9bccda5d519c51f63c27e64da76c58b063283030baeeca3b1af5
   requires_dist:
@@ -849,7 +746,7 @@ packages:
   editable: true
 - kind: pypi
   name: cellprofiler-library
-  version: 5.0.0.dev90
+  version: 5.0.0.dev92
   path: ./src/subpackages/library
   sha256: 46d34769022260bb8d27063ff544ff8c284293148be2d08572e917f58e5cfdd2
   requires_dist:
@@ -960,6 +857,12 @@ packages:
   url: https://files.pythonhosted.org/packages/98/69/5d8751b4b670d623aa7a47bef061d69c279e9f922f6705147983aa76c3ce/charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796
   requires_python: '>=3.7.0'
+- kind: pypi
+  name: colorama
+  version: 0.4.6
+  url: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
+  sha256: 4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
+  requires_python: '!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7'
 - kind: pypi
   name: contourpy
   version: 1.1.1
@@ -1083,6 +986,14 @@ packages:
   url: https://files.pythonhosted.org/packages/22/cd/a6aa959dca619918ccb55023b4cb151949c64d4d5d55b3f4ffd7eee0c6e8/docutils-0.15.2-py3-none-any.whl
   sha256: 6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0
   requires_python: '>=2.6,!=3.0.*,!=3.1.*,!=3.2.*'
+- kind: pypi
+  name: exceptiongroup
+  version: 1.2.2
+  url: https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl
+  sha256: 3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b
+  requires_dist:
+  - pytest>=6 ; extra == 'test'
+  requires_python: '>=3.7'
 - kind: pypi
   name: fasteners
   version: '0.19'
@@ -1609,6 +1520,12 @@ packages:
   - pytest-mypy>=0.9.1 ; platform_python_implementation != 'PyPy' and extra == 'testing'
   requires_python: '>=3.8'
 - kind: pypi
+  name: iniconfig
+  version: 2.0.0
+  url: https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl
+  sha256: b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
+  requires_python: '>=3.7'
+- kind: pypi
   name: jgo
   version: 1.0.6
   url: https://files.pythonhosted.org/packages/6c/0c/c29fcd6a59f50d953fd296d10fa5d455a239c84fa74ed8db4913f30d13cc/jgo-1.0.6-py3-none-any.whl
@@ -1757,21 +1674,6 @@ packages:
   - binutils_impl_linux-64 2.40
   license: GPL-3.0-only
   license_family: GPL
-  size: 707602
-  timestamp: 1718625640445
-- kind: conda
-  name: ld_impl_linux-64
-  version: '2.40'
-  build: hf3520f5_7
-  build_number: 7
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-hf3520f5_7.conda
-  sha256: 764b6950aceaaad0c67ef925417594dd14cd2e22fff864aeef455ac259263d15
-  md5: b80f2f396ca2c28b8c14c437a4ed1e74
-  constrains:
-  - binutils_impl_linux-64 2.40
-  license: GPL-3.0-only
-  license_family: GPL
   purls: []
   size: 707602
   timestamp: 1718625640445
@@ -1786,35 +1688,9 @@ packages:
   md5: ccb34fb14960ad8b125962d3d79b31a9
   license: MIT
   license_family: MIT
-  size: 51348
-  timestamp: 1636488394370
-- kind: conda
-  name: libffi
-  version: 3.4.2
-  build: h0d85af4_5
-  build_number: 5
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
-  sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
-  md5: ccb34fb14960ad8b125962d3d79b31a9
-  license: MIT
-  license_family: MIT
   purls: []
   size: 51348
   timestamp: 1636488394370
-- kind: conda
-  name: libffi
-  version: 3.4.2
-  build: h3422bc3_5
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
-  sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
-  md5: 086914b672be056eb70fd4285b6783b6
-  license: MIT
-  license_family: MIT
-  size: 39020
-  timestamp: 1636488587153
 - kind: conda
   name: libffi
   version: 3.4.2
@@ -1842,40 +1718,9 @@ packages:
   - libgcc-ng >=9.4.0
   license: MIT
   license_family: MIT
-  size: 58292
-  timestamp: 1636488182923
-- kind: conda
-  name: libffi
-  version: 3.4.2
-  build: h7f98852_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
-  sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
-  md5: d645c6d2ac96843a2bfaccd2d62b3ac3
-  depends:
-  - libgcc-ng >=9.4.0
-  license: MIT
-  license_family: MIT
   purls: []
   size: 58292
   timestamp: 1636488182923
-- kind: conda
-  name: libffi
-  version: 3.4.2
-  build: h8ffe710_5
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
-  sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
-  md5: 2c96d1b6915b408893f9472569dee135
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012
-  license: MIT
-  license_family: MIT
-  size: 42063
-  timestamp: 1636489106777
 - kind: conda
   name: libffi
   version: 3.4.2
@@ -1908,40 +1753,9 @@ packages:
   - libgomp 14.1.0 h77fa898_0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 842109
-  timestamp: 1719538896937
-- kind: conda
-  name: libgcc-ng
-  version: 14.1.0
-  build: h77fa898_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.1.0-h77fa898_0.conda
-  sha256: b8e869ac96591cda2704bf7e77a301025e405227791a0bddf14a3dac65125538
-  md5: ca0fad6a41ddaef54a153b78eccb5037
-  depends:
-  - _libgcc_mutex 0.1 conda_forge
-  - _openmp_mutex >=4.5
-  constrains:
-  - libgomp 14.1.0 h77fa898_0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
   purls: []
   size: 842109
   timestamp: 1719538896937
-- kind: conda
-  name: libgomp
-  version: 14.1.0
-  build: h77fa898_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.1.0-h77fa898_0.conda
-  sha256: 7699df61a1f6c644b3576a40f54791561f2845983120477a16116b951c9cdb05
-  md5: ae061a5ed5f05818acdf9adab72c146d
-  depends:
-  - _libgcc_mutex 0.1 conda_forge
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 456925
-  timestamp: 1719538796073
 - kind: conda
   name: libgomp
   version: 14.1.0
@@ -1969,37 +1783,9 @@ packages:
   - libgcc-ng >=12
   license: LGPL-2.1-only
   license_family: GPL
-  size: 33408
-  timestamp: 1697359010159
-- kind: conda
-  name: libnsl
-  version: 2.0.1
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
-  sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
-  md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
-  depends:
-  - libgcc-ng >=12
-  license: LGPL-2.1-only
-  license_family: GPL
   purls: []
   size: 33408
   timestamp: 1697359010159
-- kind: conda
-  name: libsqlite
-  version: 3.46.0
-  build: h1b8f9f3_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.46.0-h1b8f9f3_0.conda
-  sha256: 63af1a9e3284c7e4952364bafe7267e41e2d9d8bcc0e85a4ea4b0ec02d3693f6
-  md5: 5dadfbc1a567fe6e475df4ce3148be09
-  depends:
-  - __osx >=10.13
-  - libzlib >=1.2.13,<2.0a0
-  license: Unlicense
-  size: 908643
-  timestamp: 1718050720117
 - kind: conda
   name: libsqlite
   version: 3.46.0
@@ -2028,38 +1814,9 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Unlicense
-  size: 876677
-  timestamp: 1718051113874
-- kind: conda
-  name: libsqlite
-  version: 3.46.0
-  build: h2466b09_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.46.0-h2466b09_0.conda
-  sha256: 662bd7e0d63c5b8c31cca19b91649e798319b93568a2ba8d1375efb91eeb251b
-  md5: 951b0a3a463932e17414cd9f047fa03d
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Unlicense
   purls: []
   size: 876677
   timestamp: 1718051113874
-- kind: conda
-  name: libsqlite
-  version: 3.46.0
-  build: hde9e2c9_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.0-hde9e2c9_0.conda
-  sha256: daee3f68786231dad457d0dfde3f7f1f9a7f2018adabdbb864226775101341a8
-  md5: 18aa975d2094c34aef978060ae7da7d8
-  depends:
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<2.0a0
-  license: Unlicense
-  size: 865346
-  timestamp: 1718050628718
 - kind: conda
   name: libsqlite
   version: 3.46.0
@@ -2087,37 +1844,9 @@ packages:
   - __osx >=11.0
   - libzlib >=1.2.13,<2.0a0
   license: Unlicense
-  size: 830198
-  timestamp: 1718050644825
-- kind: conda
-  name: libsqlite
-  version: 3.46.0
-  build: hfb93653_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.46.0-hfb93653_0.conda
-  sha256: 73048f9cb8647d3d3bfe6021c0b7d663e12cffbe9b4f31bd081e713b0a9ad8f9
-  md5: 12300188028c9bc02da965128b91b517
-  depends:
-  - __osx >=11.0
-  - libzlib >=1.2.13,<2.0a0
-  license: Unlicense
   purls: []
   size: 830198
   timestamp: 1718050644825
-- kind: conda
-  name: libuuid
-  version: 2.38.1
-  build: h0b41bf4_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
-  sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
-  md5: 40b61aab5c7ba9ff276c41cfffe6b80b
-  depends:
-  - libgcc-ng >=12
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 33601
-  timestamp: 1680112270483
 - kind: conda
   name: libuuid
   version: 2.38.1
@@ -2145,42 +1874,9 @@ packages:
   depends:
   - libgcc-ng >=12
   license: LGPL-2.1-or-later
-  size: 100393
-  timestamp: 1702724383534
-- kind: conda
-  name: libxcrypt
-  version: 4.4.36
-  build: hd590300_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
-  sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
-  md5: 5aa797f8787fe7a17d1b0821485b5adc
-  depends:
-  - libgcc-ng >=12
-  license: LGPL-2.1-or-later
   purls: []
   size: 100393
   timestamp: 1702724383534
-- kind: conda
-  name: libzlib
-  version: 1.3.1
-  build: h2466b09_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_1.conda
-  sha256: b13846a54a15243e15f96fec06b526d8155adc6a1ac2b6ed47a88f6a71a94b68
-  md5: d4483ca8afc57ddf1f6dded53b36c17f
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - zlib 1.3.1 *_1
-  license: Zlib
-  license_family: Other
-  size: 56186
-  timestamp: 1716874730539
 - kind: conda
   name: libzlib
   version: 1.3.1
@@ -2216,23 +1912,6 @@ packages:
   - zlib 1.3.1 *_1
   license: Zlib
   license_family: Other
-  size: 61574
-  timestamp: 1716874187109
-- kind: conda
-  name: libzlib
-  version: 1.3.1
-  build: h4ab18f5_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-h4ab18f5_1.conda
-  sha256: adf6096f98b537a11ae3729eaa642b0811478f0ea0402ca67b5108fe2cb0010d
-  md5: 57d7dc60e9325e3de37ff8dffd18e814
-  depends:
-  - libgcc-ng >=12
-  constrains:
-  - zlib 1.3.1 *_1
-  license: Zlib
-  license_family: Other
   purls: []
   size: 61574
   timestamp: 1716874187109
@@ -2251,43 +1930,9 @@ packages:
   - zlib 1.3.1 *_1
   license: Zlib
   license_family: Other
-  size: 57372
-  timestamp: 1716874211519
-- kind: conda
-  name: libzlib
-  version: 1.3.1
-  build: h87427d6_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-h87427d6_1.conda
-  sha256: 80a62db652b1da0ccc100812a1d86e94f75028968991bfb17f9536f3aa72d91d
-  md5: b7575b5aa92108dcc9aaab0f05f2dbce
-  depends:
-  - __osx >=10.13
-  constrains:
-  - zlib 1.3.1 *_1
-  license: Zlib
-  license_family: Other
   purls: []
   size: 57372
   timestamp: 1716874211519
-- kind: conda
-  name: libzlib
-  version: 1.3.1
-  build: hfb2fe0b_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-hfb2fe0b_1.conda
-  sha256: c34365dd37b0eab27b9693af32a1f7f284955517c2cc91f1b88a7ef4738ff03e
-  md5: 636077128927cf79fd933276dc3aed47
-  depends:
-  - __osx >=11.0
-  constrains:
-  - zlib 1.3.1 *_1
-  license: Zlib
-  license_family: Other
-  size: 46921
-  timestamp: 1716874262512
 - kind: conda
   name: libzlib
   version: 1.3.1
@@ -2519,17 +2164,6 @@ packages:
   sha256: 6ecc73db0e49143092c0934355ac41583a5d5a48c6914c5f6ca48e562d3a4b79
   md5: 02a888433d165c99bf09784a7b14d900
   license: X11 AND BSD-3-Clause
-  size: 823601
-  timestamp: 1715195267791
-- kind: conda
-  name: ncurses
-  version: '6.5'
-  build: h5846eda_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h5846eda_0.conda
-  sha256: 6ecc73db0e49143092c0934355ac41583a5d5a48c6914c5f6ca48e562d3a4b79
-  md5: 02a888433d165c99bf09784a7b14d900
-  license: X11 AND BSD-3-Clause
   purls: []
   size: 823601
   timestamp: 1715195267791
@@ -2544,33 +2178,9 @@ packages:
   depends:
   - libgcc-ng >=12
   license: X11 AND BSD-3-Clause
-  size: 887465
-  timestamp: 1715194722503
-- kind: conda
-  name: ncurses
-  version: '6.5'
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h59595ed_0.conda
-  sha256: 4fc3b384f4072b68853a0013ea83bdfd3d66b0126e2238e1d6e1560747aa7586
-  md5: fcea371545eda051b6deafb24889fc69
-  depends:
-  - libgcc-ng >=12
-  license: X11 AND BSD-3-Clause
   purls: []
   size: 887465
   timestamp: 1715194722503
-- kind: conda
-  name: ncurses
-  version: '6.5'
-  build: hb89a1cb_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-hb89a1cb_0.conda
-  sha256: 87d7cf716d9d930dab682cb57b3b8d3a61940b47d6703f3529a155c938a6990a
-  md5: b13ad5724ac9ae98b6b4fd87e4500ba4
-  license: X11 AND BSD-3-Clause
-  size: 795131
-  timestamp: 1715194898402
 - kind: conda
   name: ncurses
   version: '6.5'
@@ -2730,48 +2340,9 @@ packages:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
-  size: 8385012
-  timestamp: 1721197465883
-- kind: conda
-  name: openssl
-  version: 3.3.1
-  build: h2466b09_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.1-h2466b09_2.conda
-  sha256: d86c4fa31294ad9068717788197e97e5637e056c82745ffb6d0e88fd1fef1a9d
-  md5: 375dbc2a4d5a2e4c738703207e8e368b
-  depends:
-  - ca-certificates
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - pyopenssl >=22.1
-  license: Apache-2.0
-  license_family: Apache
   purls: []
   size: 8385012
   timestamp: 1721197465883
-- kind: conda
-  name: openssl
-  version: 3.3.1
-  build: h4bc722e_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.1-h4bc722e_2.conda
-  sha256: b294b3cc706ad1048cdb514f0db3da9f37ae3fcc0c53a7104083dd0918adb200
-  md5: e1b454497f9f7c1147fdde4b53f1b512
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - ca-certificates
-  - libgcc-ng >=12
-  constrains:
-  - pyopenssl >=22.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 2895213
-  timestamp: 1721194688955
 - kind: conda
   name: openssl
   version: 3.3.1
@@ -2808,45 +2379,9 @@ packages:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
-  size: 2552939
-  timestamp: 1721194674491
-- kind: conda
-  name: openssl
-  version: 3.3.1
-  build: h87427d6_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.1-h87427d6_2.conda
-  sha256: 3cb0c05fbfd8cdb9b767396fc0e0af2d78eb4d68592855481254104330d4a4eb
-  md5: 3f3dbeedbee31e257866407d9dea1ff5
-  depends:
-  - __osx >=10.13
-  - ca-certificates
-  constrains:
-  - pyopenssl >=22.1
-  license: Apache-2.0
-  license_family: Apache
   purls: []
   size: 2552939
   timestamp: 1721194674491
-- kind: conda
-  name: openssl
-  version: 3.3.1
-  build: hfb2fe0b_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.1-hfb2fe0b_2.conda
-  sha256: dd7d988636f74473ebdfe15e05c5aabdb53a1d2a846c839d62289b0c37f81548
-  md5: 9b551a504c1cc8f8b7b22c01814da8ba
-  depends:
-  - __osx >=11.0
-  - ca-certificates
-  constrains:
-  - pyopenssl >=22.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 2899682
-  timestamp: 1721194599446
 - kind: conda
   name: openssl
   version: 3.3.1
@@ -2968,6 +2503,47 @@ packages:
   - pytest-cov ; extra == 'tests'
   - pytest-timeout ; extra == 'tests'
   requires_python: '>=3.8'
+- kind: pypi
+  name: platformdirs
+  version: 4.2.2
+  url: https://files.pythonhosted.org/packages/68/13/2aa1f0e1364feb2c9ef45302f387ac0bd81484e9c9a4c5688a322fbdfd08/platformdirs-4.2.2-py3-none-any.whl
+  sha256: 2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee
+  requires_dist:
+  - furo>=2023.9.10 ; extra == 'docs'
+  - proselint>=0.13 ; extra == 'docs'
+  - sphinx-autodoc-typehints>=1.25.2 ; extra == 'docs'
+  - sphinx>=7.2.6 ; extra == 'docs'
+  - appdirs==1.4.4 ; extra == 'test'
+  - covdefaults>=2.3 ; extra == 'test'
+  - pytest-cov>=4.1 ; extra == 'test'
+  - pytest-mock>=3.12 ; extra == 'test'
+  - pytest>=7.4.3 ; extra == 'test'
+  - mypy>=1.8 ; extra == 'type'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: pluggy
+  version: 1.5.0
+  url: https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl
+  sha256: 44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669
+  requires_dist:
+  - pre-commit ; extra == 'dev'
+  - tox ; extra == 'dev'
+  - pytest ; extra == 'testing'
+  - pytest-benchmark ; extra == 'testing'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: pooch
+  version: 1.8.2
+  url: https://files.pythonhosted.org/packages/a8/87/77cc11c7a9ea9fd05503def69e3d18605852cd0d4b0d3b8f15bbeb3ef1d1/pooch-1.8.2-py3-none-any.whl
+  sha256: 3529a57096f7198778a5ceefd5ac3ef0e4d06a6ddaf9fc2d609b806f25302c47
+  requires_dist:
+  - platformdirs>=2.5.0
+  - packaging>=20.0
+  - requests>=2.19.0
+  - tqdm<5.0.0,>=4.41.0 ; extra == 'progress'
+  - paramiko>=2.7.0 ; extra == 'sftp'
+  - xxhash>=1.4.3 ; extra == 'xxhash'
+  requires_python: '>=3.7'
 - kind: pypi
   name: proto-plus
   version: 1.24.0
@@ -3110,35 +2686,37 @@ packages:
   - railroad-diagrams ; extra == 'diagrams'
   - jinja2 ; extra == 'diagrams'
   requires_python: '>=3.6.8'
-- kind: conda
-  name: python
-  version: 3.9.19
-  build: h0755675_0_cpython
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.9.19-h0755675_0_cpython.conda
-  sha256: b9253ca9ca5427e6da4b1d43353a110e0f2edfab9c951afb4bf01cbae2825b31
-  md5: d9ee3647fbd9e8595b8df759b2bbefb8
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - ld_impl_linux-64 >=2.36.1
-  - libffi >=3.4,<4.0a0
-  - libgcc-ng >=12
-  - libnsl >=2.0.1,<2.1.0a0
-  - libsqlite >=3.45.2,<4.0a0
-  - libuuid >=2.38.1,<3.0a0
-  - libxcrypt >=4.4.36
-  - libzlib >=1.2.13,<2.0.0a0
-  - ncurses >=6.4.20240210,<7.0a0
-  - openssl >=3.2.1,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.9.* *_cp39
-  license: Python-2.0
-  size: 23800555
-  timestamp: 1710940120866
+- kind: pypi
+  name: pytest
+  version: 7.4.4
+  url: https://files.pythonhosted.org/packages/51/ff/f6e8b8f39e08547faece4bd80f89d5a8de68a38b2d179cc1c4490ffa3286/pytest-7.4.4-py3-none-any.whl
+  sha256: b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8
+  requires_dist:
+  - iniconfig
+  - packaging
+  - pluggy<2.0,>=0.12
+  - exceptiongroup>=1.0.0rc8 ; python_version < '3.11'
+  - tomli>=1.0.0 ; python_version < '3.11'
+  - importlib-metadata>=0.12 ; python_version < '3.8'
+  - colorama ; sys_platform == 'win32'
+  - argcomplete ; extra == 'testing'
+  - attrs>=19.2.0 ; extra == 'testing'
+  - hypothesis>=3.56 ; extra == 'testing'
+  - mock ; extra == 'testing'
+  - nose ; extra == 'testing'
+  - pygments>=2.7.2 ; extra == 'testing'
+  - requests ; extra == 'testing'
+  - setuptools ; extra == 'testing'
+  - xmlschema ; extra == 'testing'
+  requires_python: '>=3.7'
+- kind: pypi
+  name: pytest-timeout
+  version: 2.1.0
+  url: https://files.pythonhosted.org/packages/23/02/c85ca1e18e0c00d5ee45f4012f241098c8995294e1178367cb638a26b6c8/pytest_timeout-2.1.0-py3-none-any.whl
+  sha256: f6f50101443ce70ad325ceb4473c4255e9d74e3c7cd0ef827309dfa4c0d975c6
+  requires_dist:
+  - pytest>=5.0.0
+  requires_python: '>=3.6'
 - kind: conda
   name: python
   version: 3.9.19
@@ -3191,30 +2769,6 @@ packages:
   constrains:
   - python_abi 3.9.* *_cp39
   license: Python-2.0
-  size: 16906240
-  timestamp: 1710938565297
-- kind: conda
-  name: python
-  version: 3.9.19
-  build: h4de0772_0_cpython
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python-3.9.19-h4de0772_0_cpython.conda
-  sha256: 92d847bc9e79a60c1d139aa4ca0385d283b90aa2d7421bb3ffcb5dc0678fd72f
-  md5: b6999bc275e0e6beae7b1c8ea0be1e85
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.45.2,<4.0a0
-  - libzlib >=1.2.13,<2.0.0a0
-  - openssl >=3.2.1,<4.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - vc >=14.1,<15
-  - vc14_runtime >=14.16.27033
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.9.* *_cp39
-  license: Python-2.0
   purls: []
   size: 16906240
   timestamp: 1710938565297
@@ -3240,57 +2794,9 @@ packages:
   constrains:
   - python_abi 3.9.* *_cp39
   license: Python-2.0
-  size: 12372436
-  timestamp: 1710940037648
-- kind: conda
-  name: python
-  version: 3.9.19
-  build: h7a9c478_0_cpython
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.9.19-h7a9c478_0_cpython.conda
-  sha256: 58b76be84683bc03112b3ed7e377e99af24844ebf7d7568f6466a2dae7a887fe
-  md5: 7d53d366acd9dbfb498c69326ccb520a
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.45.2,<4.0a0
-  - libzlib >=1.2.13,<2.0.0a0
-  - ncurses >=6.4.20240210,<7.0a0
-  - openssl >=3.2.1,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.9.* *_cp39
-  license: Python-2.0
   purls: []
   size: 12372436
   timestamp: 1710940037648
-- kind: conda
-  name: python
-  version: 3.9.19
-  build: hd7ebdb9_0_cpython
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.9.19-hd7ebdb9_0_cpython.conda
-  sha256: 3b93f7a405f334043758dfa8aaca050429a954a37721a6462ebd20e94ef7c5a0
-  md5: 45c4d173b12154f746be3b49b1190634
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.45.2,<4.0a0
-  - libzlib >=1.2.13,<2.0.0a0
-  - ncurses >=6.4.20240210,<7.0a0
-  - openssl >=3.2.1,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.9.* *_cp39
-  license: Python-2.0
-  size: 11847835
-  timestamp: 1710939779164
 - kind: conda
   name: python
   version: 3.9.19
@@ -3338,41 +2844,9 @@ packages:
   - python_abi 3.9.* *_cp39
   license: BSD-3-Clause
   license_family: BSD
-  size: 18517
-  timestamp: 1695463511757
-- kind: conda
-  name: python.app
-  version: '1.4'
-  build: py39h8feb81c_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python.app-1.4-py39h8feb81c_3.conda
-  sha256: 12191401ca9aad9ca67e16f961e1a035245dcf9b76365a490d56ec3aa483d6e6
-  md5: f8ac0331eb6ce2f8ce77d0a45976a96f
-  depends:
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  license: BSD-3-Clause
-  license_family: BSD
   purls: []
   size: 18517
   timestamp: 1695463511757
-- kind: conda
-  name: python.app
-  version: '1.4'
-  build: py39hdc70f33_3
-  build_number: 3
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/python.app-1.4-py39hdc70f33_3.conda
-  sha256: 5f6a35d66a4d51502fb3f41fe9ceb14440fa89b8159e41ab14da82dd30b12066
-  md5: bbb5c0c5cc91b68d5bed414a4d8e48b8
-  depends:
-  - python >=3.9,<3.10.0a0
-  - python_abi 3.9.* *_cp39
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 18408
-  timestamp: 1695463450502
 - kind: conda
   name: python.app
   version: '1.4'
@@ -3403,39 +2877,9 @@ packages:
   - python 3.9.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
-  size: 6486
-  timestamp: 1695147714523
-- kind: conda
-  name: python_abi
-  version: '3.9'
-  build: 4_cp39
-  build_number: 4
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.9-4_cp39.conda
-  sha256: a2b38ce566d9f48a49369f46c50912300a6ac09bf1c58a0d6c2caab074ee551e
-  md5: 2d9f6c00555127a9058cfa955adf1090
-  constrains:
-  - python 3.9.* *_cpython
-  license: BSD-3-Clause
-  license_family: BSD
   purls: []
   size: 6486
   timestamp: 1695147714523
-- kind: conda
-  name: python_abi
-  version: '3.9'
-  build: 4_cp39
-  build_number: 4
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.9-4_cp39.conda
-  sha256: 2ae06dcd1a03f023b6accf5bd989f42b689f708d3495affa22c2ed9f1d127726
-  md5: be9e11a37bbab9cfdbcb36e52d8d73cb
-  constrains:
-  - python 3.9.* *_cpython
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6484
-  timestamp: 1695147719187
 - kind: conda
   name: python_abi
   version: '3.9'
@@ -3557,22 +3001,6 @@ packages:
   - ncurses >=6.3,<7.0a0
   license: GPL-3.0-only
   license_family: GPL
-  size: 281456
-  timestamp: 1679532220005
-- kind: conda
-  name: readline
-  version: '8.2'
-  build: h8228510_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
-  sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
-  md5: 47d31b792659ce70f470b5c82fdfb7a4
-  depends:
-  - libgcc-ng >=12
-  - ncurses >=6.3,<7.0a0
-  license: GPL-3.0-only
-  license_family: GPL
   purls: []
   size: 281456
   timestamp: 1679532220005
@@ -3589,39 +3017,9 @@ packages:
   - ncurses >=6.3,<7.0a0
   license: GPL-3.0-only
   license_family: GPL
-  size: 250351
-  timestamp: 1679532511311
-- kind: conda
-  name: readline
-  version: '8.2'
-  build: h92ec313_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
-  sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
-  md5: 8cbb776a2f641b943d413b3e19df71f4
-  depends:
-  - ncurses >=6.3,<7.0a0
-  license: GPL-3.0-only
-  license_family: GPL
   purls: []
   size: 250351
   timestamp: 1679532511311
-- kind: conda
-  name: readline
-  version: '8.2'
-  build: h9e318b2_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
-  sha256: 41e7d30a097d9b060037f0c6a2b1d4c4ae7e942c06c943d23f9d481548478568
-  md5: f17f77f2acf4d344734bda76829ce14e
-  depends:
-  - ncurses >=6.3,<7.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 255870
-  timestamp: 1679532707590
 - kind: conda
   name: readline
   version: '8.2'
@@ -4269,39 +3667,9 @@ packages:
   - libzlib >=1.2.13,<2.0.0a0
   license: TCL
   license_family: BSD
-  size: 3270220
-  timestamp: 1699202389792
-- kind: conda
-  name: tk
-  version: 8.6.13
-  build: h1abcd95_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
-  sha256: 30412b2e9de4ff82d8c2a7e5d06a15f4f4fef1809a72138b6ccb53a33b26faf5
-  md5: bf830ba5afc507c6232d4ef0fb1a882d
-  depends:
-  - libzlib >=1.2.13,<2.0.0a0
-  license: TCL
-  license_family: BSD
   purls: []
   size: 3270220
   timestamp: 1699202389792
-- kind: conda
-  name: tk
-  version: 8.6.13
-  build: h5083fa2_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
-  sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
-  md5: b50a57ba89c32b62428b71a875291c9b
-  depends:
-  - libzlib >=1.2.13,<2.0.0a0
-  license: TCL
-  license_family: BSD
-  size: 3145523
-  timestamp: 1699202432999
 - kind: conda
   name: tk
   version: 8.6.13
@@ -4333,42 +3701,9 @@ packages:
   - vc14_runtime >=14.29.30139
   license: TCL
   license_family: BSD
-  size: 3503410
-  timestamp: 1699202577803
-- kind: conda
-  name: tk
-  version: 8.6.13
-  build: h5226925_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
-  sha256: 2c4e914f521ccb2718946645108c9bd3fc3216ba69aea20c2c3cedbd8db32bb1
-  md5: fc048363eb8f03cd1737600a5d08aafe
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: TCL
-  license_family: BSD
   purls: []
   size: 3503410
   timestamp: 1699202577803
-- kind: conda
-  name: tk
-  version: 8.6.13
-  build: noxft_h4845f30_101
-  build_number: 101
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
-  sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
-  md5: d453b98d9c83e71da0741bb0ff4d76bc
-  depends:
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<2.0.0a0
-  license: TCL
-  license_family: BSD
-  size: 3318875
-  timestamp: 1699202167581
 - kind: conda
   name: tk
   version: 8.6.13
@@ -4387,6 +3722,12 @@ packages:
   size: 3318875
   timestamp: 1699202167581
 - kind: pypi
+  name: tomli
+  version: 2.0.1
+  url: https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl
+  sha256: 939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc
+  requires_python: '>=3.7'
+- kind: pypi
   name: typing-extensions
   version: 4.12.2
   url: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
@@ -4402,35 +3743,9 @@ packages:
   sha256: 7b2b69c54ec62a243eb6fba2391b5e443421608c3ae5dbff938ad33ca8db5122
   md5: 161081fc7cec0bfda0d86d7cb595f8d8
   license: LicenseRef-Public-Domain
-  size: 119815
-  timestamp: 1706886945727
-- kind: conda
-  name: tzdata
-  version: 2024a
-  build: h0c530f3_0
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
-  sha256: 7b2b69c54ec62a243eb6fba2391b5e443421608c3ae5dbff938ad33ca8db5122
-  md5: 161081fc7cec0bfda0d86d7cb595f8d8
-  license: LicenseRef-Public-Domain
   purls: []
   size: 119815
   timestamp: 1706886945727
-- kind: conda
-  name: ucrt
-  version: 10.0.22621.0
-  build: h57928b3_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
-  sha256: f29cdaf8712008f6b419b8b1a403923b00ab2504bfe0fb2ba8eb60e72d4f14c6
-  md5: 72608f6cd3e5898229c3ea16deb1ac43
-  constrains:
-  - vs2015_runtime >=14.29.30037
-  license: LicenseRef-Proprietary
-  license_family: PROPRIETARY
-  size: 1283972
-  timestamp: 1666630199266
 - kind: conda
   name: ucrt
   version: 10.0.22621.0
@@ -4479,23 +3794,6 @@ packages:
   - vc14
   license: BSD-3-Clause
   license_family: BSD
-  size: 17391
-  timestamp: 1717709040616
-- kind: conda
-  name: vc
-  version: '14.3'
-  build: h8a93ad2_20
-  build_number: 20
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h8a93ad2_20.conda
-  sha256: 23ac5feb15a9adf3ab2b8c4dcd63650f8b7ae860c5ceb073e49cf71d203eddef
-  md5: 8558f367e1d7700554f7cdb823c46faf
-  depends:
-  - vc14_runtime >=14.40.33810
-  track_features:
-  - vc14
-  license: BSD-3-Clause
-  license_family: BSD
   purls: []
   size: 17391
   timestamp: 1717709040616
@@ -4514,41 +3812,9 @@ packages:
   - vs2015_runtime 14.40.33810.* *_20
   license: LicenseRef-ProprietaryMicrosoft
   license_family: Proprietary
-  size: 751934
-  timestamp: 1717709031266
-- kind: conda
-  name: vc14_runtime
-  version: 14.40.33810
-  build: ha82c5b3_20
-  build_number: 20
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-ha82c5b3_20.conda
-  sha256: af3cfa347e3d7c1277e9b964b0849a9a9f095bff61836cb3c3a89862fbc32e17
-  md5: e39cc4c34c53654ec939558993d9dc5b
-  depends:
-  - ucrt >=10.0.20348.0
-  constrains:
-  - vs2015_runtime 14.40.33810.* *_20
-  license: LicenseRef-ProprietaryMicrosoft
-  license_family: Proprietary
   purls: []
   size: 751934
   timestamp: 1717709031266
-- kind: conda
-  name: vs2015_runtime
-  version: 14.40.33810
-  build: h3bf8584_20
-  build_number: 20
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_20.conda
-  sha256: 0c2803f7a788c51f28235a7228dc2ab3f107b4b16ab0845a3e595c8c51e50a7a
-  md5: c21f1b4a3a30bbc3ef35a50957578e0e
-  depends:
-  - vc14_runtime >=14.40.33810
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 17395
-  timestamp: 1717709043353
 - kind: conda
   name: vs2015_runtime
   version: 14.40.33810
@@ -4606,33 +3872,9 @@ packages:
   depends:
   - libgcc-ng >=12
   license: LGPL-2.1 and GPL-2.0
-  size: 418368
-  timestamp: 1660346797927
-- kind: conda
-  name: xz
-  version: 5.2.6
-  build: h166bdaf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
-  sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
-  md5: 2161070d867d1b1204ea749c8eec4ef0
-  depends:
-  - libgcc-ng >=12
-  license: LGPL-2.1 and GPL-2.0
   purls: []
   size: 418368
   timestamp: 1660346797927
-- kind: conda
-  name: xz
-  version: 5.2.6
-  build: h57fd34a_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
-  sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
-  md5: 39c6b54e94014701dd157f4f576ed211
-  license: LGPL-2.1 and GPL-2.0
-  size: 235693
-  timestamp: 1660346961024
 - kind: conda
   name: xz
   version: 5.2.6
@@ -4654,34 +3896,9 @@ packages:
   sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
   md5: a72f9d4ea13d55d745ff1ed594747f10
   license: LGPL-2.1 and GPL-2.0
-  size: 238119
-  timestamp: 1660346964847
-- kind: conda
-  name: xz
-  version: 5.2.6
-  build: h775f41a_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
-  sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
-  md5: a72f9d4ea13d55d745ff1ed594747f10
-  license: LGPL-2.1 and GPL-2.0
   purls: []
   size: 238119
   timestamp: 1660346964847
-- kind: conda
-  name: xz
-  version: 5.2.6
-  build: h8d14728_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
-  sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
-  md5: 515d77642eaa3639413c6b1bc3f94219
-  depends:
-  - vc >=14.1,<15
-  - vs2015_runtime >=14.16.27033
-  license: LGPL-2.1 and GPL-2.0
-  size: 217804
-  timestamp: 1660346976440
 - kind: conda
   name: xz
   version: 5.2.6

--- a/pixi.toml
+++ b/pixi.toml
@@ -26,9 +26,9 @@ python = "3.9.*"
 # wxPython = { url = "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04/wxPython-4.2.1-cp39-cp39-linux_x86_64.whl" }
 
 [feature.mod.pypi-dependencies]
-cellprofiler-library = { path = "./src/subpackages/library", editable = true }
-cellprofiler-core = { path = "./src/subpackages/core", editable = true }
-cellprofiler = { path = "./src/frontend", editable = true }
+cellprofiler-library = { path = "./src/subpackages/library", extras = ["test"], editable = true }
+cellprofiler-core = { path = "./src/subpackages/core", extras = ["test"], editable = true }
+cellprofiler = { path = "./src/frontend", extras = ["test"], editable = true }
 
 [environments]
 dev = ["mod"]

--- a/src/subpackages/core/cellprofiler_core/analysis/_runner.py
+++ b/src/subpackages/core/cellprofiler_core/analysis/_runner.py
@@ -730,9 +730,12 @@ class Runner:
 
     def stop_workers(self):
         if self.boundary is not None:
+            LOGGER.debug("joining boundary")
             self.boundary.join()
+            LOGGER.debug("destroying boundary zmq context")
             self.boundary.zmq_context.destroy(0)
             self.boundary = None
         for worker in self.workers:
+            LOGGER.debug("waiting on worker")
             worker.wait()
         self.workers = []

--- a/src/subpackages/core/cellprofiler_core/utilities/zmq/_boundary.py
+++ b/src/subpackages/core/cellprofiler_core/utilities/zmq/_boundary.py
@@ -222,6 +222,7 @@ class Boundary:
                     with self.analysis_context_lock:
                         if not self.analysis_context.enqueue(req):
                             continue
+            LOGGER.debug("boundary received stop")
             # Give the workers an explicit stop command
             self.keepalive_socket.send(NOTIFY_STOP)
             self.keepalive_socket.close()
@@ -237,7 +238,9 @@ class Boundary:
             # blocks?
             with self.analysis_context_lock:
                 self.analysis_context.cancel()
-                for request_class_queue in self.request_dictionary.values():
+                request_dict_values = self.request_dictionary.values()
+                LOGGER.debug(f"joining {len(request_dict_values)} threads")
+                for request_class_queue in request_dict_values:
                     #
                     # Tell each response class to stop. Wait for a reply
                     # which may be a thread instance. If so, join to the
@@ -248,6 +251,7 @@ class Boundary:
                         [self, self.NOTIFY_STOP, response_queue]
                     )
                     thread = response_queue.get()
+                    LOGGER.debug("joining on thread from response_queue")
                     if isinstance(thread, threading.Thread):
                         thread.join()
 

--- a/tests/core/analysis/test_analysis.py
+++ b/tests/core/analysis/test_analysis.py
@@ -3,7 +3,6 @@
 
 import logging
 import queue
-import pytest
 import inspect
 import numpy
 import os
@@ -13,8 +12,8 @@ import traceback
 import unittest
 import uuid
 import zmq
-import six.moves
-import six.moves.queue
+import queue
+from io import StringIO
 from importlib.util import find_spec
 
 import cellprofiler_core.constants.measurement
@@ -53,8 +52,8 @@ class TestAnalysis(unittest.TestCase):
             self.setDaemon(True)
             self.zmq_context = zmq.Context()
             self.zmq_context.setsockopt(zmq.LINGER, 0)
-            self.queue = six.moves.queue.Queue()
-            self.response_queue = six.moves.queue.Queue()
+            self.queue = queue.Queue()
+            self.response_queue = queue.Queue()
             self.start_signal = threading.Semaphore(0)
             self.keep_going = True
             self.analysis_id = None
@@ -68,20 +67,36 @@ class TestAnalysis(unittest.TestCase):
             self.start()
             self.start_signal.acquire()
 
+            logging.root.setLevel(10)
+            if len(logging.root.handlers) == 0:
+                stream_handler = logging.StreamHandler()
+                # fmt = logging.Formatter("%(process)d|%(levelno)s|%(name)s::%(funcName)s: %(message)s")
+                # stream_handler.setFormatter(fmt)
+                logging.root.addHandler(stream_handler)
+
         def __enter__(self):
             return self
 
         def __exit__(self, type, value, traceback):
+            LOGGER.debug("FakeWorker::__exit__ - Stopping the worker")
             self.stop()
-            for socket in self.sockets:
+            LOGGER.debug("FakeWorker::__exit__ - Closing sockets (notify, work, recv_notify, and keepalive)")
+            for i, socket in enumerate(self.sockets):
                 if socket is not None:
+                    LOGGER.debug(f"  FakeWorker::__exit__ - Closing socket {i}")
                     socket.close(linger=0)
-            self.zmq_context.destroy(linger=0)
+                else:
+                    LOGGER.debug(f"  FakeWorker::__exit__ - sockets {i} is None")
+            self.zmq_context.setsockopt(zmq.LINGER, 0)
+            LOGGER.debug("FakeWorker::__exit__ - Destroying zmq context")
+            self.zmq_context.destroy()
 
+            LOGGER.debug("FakeWorker::__exit__ - waiting on join")
             self.join()
+            LOGGER.debug("FakeWorker::__exit__ - did join")
 
         def run(self):
-            LOGGER.info("Client thread starting")
+            LOGGER.info("FakeWorker::run - starting")
             try:
                 self.work_socket = self.zmq_context.socket(zmq.REQ)
                 self.recv_notify_socket = self.zmq_context.socket(zmq.SUB)
@@ -93,18 +108,23 @@ class TestAnalysis(unittest.TestCase):
                 self.start_signal.release()
 
                 while self.keep_going:
+                    LOGGER.debug("FakeWorker::run - keep going, poll for a second")
                     socks = dict(self.poller.poll(1000))
                     if socks.get(self.recv_notify_socket, None) == zmq.POLLIN:
                         # Discard whatever comes down the notify socket.
                         # It's only used to wake us up.
+                        LOGGER.debug("FakeWorker::run - Blocking on recv_notify_socket")
                         msg = self.recv_notify_socket.recv()
+                        LOGGER.debug("FakeWorker::run - Received message on recv_notify_socket")
                     while True:
                         try:
                             if not self.keep_going:
+                                LOGGER.debug("FakeWorker::run - keep going is false, breaking")
                                 break
                             fn_and_args = self.queue.get_nowait()
 
-                        except six.moves.queue.Empty:
+                        except queue.Empty:
+                            LOGGER.debug("FakeWorker::run - queue empty, breaking")
                             break
                         try:
                             response = fn_and_args[0](*fn_and_args[1:])
@@ -113,17 +133,17 @@ class TestAnalysis(unittest.TestCase):
                             traceback.print_exc()
                             self.response_queue.put((e, None))
             except:
-                LOGGER.warning("Client thread caught exception", exc_info=True)
+                LOGGER.warning("FakeWorker::run - thread caught exception", exc_info=True)
                 self.start_signal.release()
             finally:
-                LOGGER.debug("Client thread exiting")
+                LOGGER.debug("FakeWorker::run - thread exiting")
 
         def stop(self):
             self.keep_going = False
             self.notify_socket.send(b"Stop")
 
         def send(self, req):
-            LOGGER.debug("    Enqueueing send of %s" % str(type(req)))
+            LOGGER.debug("    FakeWorker::send - Enqueueing send of %s" % str(type(req)))
             self.queue.put((self.do_send, req))
             self.notify_socket.send(b"Send")
             return self.recv
@@ -140,7 +160,7 @@ class TestAnalysis(unittest.TestCase):
                     )
 
         def do_send(self, req):
-            LOGGER.info("    Sending %s" % str(type(req)))
+            LOGGER.info("    FakeWorker::do_send - Sending %s" % str(type(req)))
             cellprofiler_core.utilities.zmq.communicable.Communicable.send(
                 req, self.work_socket
             )
@@ -161,13 +181,13 @@ class TestAnalysis(unittest.TestCase):
                 self.poller.unregister(self.work_socket)
 
         def recv(self):
-            LOGGER.debug("     Waiting for client thread")
+            LOGGER.debug("     FakeWorker::recv - Waiting for client thread")
             exception, result = self.response_queue.get()
             if exception is not None:
-                LOGGER.debug("    Client thread communicated exception")
+                LOGGER.debug("    FakeWorker::recv - Client thread communicated exception")
                 raise exception
             else:
-                LOGGER.debug("    Client thread communicated result")
+                LOGGER.debug("    FakeWorker::recv - Client thread communicated result")
                 return result
 
         def listen_for_heartbeat(self, address):
@@ -223,13 +243,16 @@ class TestAnalysis(unittest.TestCase):
         self.cpinstalled = find_spec("cellprofiler") != None
 
     def tearDown(self):
+        LOGGER.debug("Tearing down")
         self.cancel_analysis()
         if self.measurements_to_close is not None:
             self.measurements_to_close.close()
         if os.path.exists(self.filename):
             os.unlink(self.filename)
+        LOGGER.debug("Tear down complete")
 
     def cancel_analysis(self):
+        LOGGER.debug("Canceling analysis")
         if self.analysis is not None:
             self.analysis.cancel()
             self.analysis = None
@@ -276,12 +299,13 @@ class TestAnalysis(unittest.TestCase):
             ] = group_index
         pipeline = cellprofiler_core.pipeline.Pipeline()
         if self.cpinstalled:
-            pipeline.loadtxt(six.moves.StringIO(SBS_PIPELINE), raise_on_error=True)
+            pipeline.loadtxt(StringIO(SBS_PIPELINE), raise_on_error=True)
         else:
-            pipeline.loadtxt(six.moves.StringIO(SBS_PIPELINE_CORE_ONLY), raise_on_error=True)
+            pipeline.loadtxt(StringIO(SBS_PIPELINE_CORE_ONLY), raise_on_error=True)
         return pipeline, m
 
     def make_pipeline_and_measurements_and_start(self, **kwargs):
+        LOGGER.debug("Making pipeline and measurements, and starting analysis")
         pipeline, m = self.make_pipeline_and_measurements(**kwargs)
         if "status" in kwargs:
             overwrite = False
@@ -296,6 +320,7 @@ class TestAnalysis(unittest.TestCase):
             overwrite = True
         self.analysis = Analysis(pipeline, m)
 
+        LOGGER.debug("Starting Analysis")
         self.analysis.start(
             self.analysis_event_handler, num_workers=0, overwrite=overwrite
         )
@@ -308,6 +333,7 @@ class TestAnalysis(unittest.TestCase):
     def check_display_post_run_requests(self, pipeline):
         """Read the request.DisplayPostRun messages during the post_run phase"""
 
+        LOGGER.debug("check_display_post_run_requests: for all pipeline modules, get from event queue and assert DisplayPostRun request")
         for module in pipeline.modules():
             if (
                 module.show_window
@@ -317,6 +343,7 @@ class TestAnalysis(unittest.TestCase):
                 result = self.event_queue.get()
                 self.assertIsInstance(result, anarequest.DisplayPostRun)
                 self.assertEqual(result.module_num, module.module_num)
+        LOGGER.debug("check_display_post_run_requests: all passed")
 
     def test_01_01_start_and_stop(self):
         LOGGER.debug(
@@ -350,11 +377,14 @@ class TestAnalysis(unittest.TestCase):
 
         with self.FakeWorker() as worker:
             heartbeat_address = self.analysis.runner.boundary.keepalive_address
+            LOGGER.debug("test_02_01: listening for heartbeat")
             response = worker.listen_for_heartbeat(heartbeat_address)()
             from cellprofiler_core.constants.worker import NOTIFY_RUN, NOTIFY_STOP
             assert response == NOTIFY_RUN
 
             def collect_messages(container):
+                LOGGER.debug("test_02_01: spy thred - subscribing to heartbeat")
+                print("test_02_01: spy thread - container contents: ", container)
                 sock = worker.zmq_context.socket(zmq.SUB)
                 sock.setsockopt(zmq.SUBSCRIBE, b"")
                 sock.connect(heartbeat_address)
@@ -362,6 +392,8 @@ class TestAnalysis(unittest.TestCase):
                 poller.register(sock, zmq.POLLIN)
                 while len(container) < 10:
                     msg = poller.poll(2000)
+                    LOGGER.debug("test_02_01: spy thread - polled 2s and got message, adding to")
+                    print("test_02_01 - spy thread - messages is", msg)
                     if msg:
                         container.append(sock.recv())
                     else:
@@ -370,25 +402,42 @@ class TestAnalysis(unittest.TestCase):
             messages = []
 
             spy_thread = threading.Thread(target=collect_messages, args=(messages, ))
+            LOGGER.debug("test_02_01: starting spy thread, collecting messages")
             spy_thread.start()
+            LOGGER.debug("test_02_01: canceling analysis")
             self.cancel_analysis()
+            LOGGER.debug("test_02_01: joingin on spy thread 2s")
             spy_thread.join(2000)
             assert not spy_thread.is_alive()
+            LOGGER.debug("test_02_01: spy thread is now dead (joined)")
             assert len(messages)
+            LOGGER.debug("test_02_01: messages has length")
             assert messages[-1] == NOTIFY_STOP
+            LOGGER.debug("test_02_01: the last message has NOTIFY_STOP")
         LOGGER.debug(
             "Exiting %s" % inspect.getframeinfo(inspect.currentframe()).function
         )
 
     def test_03_01_get_work(self):
+        LOGGER.debug(
+            "Entering %s" % inspect.getframeinfo(inspect.currentframe()).function
+        )
         pipeline, m = self.make_pipeline_and_measurements_and_start()
         with self.FakeWorker() as worker:
+            LOGGER.debug("test_03_01: connecting worker to boundary request addr, with analysis_id")
             worker.connect(self.analysis.runner.boundary.request_address, self.analysis.runner.analysis_id)
+            print("test_03_01 - boundary request addr", self.analysis.runner.boundary.request_address, ", analysis_id", self.analysis.runner.analysis_id)
+            LOGGER.debug("test_03_01: sending work to worker")
             response = worker.send(anarequest.Work(worker.analysis_id))()
+            LOGGER.debug("test_03_01: got work response from worker")
             self.assertIsInstance(response, anareply.Work)
+            LOGGER.debug("test_03_01: wwork response valid")
             self.assertSequenceEqual(response.image_set_numbers, (1,))
+            LOGGER.debug("test_03_01: image set nuber valid")
             self.assertFalse(response.worker_runs_post_group)
+            LOGGER.debug("test_03_01: worker does not run post group")
             self.assertTrue(response.wants_dictionary)
+            LOGGER.debug("test_03_01: worker wants dictionary")
         LOGGER.debug(
             "Exiting %s" % inspect.getframeinfo(inspect.currentframe()).function
         )
@@ -400,11 +449,18 @@ class TestAnalysis(unittest.TestCase):
         pipeline, m = self.make_pipeline_and_measurements_and_start()
 
         with self.FakeWorker() as worker:
+            LOGGER.debug("test_03_02: connecting worker to boundary request addr with analysis id")
+            print("test_03_02 - boundary request addr", self.analysis.runner.boundary.request_address, ", analysis_id", self.analysis.runner.analysis_id)
             worker.connect(self.analysis.runner.boundary.request_address, self.analysis.runner.analysis_id)
+            LOGGER.debug("test_03_02: sending work request to worker")
             response = worker.send(anarequest.Work(worker.analysis_id))()
+            LOGGER.debug("test_03_02: got repsonse from worker")
             self.assertIsInstance(response, anareply.Work)
+            LOGGER.debug("test_03_02: repsonse is Work repsonse, sending another work request")
             response = worker.send(anarequest.Work(worker.analysis_id))()
+            LOGGER.debug("test_03_02: got response second time")
             self.assertIsInstance(response, anareply.NoWork)
+            LOGGER.debug("test_03_02: second response is NoWork")
         LOGGER.debug(
             "Exiting %s" % inspect.getframeinfo(inspect.currentframe()).function
         )
@@ -416,9 +472,14 @@ class TestAnalysis(unittest.TestCase):
         pipeline, m = self.make_pipeline_and_measurements_and_start()
 
         with self.FakeWorker() as worker:
+            LOGGER.debug("test_03_03: connecting worker to boundary request addr with analysis id")
+            print("test_03_03 - boundary request addr", self.analysis.runner.boundary.request_address, ", analysis_id", self.analysis.runner.analysis_id)
             worker.connect(self.analysis.runner.boundary.request_address, self.analysis.runner.analysis_id)
+            LOGGER.debug("test_03_03: canceling analysis before work")
             self.cancel_analysis()
+            LOGGER.debug("test_03_03: finished canceling analysis")
             assert self.analysis is None
+            LOGGER.debug("test_03_03: analysis is none")
             # The boundary thread used to spin eternally and reply with
             # BoundaryExited if analysis was cancelled. From CP5 it'll shut
             # down with the workers and so any open sockets will be closed.
@@ -450,7 +511,7 @@ class TestAnalysis(unittest.TestCase):
     #         #
     #         client_pipeline = cellprofiler_core.pipeline.Pipeline()
     #         pipeline_txt = response.pipeline_blob.tostring()
-    #         client_pipeline.loadtxt(six.moves.StringIO(pipeline_txt),
+    #         client_pipeline.loadtxt(StringIO(pipeline_txt),
     #                                 raise_on_error=True)
     #         self.assertEqual(len(pipeline.modules()),
     #                          len(client_pipeline.modules()))
@@ -482,8 +543,12 @@ class TestAnalysis(unittest.TestCase):
         )
         pipeline, m = self.make_pipeline_and_measurements_and_start()
         with self.FakeWorker() as worker:
+            LOGGER.debug("test_04_02: connecting worker to boundary request addr with analysis id")
+            print("test_04_02 - boundary request addr", self.analysis.runner.boundary.request_address, ", analysis_id", self.analysis.runner.analysis_id)
             worker.connect(self.analysis.runner.boundary.request_address, self.analysis.runner.analysis_id)
+            LOGGER.debug("test_04_02: connected, sending worker InitialMeasurments request")
             response = worker.send(anarequest.InitialMeasurements(worker.analysis_id))()
+            LOGGER.debug("test_04_02: got response, loading the measurments form buffer")
             client_measurements = cellprofiler_core.utilities.measurement.load_measurements_from_buffer(
                 response.buf
             )
@@ -491,14 +556,18 @@ class TestAnalysis(unittest.TestCase):
                 assert isinstance(
                     client_measurements, cellprofiler_core.measurement.Measurements
                 )
+                LOGGER.debug("test_04_02: measurements received are indeed measurements")
                 assert isinstance(m, cellprofiler_core.measurement.Measurements)
+                LOGGER.debug("test_04_02: the measurments we sent were measurements too")
                 self.assertSequenceEqual(
                     m.get_image_numbers(), client_measurements.get_image_numbers()
                 )
+                LOGGER.debug("test_04_02: image set numbers are correct")
                 image_numbers = m.get_image_numbers()
                 self.assertCountEqual(
                     m.get_object_names(), client_measurements.get_object_names()
                 )
+                LOGGER.debug("test_04_02: image numbers are correct")
                 for object_name in m.get_object_names():
                     self.assertCountEqual(
                         m.get_feature_names(object_name),
@@ -517,11 +586,16 @@ class TestAnalysis(unittest.TestCase):
                                 self.assertEqual(sv, cv)
                             else:
                                 numpy.testing.assert_almost_equal(sv, cv)
+                LOGGER.debug("test_04_02: for all objets, and all features per object, and all image numbers per object, they are correct")
             finally:
                 client_measurements.close()
+                LOGGER.debug("test_04_02: closed measurements")
                 LOGGER.debug(
                     "Exiting %s" % inspect.getframeinfo(inspect.currentframe()).function
                 )
+        LOGGER.debug(
+            "Exiting %s" % inspect.getframeinfo(inspect.currentframe()).function
+        )
 
     def test_04_03_interaction(self):
         LOGGER.debug(
@@ -529,17 +603,27 @@ class TestAnalysis(unittest.TestCase):
         )
         pipeline, m = self.make_pipeline_and_measurements_and_start()
         with self.FakeWorker() as worker:
+            LOGGER.debug("test_04_03: connecting worker to boundary request addr with analysis id")
+            print("test_04_03 - boundary request addr", self.analysis.runner.boundary.request_address, ", analysis_id", self.analysis.runner.analysis_id)
             worker.connect(self.analysis.runner.boundary.request_address, self.analysis.runner.analysis_id)
+            LOGGER.debug("test_04_03: sending worker Interaction request with foo=bar, expecting fn reply back")
             fn_interaction_reply = worker.send(
                 anarequest.Interaction(worker.analysis_id, foo="bar")
             )
+            LOGGER.debug("test_04_03: received a fn reply, getting from event queue")
             request = self.event_queue.get()
+            LOGGER.debug("test_04_03: got request from event queue")
             self.assertIsInstance(request, anarequest.Interaction)
+            LOGGER.debug("test_04_03: event queue request is an Interaction request")
             self.assertEqual(request.foo, "bar")
+            LOGGER.debug("test_04_03: requst's foo is bar, replying with hello=world Interaction reply")
             request.reply(anareply.Interaction(hello="world"))
+            LOGGER.debug("test_04_03: invoking the fn reply from before and getting a reply")
             reply = fn_interaction_reply()
             self.assertIsInstance(reply, anareply.Interaction)
+            LOGGER.debug("test_04_03: the reply from fn is Interaction")
             self.assertEqual(reply.hello, "world")
+            LOGGER.debug("test_04_03: reply's hello is world")
         LOGGER.debug(
             "Exiting %s" % inspect.getframeinfo(inspect.currentframe()).function
         )
@@ -550,20 +634,29 @@ class TestAnalysis(unittest.TestCase):
         )
         pipeline, m = self.make_pipeline_and_measurements_and_start()
         with self.FakeWorker() as worker:
+            LOGGER.debug("test_04_04_01: connecting worker to boundary request addr with analysis id")
+            print("test_04_04_01 - boundary request addr", self.analysis.runner.boundary.request_address, ", analysis_id", self.analysis.runner.analysis_id)
             worker.connect(self.analysis.runner.boundary.request_address, self.analysis.runner.analysis_id)
+            LOGGER.debug("test_04_04_01: sending worker Display request, with foo=bar, expecting a fn reply back")
             fn_interaction_reply = worker.send(
                 anarequest.Display(worker.analysis_id, foo="bar")
             )
             #
             # The event queue should be hooked up to the interaction callback
             #
+            LOGGER.debug("test_04_04_01: getting request from event queue")
             request = self.event_queue.get()
             self.assertIsInstance(request, anarequest.Display)
+            LOGGER.debug("test_04_04_01: event queue request is Display request")
             self.assertEqual(request.foo, "bar")
+            LOGGER.debug("test_04_04_01: event queue Display request's foo is bar, replying with Ack, with message as Gimme Pony")
             request.reply(anareply.Ack(message="Gimme Pony"))
+            LOGGER.debug("test_04_04_01: invoking fn reply from before")
             reply = fn_interaction_reply()
             self.assertIsInstance(reply, anareply.Ack)
+            LOGGER.debug("test_04_04_01: fn reply is indeed Ack")
             self.assertEqual(reply.message, "Gimme Pony")
+            LOGGER.debug("test_04_04_01: fn reply message is indeed Gimme Pony")
         LOGGER.debug(
             "Exiting %s" % inspect.getframeinfo(inspect.currentframe()).function
         )
@@ -574,21 +667,31 @@ class TestAnalysis(unittest.TestCase):
         )
         pipeline, m = self.make_pipeline_and_measurements_and_start()
         with self.FakeWorker() as worker:
+            LOGGER.debug("test_04_04_02: connecting worker to boundary request addr with analysis id")
+            print("test_04_04_02 - boundary request addr", self.analysis.runner.boundary.request_address, ", analysis_id", self.analysis.runner.analysis_id)
             worker.connect(self.analysis.runner.boundary.request_address, self.analysis.runner.analysis_id)
+            LOGGER.debug("test_04_04_02: sending worker DisplayPostGroup request, with 1 dict(foo=bar) and 3, expecting fn reply back")
             fn_interaction_reply = worker.send(
                 anarequest.DisplayPostGroup(worker.analysis_id, 1, dict(foo="bar"), 3)
             )
+            LOGGER.debug("test_04_04_02: got fn reply back, getting request from event queue")
             #
             # The event queue should be hooked up to the interaction callback
             #
             request = self.event_queue.get()
+            LOGGER.debug("test_04_04_02: got event queue request")
             self.assertIsInstance(request, anarequest.DisplayPostGroup)
+            LOGGER.debug("test_04_04_02: event queue request is indeed DisplayPostGroup")
             display_data = request.display_data
             self.assertEqual(display_data["foo"], "bar")
+            LOGGER.debug("test_04_04_02: DisplayPostGroup's display data's foo is indeed bar, replying with Ack, with message of Gimme Pony")
             request.reply(anareply.Ack(message="Gimme Pony"))
+            LOGGER.debug("test_04_04_02: invoking fn from before")
             reply = fn_interaction_reply()
             self.assertIsInstance(reply, anareply.Ack)
+            LOGGER.debug("test_04_04_02: reply fn is indeed Ack")
             self.assertEqual(reply.message, "Gimme Pony")
+            LOGGER.debug("test_04_04_02: reply fn message is indeed Gimmme Pony")
         LOGGER.debug(
             "Exiting %s" % inspect.getframeinfo(inspect.currentframe()).function
         )
@@ -599,8 +702,12 @@ class TestAnalysis(unittest.TestCase):
         )
         pipeline, m = self.make_pipeline_and_measurements_and_start()
         with self.FakeWorker() as worker:
+            LOGGER.debug("test_04_5: connecting worker to boundary request addr with analysis id")
+            print("test_04_5 - boundary request addr", self.analysis.runner.boundary.request_address, ", analysis_id", self.analysis.runner.analysis_id)
             worker.connect(self.analysis.runner.boundary.request_address, self.analysis.runner.analysis_id)
+            LOGGER.debug("test_04_05: constructing fake traceback")
             fake_traceback = ''.join(traceback.format_list(traceback.extract_stack()))
+            LOGGER.debug("test_04_05: sending ExceptionReport request with fake traceback, receiving fn reply")
             fn_interaction_reply = worker.send(
                 anarequest.ExceptionReport(
                     worker.analysis_id,
@@ -616,34 +723,48 @@ class TestAnalysis(unittest.TestCase):
             #
             # The event queue should be hooked up to the interaction callback
             #
+            LOGGER.debug("test_04_05: getting request from event queue")
             request = self.event_queue.get()
             self.assertIsInstance(request, anarequest.ExceptionReport)
+            LOGGER.debug("test_04_05: event queue request is indeed ExceptionReport")
             self.assertEqual(
                 fake_traceback, request.exc_traceback
             )
+            LOGGER.debug("test_04_05: event queue ExceptionReport is as expected")
             self.assertEqual(request.filename, "test_analysis.py")
+            LOGGER.debug("test_04_05: event queue ExceptionReport filename is test_analysis.py; replying with ExceptionPleaseDebug with verification hash corned beef and dispostion 1")
             request.reply(
                 anareply.ExceptionPleaseDebug(
                     disposition=1, verification_hash="corned beef"
                 )
             )
+            LOGGER.debug("test_04_05: invoking reply fn from before")
             reply = fn_interaction_reply()
             self.assertIsInstance(reply, anareply.ExceptionPleaseDebug)
+            LOGGER.debug("test_04_05: fn reply is indeed ExceptionPleaseDebug")
             self.assertEqual(reply.verification_hash, "corned beef")
+            LOGGER.debug("test_04_05: fn reply's verification hash is indeed corned beef")
             self.assertEqual(reply.disposition, 1)
+            LOGGER.debug("test_04_05: fn reply's dispostion is indeed 1")
             #
             # Try DebugWaiting and DebugComplete as well
             #
+            LOGGER.debug("test_04_05: for DebugWaiting on 8080 and DebugComplete:")
             for req in (
                 anarequest.DebugWaiting(worker.analysis_id, 8080),
                 anarequest.DebugComplete(worker.analysis_id),
             ):
+                LOGGER.debug("  test_04_05: sending the req, expecting fn reply")
                 fn_interaction_reply = worker.send(req)
+                LOGGER.debug("  test_04_05: getting event queue request")
                 request = self.event_queue.get()
                 self.assertEqual(type(request), type(req))
+                LOGGER.debug("  test_04_05: request is DebugWaiting or DebugComplete, sending ACK")
                 request.reply(anareply.Ack())
+                LOGGER.debug("test_04_05: invoking fn, getting reply")
                 reply = fn_interaction_reply()
                 self.assertIsInstance(reply, anareply.Ack)
+                LOGGER.debug("test_04_05: reply is indeed Ack")
         LOGGER.debug(
             "Exiting %s" % inspect.getframeinfo(inspect.currentframe()).function
         )
@@ -665,28 +786,36 @@ class TestAnalysis(unittest.TestCase):
         r = numpy.random.RandomState()
         r.seed(51)
         with self.FakeWorker() as worker:
+            LOGGER.debug("test_05_01: connecting worker to boundary request addr with analysis id")
+            print("test_05_01 - boundary request addr", self.analysis.runner.boundary.request_address, ", analysis_id", self.analysis.runner.analysis_id)
             worker.connect(self.analysis.runner.boundary.request_address, self.analysis.runner.analysis_id)
+            LOGGER.debug("test_05_01: requesting work from worker, getting response")
             response = worker.request_work()
             dictionaries = [
                 dict([(uuid.uuid4().hex, r.uniform(size=(10, 15))) for _ in range(10)])
                 for module in pipeline.modules()
             ]
+            LOGGER.debug("test_05_01: sending worker ImageSetSuccessWithDictionary, from constructed dictionary, IIF reply fn")
             response = worker.send(
                 anareply.ImageSetSuccessWithDictionary(
                     worker.analysis_id, response.image_set_numbers[0], dictionaries
                 )
             )()
             self.assertIsInstance(response, anareply.Ack)
+            LOGGER.debug("test_05_01: reply is indeed Ack, requesting additional work")
             response = worker.request_work()
             self.assertSequenceEqual(response.image_set_numbers, [2])
+            LOGGER.debug("test_05_01: reply image set numbers is [2]; sending SharedDictionary, IIF reply fn")
             response = worker.send(anarequest.SharedDictionary(worker.analysis_id))()
             self.assertIsInstance(response, anareply.SharedDictionary)
+            LOGGER.debug("test_05_01: response is indeed SharedDictionary")
             result = response.dictionaries
             self.assertEqual(len(dictionaries), len(result))
             for ed, d in zip(dictionaries, result):
                 self.assertCountEqual(list(ed.keys()), list(d.keys()))
                 for k in list(ed.keys()):
                     numpy.testing.assert_almost_equal(ed[k], d[k])
+            LOGGER.debug("test_05_01: dictionary is correctly constructed")
         LOGGER.debug(
             "Exiting %s" % inspect.getframeinfo(inspect.currentframe()).function
         )
@@ -701,18 +830,28 @@ class TestAnalysis(unittest.TestCase):
         r = numpy.random.RandomState()
         r.seed(52)
         with self.FakeWorker() as worker:
+            LOGGER.debug("test_05_02: connecting worker to boundary request addr with analysis id")
+            print("test_05_02 - boundary request addr", self.analysis.runner.boundary.request_address, ", analysis_id", self.analysis.runner.analysis_id)
             worker.connect(self.analysis.runner.boundary.request_address, self.analysis.runner.analysis_id)
+            LOGGER.debug("test_05_02: requesting work from worker")
             response = worker.request_work()
             self.assertTrue(response.worker_runs_post_group)
+            LOGGER.debug("test_05_02: worker does runs post group")
             self.assertFalse(response.wants_dictionary)
+            LOGGER.debug("test_05_02: worker does want dictionary")
             self.assertSequenceEqual(response.image_set_numbers, [1, 2])
+            LOGGER.debug("test_05_02: worker image set numbers as expected, [1,2]; sending ImageSetSuccess, IIF response fn")
             response = worker.send(
                 ImageSetSuccess(worker.analysis_id, response.image_set_numbers[0])
             )()
+            LOGGER.debug("test_05_02: not testing previous response; requesting additional work")
             response = worker.request_work()
             self.assertSequenceEqual(response.image_set_numbers, [3, 4])
+            LOGGER.debug("test_05_02: response image set numbers indeed [3,4]")
             self.assertTrue(response.worker_runs_post_group)
+            LOGGER.debug("test_05_02: response indeed runs post group")
             self.assertFalse(response.wants_dictionary)
+            LOGGER.debug("test_05_02: response indeed wants dictionary")
         LOGGER.debug(
             "Exiting %s" % inspect.getframeinfo(inspect.currentframe()).function
         )
@@ -736,9 +875,14 @@ class TestAnalysis(unittest.TestCase):
             # the initial measurements.
             #
             #####################################################
+            LOGGER.debug("test_06_01: connecting worker to boundary request addr with analysis id")
+            print("test_06_01 - boundary request addr", self.analysis.runner.boundary.request_address, ", analysis_id", self.analysis.runner.analysis_id)
             worker.connect(self.analysis.runner.boundary.request_address, self.analysis.runner.analysis_id)
+            LOGGER.debug("test_06_01: requesting work from worker")
             response = worker.request_work()
+            LOGGER.debug("test_06_01: sending worker InitialMeasurements; IIF response fn")
             response = worker.send(anarequest.InitialMeasurements(worker.analysis_id))()
+            LOGGER.debug("test_06_01: loading response buf")
             client_measurements = cellprofiler_core.utilities.measurement.load_measurements_from_buffer(
                 response.buf
             )
@@ -752,6 +896,7 @@ class TestAnalysis(unittest.TestCase):
                 dict([(uuid.uuid4().hex, r.uniform(size=(10, 15))) for _ in range(10)])
                 for module in pipeline.modules()
             ]
+            LOGGER.debug("test_06_01: sending ImageSetSuccessWithDictionary with constructed dictionary; IIF response fn")
             response = worker.send(
                 anareply.ImageSetSuccessWithDictionary(
                     worker.analysis_id, 1, dictionaries
@@ -767,7 +912,9 @@ class TestAnalysis(unittest.TestCase):
                 client_measurements.file_contents(),
                 image_set_numbers=[1],
             )
+            LOGGER.debug("test_06_01: closing ClientMeasurements")
             client_measurements.close()
+            LOGGER.debug("test_06_01: sending MeasurementsReport")
             response_fn = worker.send(req)
 
             self.check_display_post_run_requests(pipeline)
@@ -779,11 +926,15 @@ class TestAnalysis(unittest.TestCase):
             #
             #####################################################
 
+            LOGGER.debug("test_06_01: getting from event queue")
             result = self.event_queue.get()
             self.assertIsInstance(result, cellprofiler_core.analysis.event.Finished)
+            LOGGER.debug("test_06_01: result is indeed event Finished")
             self.assertFalse(result.cancelled)
+            LOGGER.debug("test_06_01: result is not cancelled")
             measurements = result.measurements
             self.assertSequenceEqual(measurements.get_image_numbers(), [1])
+            LOGGER.debug("test_06_01: result measurments image numbers as expected")
             self.assertEqual(
                 measurements[
                     cellprofiler_core.constants.measurement.IMAGE, IMAGE_FEATURE, 1
@@ -793,8 +944,11 @@ class TestAnalysis(unittest.TestCase):
             numpy.testing.assert_almost_equal(
                 measurements[OBJECTS_NAME, OBJECTS_FEATURE, 1], objects_measurements
             )
+            LOGGER.debug("test_06_01: result mesurements internals matches expectation")
+        LOGGER.debug(
+            "Exiting %s" % inspect.getframeinfo(inspect.currentframe()).function
+        )
 
-    @pytest.mark.timeout(20)
     def test_06_02_test_three_imagesets(self):
         # Test an analysis of three imagesets
         #
@@ -812,9 +966,14 @@ class TestAnalysis(unittest.TestCase):
             # the initial measurements.
             #
             #####################################################
+            LOGGER.debug("test_06_02: connecting worker to boundary request addr with analysis id")
+            print("test_06_02 - boundary request addr", self.analysis.runner.boundary.request_address, ", analysis_id", self.analysis.runner.analysis_id)
             worker.connect(self.analysis.runner.boundary.request_address, self.analysis.runner.analysis_id)
+            LOGGER.debug("test_06_02: requesting work from worker")
             response = worker.request_work()
+            LOGGER.debug("test_06_02: got response, not doing anything with it, sending worker InitialMeasurements, IIF fn reply")
             response = worker.send(anarequest.InitialMeasurements(worker.analysis_id))()
+            LOGGER.debug("test_06_02: loading measurements from reply buffer")
             client_measurements = cellprofiler_core.utilities.measurement.load_measurements_from_buffer(
                 response.buf
             )
@@ -824,10 +983,12 @@ class TestAnalysis(unittest.TestCase):
             # report the results of the first job
             #
             #####################################################
+            LOGGER.debug("test_06_02: constructing dictionary")
             dictionaries = [
                 dict([(uuid.uuid4().hex, r.uniform(size=(10, 15))) for _ in range(10)])
                 for module in pipeline.modules()
             ]
+            LOGGER.debug("test_06_02: sending ImageSetSuccessWithDictionary, with constructed dictionary; IIF fn response")
             response = worker.send(
                 anareply.ImageSetSuccessWithDictionary(
                     worker.analysis_id, 1, dictionaries
@@ -839,12 +1000,16 @@ class TestAnalysis(unittest.TestCase):
             # more jobs to do.
             #
             #####################################################
+            LOGGER.debug("test_06_02: for expected jobs 2 and 3:")
             expected_jobs = [2, 3]
             for _ in range(2):
+                LOGGER.debug("  test_06_02: requesting work from worker")
                 response = worker.request_work()
                 image_numbers = response.image_set_numbers
                 self.assertEqual(len(image_numbers), 1)
+                LOGGER.debug("  test_06_02: image set numbers are expected length")
                 self.assertIn(image_numbers[0], expected_jobs)
+                LOGGER.debug("  test_06_02: image set num 0 in expected jobs 2 and 3")
                 expected_jobs.remove(image_numbers[0])
             #####################################################
             #
@@ -852,14 +1017,17 @@ class TestAnalysis(unittest.TestCase):
             #
             #####################################################
             objects_measurements = [r.uniform(size=10) for _ in range(3)]
+            LOGGER.debug("test_06_02: for three random object measurements")
             for i, om in enumerate(objects_measurements):
                 image_number = i + 1
                 if image_number > 0:
+                    LOGGER.debug("  test_06_02: first image number - send ImageSetSuccess")
                     worker.send(
                         ImageSetSuccess(
                             worker.analysis_id, image_set_number=image_number
                         )
                     )
+                LOGGER.debug("  test_06_02: construct new Measurements from one returned before")
                 m = cellprofiler_core.measurement.Measurements(copy=client_measurements)
                 m[
                     cellprofiler_core.constants.measurement.IMAGE,
@@ -867,13 +1035,17 @@ class TestAnalysis(unittest.TestCase):
                     image_number,
                 ] = ("Hello %d" % image_number)
                 m[OBJECTS_NAME, OBJECTS_FEATURE, image_number] = om
+                LOGGER.debug("  test_06_02: construct MeasurementsReport request")
                 req = anarequest.MeasurementsReport(
                     worker.analysis_id,
                     m.file_contents(),
                     image_set_numbers=[image_number],
                 )
+                LOGGER.debug("  test_06_02: close measurements")
                 m.close()
+                LOGGER.debug("  test_06_02: send the MeasurementsReport request; IIF reply fn")
                 response = worker.send(req)()
+            LOGGER.debug("test_06_02: close client measurements returned previously")
             client_measurements.close()
             #####################################################
             #
@@ -883,10 +1055,14 @@ class TestAnalysis(unittest.TestCase):
             #
             #####################################################
 
+            LOGGER.debug("test_06_02: check_display_post_run_requests")
             self.check_display_post_run_requests(pipeline)
+            LOGGER.debug("test_06_02: get from event queue")
             result = self.event_queue.get()
             self.assertIsInstance(result, cellprofiler_core.analysis.event.Finished)
+            LOGGER.debug("test_06_02: event queue result is Finished event")
             self.assertFalse(result.cancelled)
+            LOGGER.debug("test_06_02: result is not cancelled")
             measurements = result.measurements
             self.assertSequenceEqual(list(measurements.get_image_numbers()), [1, 2, 3])
             for i in range(1, 4):
@@ -900,6 +1076,10 @@ class TestAnalysis(unittest.TestCase):
                     measurements[OBJECTS_NAME, OBJECTS_FEATURE, i],
                     objects_measurements[i - 1],
                 )
+            LOGGER.debug("test_06_02: result measurements are internally as expected")
+        LOGGER.debug(
+            "Exiting %s" % inspect.getframeinfo(inspect.currentframe()).function
+        )
 
     def test_06_03_test_grouped_imagesets(self):
         # Test an analysis of four imagesets in two groups
@@ -920,27 +1100,36 @@ class TestAnalysis(unittest.TestCase):
             # the initial measurements.
             #
             #####################################################
+            LOGGER.debug("test_06_03: connecting worker to boundary request addr with analysis id")
+            print("test_06_03 - boundary request addr", self.analysis.runner.boundary.request_address, ", analysis_id", self.analysis.runner.analysis_id)
             worker.connect(self.analysis.runner.boundary.request_address, self.analysis.runner.analysis_id)
+            LOGGER.debug("test_06_03: requesting work from worker")
             response = worker.request_work()
+            LOGGER.debug("test_06_03: ignroing response and sending InitialMeasurements; IIF reply fn")
             response = worker.send(anarequest.InitialMeasurements(worker.analysis_id))()
+            LOGGER.debug("test_06_03: loading measurements from response buffer")
             client_measurements = cellprofiler_core.utilities.measurement.load_measurements_from_buffer(
                 response.buf
             )
+            LOGGER.debug("test_06_03: sending ImageSetSuccess; IIF reply fn")
             response = worker.send(ImageSetSuccess(worker.analysis_id, 1))()
             #####################################################
             #
             # Get the second group.
             #
             #####################################################
+            LOGGER.debug("test_06_03: requesting second work group")
             response = worker.request_work()
             image_numbers = response.image_set_numbers
             self.assertSequenceEqual(list(image_numbers), [3, 4])
+            LOGGER.debug("test_06_03: got back expected images et numbers [3,4]")
             #####################################################
             #
             # Send the measurement groups
             #
             #####################################################
             objects_measurements = [r.uniform(size=10) for _ in range(4)]
+            LOGGER.debug("test_06_03: sending ImageSetSuccess with image set number 2, 3, and 4")
             for image_number in range(2, 5):
                 worker.send(
                     ImageSetSuccess(worker.analysis_id, image_set_number=image_number)
@@ -963,6 +1152,8 @@ class TestAnalysis(unittest.TestCase):
                 )
                 m.close()
                 response = worker.send(req)()
+            LOGGER.debug("test_06_03: for image numbers in ((1,2),(3,4)): did copy Measurements from client measurements, request MeasurementsReport, close constructed measurements, and sent the MeasurementsReport; IIF reply fn")
+            LOGGER.debug("test_06_03: close client measurements")
             client_measurements.close()
             #####################################################
             #
@@ -972,10 +1163,14 @@ class TestAnalysis(unittest.TestCase):
             #
             #####################################################
 
+            LOGGER.debug("test_06_03: check_display_post_run_requests")
             self.check_display_post_run_requests(pipeline)
+            LOGGER.debug("test_06_03: get from event queue")
             result = self.event_queue.get()
             self.assertIsInstance(result, cellprofiler_core.analysis.event.Finished)
+            LOGGER.debug("test_06_03: event queue result is Finished event")
             self.assertFalse(result.cancelled)
+            LOGGER.debug("test_06_03: not cancelled")
             measurements = result.measurements
             self.assertSequenceEqual(
                 list(measurements.get_image_numbers()), [1, 2, 3, 4]
@@ -991,6 +1186,10 @@ class TestAnalysis(unittest.TestCase):
                     measurements[OBJECTS_NAME, OBJECTS_FEATURE, i],
                     objects_measurements[i - 1],
                 )
+            LOGGER.debug("test_06_03: result measurements internally as expected")
+        LOGGER.debug(
+            "Exiting %s" % inspect.getframeinfo(inspect.currentframe()).function
+        )
 
     def test_06_04_test_restart(self):
         # Test a restart of an analysis
@@ -1016,9 +1215,13 @@ class TestAnalysis(unittest.TestCase):
             # the initial measurements.
             #
             #####################################################
+            LOGGER.debug("test_06_04: connecting worker to boundary request addr with analysis id")
+            print("test_06_04 - boundary request addr", self.analysis.runner.boundary.request_address, ", analysis_id", self.analysis.runner.analysis_id)
             worker.connect(self.analysis.runner.boundary.request_address, self.analysis.runner.analysis_id)
             response = worker.request_work()
+            LOGGER.debug("test_06_04: sinding InitialMeasurements to worker; IIF reply fn")
             response = worker.send(anarequest.InitialMeasurements(worker.analysis_id))()
+            LOGGER.debug("test_06_04: contructing client measurements from response buffer")
             client_measurements = cellprofiler_core.utilities.measurement.load_measurements_from_buffer(
                 response.buf
             )
@@ -1028,10 +1231,12 @@ class TestAnalysis(unittest.TestCase):
             # report the results of the first job
             #
             #####################################################
+            LOGGER.debug("test_06_04: constructing dictionaries")
             dictionaries = [
                 dict([(uuid.uuid4().hex, r.uniform(size=(10, 15))) for _ in range(10)])
                 for module in pipeline.modules()
             ]
+            LOGGER.debug("test_06_04: sending ImageSetSuccessWithDictionary with constructed dictionary; IIF reply fn")
             response = worker.send(
                 anareply.ImageSetSuccessWithDictionary(
                     worker.analysis_id, 1, dictionaries
@@ -1043,10 +1248,12 @@ class TestAnalysis(unittest.TestCase):
             # the third job.
             #
             #####################################################
+            LOGGER.debug("test_06_04: ignoring previous response; requesting work")
             response = worker.request_work()
             image_numbers = response.image_set_numbers
             self.assertEqual(len(image_numbers), 1)
             self.assertEqual(image_numbers[0], 3)
+            LOGGER.debug("test_06_04: response image set numbers properly structured")
             #####################################################
             #
             # Send the measurement groups
@@ -1074,6 +1281,8 @@ class TestAnalysis(unittest.TestCase):
                 )
                 m.close()
                 response = worker.send(req)()
+            LOGGER.debug("test_06_04: for each image number, object mesurement pair, send ImageSetSuccess, copy client measurements, construct MeasurementsReport, close copied measurements, send MesurementsReport; IIF rply fn")
+            LOGGER.debug("test_06_04: close client mesurements")
             client_measurements.close()
             #####################################################
             #
@@ -1083,10 +1292,14 @@ class TestAnalysis(unittest.TestCase):
             #
             #####################################################
 
+            LOGGER.debug("test_06_04: check_dipslay_post_run_requests")
             self.check_display_post_run_requests(pipeline)
+            LOGGER.debug("test_06_04: get form event queue")
             result = self.event_queue.get()
             self.assertIsInstance(result, cellprofiler_core.analysis.event.Finished)
+            LOGGER.debug("test_06_04: event queue event is Finished event")
             self.assertFalse(result.cancelled)
+            LOGGER.debug("test_06_04: event queue event is not cancelled")
             measurements = result.measurements
             assert isinstance(measurements, cellprofiler_core.measurement.Measurements)
             self.assertSequenceEqual(list(measurements.get_image_numbers()), [1, 2, 3])
@@ -1113,6 +1326,10 @@ class TestAnalysis(unittest.TestCase):
                         measurements[OBJECTS_NAME, OBJECTS_FEATURE, i],
                         objects_measurements[i - 1],
                     )
+            LOGGER.debug("test_06_04: event queue result measurements is as expected")
+        LOGGER.debug(
+            "Exiting %s" % inspect.getframeinfo(inspect.currentframe()).function
+        )
 
     def test_06_05_test_grouped_restart(self):
         # Test an analysis of four imagesets in two groups with all but one
@@ -1142,10 +1359,15 @@ class TestAnalysis(unittest.TestCase):
             # the initial measurements.
             #
             #####################################################
+            LOGGER.debug("test_06_05: connecting worker to boundary request addr with analysis id")
+            print("test_06_05 - boundary request addr", self.analysis.runner.boundary.request_address, ", analysis_id", self.analysis.runner.analysis_id)
             worker.connect(self.analysis.runner.boundary.request_address, self.analysis.runner.analysis_id)
+            LOGGER.debug("test_06_05: requesting work from worker")
             response = worker.request_work()
             self.assertSequenceEqual(response.image_set_numbers, [1, 2])
+            LOGGER.debug("test_06_05: response image set numbers as expected, sending InitialMeasurements; IIF reply fn")
             response = worker.send(anarequest.InitialMeasurements(worker.analysis_id))()
+            LOGGER.debug("test_06_05: loading client measurements from response buffer")
             client_measurements = cellprofiler_core.utilities.measurement.load_measurements_from_buffer(
                 response.buf
             )
@@ -1153,6 +1375,8 @@ class TestAnalysis(unittest.TestCase):
                 response = worker.send(
                     ImageSetSuccess(worker.analysis_id, image_number)
                 )()
+            LOGGER.debug("test_06_05: for each image number, send ImageSetSuccess; IFF reply fn")
+            LOGGER.debug("test_06_05: construct Measurements from client measurements")
             m = cellprofiler_core.measurement.Measurements(copy=client_measurements)
             objects_measurements = [r.uniform(size=10) for _ in range(2)]
             for image_number in (1, 2):
@@ -1164,11 +1388,15 @@ class TestAnalysis(unittest.TestCase):
                 m[OBJECTS_NAME, OBJECTS_FEATURE, image_number] = objects_measurements[
                     image_number - 1
                 ]
+            LOGGER.debug("test_06_05: construct MeasurementsReport")
             req = anarequest.MeasurementsReport(
                 worker.analysis_id, m.file_contents(), image_set_numbers=(1, 2)
             )
+            LOGGER.debug("test_06_05: close client measurements")
             m.close()
+            LOGGER.debug("test_06_05: send MeasurementsReport; IFF rply fn")
             response = worker.send(req)()
+            LOGGER.debug("test_06_05: close client measurements")
             client_measurements.close()
             #####################################################
             #
@@ -1178,10 +1406,14 @@ class TestAnalysis(unittest.TestCase):
             #
             #####################################################
 
+            LOGGER.debug("test_06_05: check_display_post_run_requessts")
             self.check_display_post_run_requests(pipeline)
+            LOGGER.debug("test_06_05: get from event queue")
             result = self.event_queue.get()
             self.assertIsInstance(result, cellprofiler_core.analysis.event.Finished)
+            LOGGER.debug("test_06_05: event queue event is Finished")
             self.assertFalse(result.cancelled)
+            LOGGER.debug("test_06_05: event queue event is not cancelled")
             measurements = result.measurements
             for i in range(1, 3):
                 self.assertEqual(
@@ -1194,6 +1426,10 @@ class TestAnalysis(unittest.TestCase):
                     measurements[OBJECTS_NAME, OBJECTS_FEATURE, i],
                     objects_measurements[i - 1],
                 )
+            LOGGER.debug("test_06_05: event queue result measurements is structured as expected")
+        LOGGER.debug(
+            "Exiting %s" % inspect.getframeinfo(inspect.currentframe()).function
+        )
 
     def test_06_06_relationships(self):
         #
@@ -1213,10 +1449,15 @@ class TestAnalysis(unittest.TestCase):
             # the initial measurements.
             #
             #####################################################
+            LOGGER.debug("test_06_06: connecting worker to boundary request addr with analysis id")
+            print("test_06_06 - boundary request addr", self.analysis.runner.boundary.request_address, ", analysis_id", self.analysis.runner.analysis_id)
             worker.connect(self.analysis.runner.boundary.request_address,
                            self.analysis.runner.analysis_id)
+            LOGGER.debug("test_06_06: requesting work")
             response = worker.request_work()
+            LOGGER.debug("test_06_06: ignore response, sending InitialMeasuremnts; IFF reply fn")
             response = worker.send(anarequest.InitialMeasurements(worker.analysis_id))()
+            LOGGER.debug("test_06_06: load client measurements from response buffer")
             client_measurements = cellprofiler_core.utilities.measurement.load_measurements_from_buffer(
                 response.buf
             )
@@ -1226,15 +1467,18 @@ class TestAnalysis(unittest.TestCase):
             # report the results of the first job
             #
             #####################################################
+            LOGGER.debug("test_06_06: create dictionaries")
             dictionaries = [
                 dict([(uuid.uuid4().hex, r.uniform(size=(10, 15))) for _ in range(10)])
                 for module in pipeline.modules()
             ]
+            LOGGER.debug("test_06_06: send ImageSetSuccessWithDictionary; IFF reply fn")
             response = worker.send(
                 anareply.ImageSetSuccessWithDictionary(
                     worker.analysis_id, 1, dictionaries
                 )
             )()
+            LOGGER.debug("test_06_06: mutate client measurements")
             n_objects = 10
             objects_measurements = r.uniform(size=n_objects)
             objects_relationship = r.permutation(n_objects) + 1
@@ -1252,14 +1496,18 @@ class TestAnalysis(unittest.TestCase):
                 numpy.ones(n_objects, int),
                 objects_relationship,
             )
+            LOGGER.debug("test_06_06: create MeasurementsReport from client measurements file contents")
             req = anarequest.MeasurementsReport(
                 worker.analysis_id,
                 client_measurements.file_contents(),
                 image_set_numbers=[1],
             )
+            LOGGER.debug("test_06_06: close client measurements")
             client_measurements.close()
+            LOGGER.debug("test_06_06: send MeasurementsReport")
             response_fn = worker.send(req)
 
+            LOGGER.debug("test_06_06: check_display_post_run")
             self.check_display_post_run_requests(pipeline)
             #####################################################
             #
@@ -1269,9 +1517,12 @@ class TestAnalysis(unittest.TestCase):
             #
             #####################################################
 
+            LOGGER.debug("test_06_06: get from event queue")
             result = self.event_queue.get()
             self.assertIsInstance(result, cellprofiler_core.analysis.event.Finished)
+            LOGGER.debug("test_06_06: event queue event is Finished")
             self.assertFalse(result.cancelled)
+            LOGGER.debug("test_06_06: event queue event is not cancelled")
             measurements = result.measurements
             assert isinstance(measurements, cellprofiler_core.measurement.Measurements)
             self.assertSequenceEqual(measurements.get_image_numbers(), [1])
@@ -1284,6 +1535,7 @@ class TestAnalysis(unittest.TestCase):
             numpy.testing.assert_almost_equal(
                 measurements[OBJECTS_NAME, OBJECTS_FEATURE, 1], objects_measurements
             )
+            LOGGER.debug("test_06_06: event queue events result measurements are structured as expected, checking relationship groups")
             rg = measurements.get_relationship_groups()
             self.assertEqual(len(rg), 1)
             rk = rg[0]
@@ -1308,6 +1560,10 @@ class TestAnalysis(unittest.TestCase):
                 r[cellprofiler_core.constants.measurement.R_SECOND_OBJECT_NUMBER],
                 objects_relationship,
             )
+            LOGGER.debug("test_06_06: all relationship groups as expected")
+        LOGGER.debug(
+            "Exiting %s" % inspect.getframeinfo(inspect.currentframe()).function
+        )
 
     def test_06_07_worker_cancel(self):
         #
@@ -1327,8 +1583,12 @@ class TestAnalysis(unittest.TestCase):
             # the initial measurements.
             #
             #####################################################
+            LOGGER.debug("test_06_07: connecting worker to boundary request addr with analysis id")
+            print("test_06_07 - boundary request addr", self.analysis.runner.boundary.request_address, ", analysis_id", self.analysis.runner.analysis_id)
             worker.connect(self.analysis.runner.boundary.request_address, self.analysis.runner.analysis_id)
+            LOGGER.debug("test_06_07: requesting work from worker")
             response = worker.request_work()
+            LOGGER.debug("test_06_07: sending InitialMeasurements; IFF reply fn")
             response = worker.send(anarequest.InitialMeasurements(worker.analysis_id))()
             #####################################################
             #
@@ -1337,10 +1597,17 @@ class TestAnalysis(unittest.TestCase):
             #
             #####################################################
 
+            LOGGER.debug("test_06_07: sending AnalysisCancel; IFF reply fn")
             response = worker.send(anarequest.AnalysisCancel(worker.analysis_id))()
+            LOGGER.debug("test_06_07: getting from event queue")
             result = self.event_queue.get()
             self.assertIsInstance(result, cellprofiler_core.analysis.event.Finished)
+            LOGGER.debug("test_06_07: event queue event is Finished")
             self.assertTrue(result.cancelled)
+            LOGGER.debug("test_06_07: event queue event is cancelled")
+        LOGGER.debug(
+            "Exiting %s" % inspect.getframeinfo(inspect.currentframe()).function
+        )
 
 # Sample pipeline - should only be used if cellprofiler is installed
 SBS_PIPELINE = r"""CellProfiler Pipeline: http://www.cellprofiler.org


### PR DESCRIPTION
Addresses #4859 (maybe). Logging statements were added throughout in order to track the source of the error. Most logging statements, within individual tests, did nothing to alter the sporadic failures. However, after putting logging statements within the `__exit__` method of `FakeWorker`, several dozen runs of testing did not run into the error.

This may have been coincidence. For instance, It could be the case, that although the macos version is specified, different VMs provided by GitHub cause the error to occur, or not occur. Given that the multiple successful runs were conducted over a period of three days (mostly during the weekend), there may have been a string of lucky VM allocations.

However, if the simple act of logging within `__exit__` did indeed fix the problem, it points to what has always been the prime suspect: a race condition. Specifically, each test sets up a context in which `FakeWorker` is instantiated. Once the test cases pass, the work is cancelled, the `uinittest.TestCase`'s `teardown` is called, the sockets are terminated, queues are closed, and the context is exited, causing `__exit__` to be invoked. There is a strong suspicion that during this tear down process, given that multiple things are happening concurrently, there is an order of events (only occurring sometimes) such that the `__exits__`'s invocation of `self.join()` hangs indefinitely, because the `FakeWorker`'s thread has already closed or is otherwise blocked. 

If that is the case, the act of logging, which requires calls to `logging` and system writes, slows things down just enough to avoid the race condition. This conclusion is wild speculation, but I have nothing else to go off of at the moment unless and until tests start failing again, and I can actually read the output of the logging statements.