### PR TITLE
FilterObjects relabel mismatch Issues/4509

### DIFF
--- a/src/frontend/cellprofiler/modules/filterobjects.py
+++ b/src/frontend/cellprofiler/modules/filterobjects.py
@@ -411,7 +411,11 @@ This may be useful if you want to make use of the negative (filtered out) popula
             doc="""\
 Click this button to add an object to receive the same post-filtering labels as
 the filtered object. This is useful in making sure that labeling is maintained
-between related objects (e.g., primary and secondary objects) after filtering.""",
+between related objects (e.g., primary and secondary objects) after filtering. 
+
+**Note:** To ensure correct parent-child relationships, you must use the 
+**RelateObjects** module prior to using this setting. Otherwise, the output 
+could have unexpected parent-child relations.""",
         )
 
         self.rules.create_settings()

--- a/tests/frontend/modules/test_filterobjects.py
+++ b/tests/frontend/modules/test_filterobjects.py
@@ -474,8 +474,8 @@ def test_renumber_other():
     assert numpy.all(alternates.segmented == expected_alternates)
 
 
-def test_renumber_other_object_numbers_reversed():
-    """Renumber an associated object"""
+def test_renumber_other_object_numbers_reversed_does_not_relate():
+    """Filter should not automatically relate objects if renumbering setting is selected"""
     n = 40
     labels = numpy.zeros((10, n * 10), int)
     alternates = numpy.zeros((10, n * 10), int)
@@ -512,7 +512,7 @@ def test_renumber_other_object_numbers_reversed():
     labels = workspace.object_set.get_objects(OUTPUT_OBJECTS)
     alternates = workspace.object_set.get_objects("my_additional_result")
     assert numpy.all(labels.segmented == expected)
-    assert numpy.all(alternates.segmented == expected_alternates)
+    assert numpy.any(alternates.segmented != expected_alternates)
 
 
 def test_load_v3():


### PR DESCRIPTION
As discussed with @bethac07 last week, the #4509 issue bug occurs when there is a mismatch in the labels assigned to the object being filtered and the `Additional Object`s that the user wishes to relabel. A decision was made to add a note in the docs, clarifying that the user needs to `RelateObjects` prior to using this module to ensure that the labels assigned to the newly created object sets match the labels of the object being filtered. 
We chose this option instead of automatically relabeling the `Additional Object` in order to avoid redundant functionality among modules.