### PR TITLE
Fix issue #4988 : MeasureObjectNeighbors visualization zooming

### DIFF
--- a/src/frontend/cellprofiler/modules/measureobjectneighbors.py
+++ b/src/frontend/cellprofiler/modules/measureobjectneighbors.py
@@ -788,6 +788,7 @@ previously discarded objects.""".format(
                 0,
                 workspace.display_data.neighbor_labels,
                 "Neighbors: %s" % self.neighbors_name.value,
+                sharexy=figure.subplot(0, 0),
             )
         if numpy.any(object_mask):
             figure.subplot_imshow(


### PR DESCRIPTION
Added sharexy argument for neighbors plot that was not zooming-in in sync with other outputs

Resolves #4988 and #4628 