### PR TITLE
Set Python version upper limit within `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setuptools.setup(
     package_data=package_data(),
     include_package_data=True,
     packages=setuptools.find_packages(exclude=["tests*"]),
-    python_requires=">=3.8",
+    python_requires=">=3.8,<3.10",
     setup_requires=["pytest"],
     url="https://github.com/CellProfiler/CellProfiler",
     version=find_version("cellprofiler", "__init__.py"),


### PR DESCRIPTION
This PR sets an upper limit to what Python versions may be used with CellProfiler 4.2.x in alignment with comments in #4946  . After this change, `pip` (for example) will prevent a person from attempting to install CellProfiler with Python versions that are not supported for this version range.