### PR TITLE
warn in correctillumapply if applying image to itself

### DIFF
--- a/src/frontend/cellprofiler/modules/correctilluminationapply.py
+++ b/src/frontend/cellprofiler/modules/correctilluminationapply.py
@@ -366,6 +366,14 @@ somewhat empirical.
                     % image.rescale_option,
                     image.divide_or_subtract,
                 )
+        for image in self.images:
+            image_name = image.image_name.value
+            illum_correct_name = image.illum_correct_function_image_name.value
+            if image_name == illum_correct_name:
+                raise ValidationError(
+                    "You are applying an image to itself. Check your input image/s and illumination function/s.",
+                    self.images,
+                )
 
     def upgrade_settings(self, setting_values, variable_revision_number, module_name):
         """Adjust settings based on revision # of save file


### PR DESCRIPTION
My goal is for the GUI to throw the Red X if, for any image, the user has set the `input image` and the `illumination function` to the same image.

In a test where I set the `input image` and the `illumination function` to the same image, I know that the validation error is being reached because if I add a print statement after `if image_name == illum_correct_name:` it prints. However, there is no Red X. 

If I put the check in `validate_module()` (instead of `validate_module_warnings`) it behaves similarly

(I'm not sure how to pass the specific image that is raising the error as if I put `self.images.image` in the ValidationError() (instead of the `self.images` that's in this draft) it throws `Exception in cpmodule.text_valid 'list' object has no attribute 'image'`)