### PR TITLE
Bug fix: FilterObjects parent-child relationship

### DIFF
--- a/tests/frontend/modules/test_relateobjects.py
+++ b/tests/frontend/modules/test_relateobjects.py
@@ -1,5 +1,5 @@
 import numpy
-import unittest
+import pytest
 
 import cellprofiler_core.image
 import cellprofiler_core.measurement
@@ -26,481 +26,670 @@ MEASUREMENT = "Measurement"
 IGNORED_MEASUREMENT = "%s_Foo" % C_PARENT
 
 
-class TestRelateObjects(unittest.TestCase):
-    def make_workspace(self, parents, children, fake_measurement=False):
-        """Make a workspace for testing Relate"""
-        pipeline = cellprofiler_core.pipeline.Pipeline()
-        if fake_measurement:
+def make_workspace(parents, children, fake_measurement=False):
+    """Make a workspace for testing Relate"""
+    pipeline = cellprofiler_core.pipeline.Pipeline()
+    if fake_measurement:
 
-            class FakeModule(cellprofiler_core.module.Module):
-                def get_measurement_columns(self, pipeline):
-                    return [
-                        (CHILD_OBJECTS, MEASUREMENT, COLTYPE_FLOAT,),
-                        (CHILD_OBJECTS, IGNORED_MEASUREMENT, COLTYPE_INTEGER,),
-                    ]
+        class FakeModule(cellprofiler_core.module.Module):
+            def get_measurement_columns(self, pipeline):
+                return [
+                    (CHILD_OBJECTS, MEASUREMENT, COLTYPE_FLOAT,),
+                    (CHILD_OBJECTS, IGNORED_MEASUREMENT, COLTYPE_INTEGER,),
+                ]
 
-            module = FakeModule()
-            module.set_module_num(1)
-            pipeline.add_module(module)
-        module = cellprofiler.modules.relateobjects.Relate()
-        module.x_name.value = PARENT_OBJECTS
-        module.y_name.value = CHILD_OBJECTS
-        module.find_parent_child_distances.value = (
-            cellprofiler.modules.relateobjects.D_NONE
-        )
-        module.wants_child_objects_saved.value = False
-        new_module_num = 2 if fake_measurement else 1
-        module.set_module_num(new_module_num)
+        module = FakeModule()
+        module.set_module_num(1)
         pipeline.add_module(module)
-        object_set = cellprofiler_core.object.ObjectSet()
-        image_set_list = cellprofiler_core.image.ImageSetList()
-        image_set = image_set_list.get_image_set(0)
-        m = cellprofiler_core.measurement.Measurements()
-        m.add_image_measurement(GROUP_NUMBER, 1)
-        m.add_image_measurement(GROUP_INDEX, 1)
-        workspace = cellprofiler_core.workspace.Workspace(
-            pipeline, module, image_set, object_set, m, image_set_list
-        )
-        o = cellprofiler_core.object.Objects()
-        if parents.shape[1] == 3:
-            # IJV format
-            o.ijv = parents
-        else:
-            o.segmented = parents
-        object_set.add_objects(o, PARENT_OBJECTS)
-        o = cellprofiler_core.object.Objects()
-        if children.shape[1] == 3:
-            o.ijv = children
-        else:
-            o.segmented = children
-        object_set.add_objects(o, CHILD_OBJECTS)
-        return workspace, module
+    module = cellprofiler.modules.relateobjects.Relate()
+    module.x_name.value = PARENT_OBJECTS
+    module.y_name.value = CHILD_OBJECTS
+    module.find_parent_child_distances.value = (
+        cellprofiler.modules.relateobjects.D_NONE
+    )
+    module.wants_child_objects_saved.value = False
+    new_module_num = 2 if fake_measurement else 1
+    module.set_module_num(new_module_num)
+    pipeline.add_module(module)
+    object_set = cellprofiler_core.object.ObjectSet()
+    image_set_list = cellprofiler_core.image.ImageSetList()
+    image_set = image_set_list.get_image_set(0)
+    m = cellprofiler_core.measurement.Measurements()
+    m.add_image_measurement(GROUP_NUMBER, 1)
+    m.add_image_measurement(GROUP_INDEX, 1)
+    workspace = cellprofiler_core.workspace.Workspace(
+        pipeline, module, image_set, object_set, m, image_set_list
+    )
+    o = cellprofiler_core.object.Objects()
+    if parents.shape[1] == 3:
+        # IJV format
+        o.ijv = parents
+    else:
+        o.segmented = parents
+    object_set.add_objects(o, PARENT_OBJECTS)
+    o = cellprofiler_core.object.Objects()
+    if children.shape[1] == 3:
+        o.ijv = children
+    else:
+        o.segmented = children
+    object_set.add_objects(o, CHILD_OBJECTS)
+    return workspace, module
 
-    def features_and_columns_match(self, workspace):
-        module = workspace.module
-        pipeline = workspace.pipeline
-        measurements = workspace.measurements
-        object_names = [x for x in measurements.get_object_names() if x != "Image"]
-        features = [
-            [
-                feature
-                for feature in measurements.get_feature_names(object_name)
-                if feature not in (MEASUREMENT, IGNORED_MEASUREMENT)
-            ]
-            for object_name in object_names
+def features_and_columns_match(workspace):
+    module = workspace.module
+    pipeline = workspace.pipeline
+    measurements = workspace.measurements
+    object_names = [x for x in measurements.get_object_names() if x != "Image"]
+    features = [
+        [
+            feature
+            for feature in measurements.get_feature_names(object_name)
+            if feature not in (MEASUREMENT, IGNORED_MEASUREMENT)
         ]
-        columns = [
-            x for x in module.get_measurement_columns(pipeline) if x[0] != "Image"
-        ]
-        self.assertEqual(sum([len(f) for f in features]), len(columns))
-        for column in columns:
-            index = object_names.index(column[0])
-            self.assertTrue(column[1] in features[index])
+        for object_name in object_names
+    ]
+    columns = [
+        x for x in module.get_measurement_columns(pipeline) if x[0] != "Image"
+    ]
+    assert(sum([len(f) for f in features]) == len(columns))
+    for column in columns:
+        index = object_names.index(column[0])
+        assert(column[1] in features[index])
 
-    def test_02_01_relate_zeros(self):
-        """Relate a field of empty parents to empty children"""
-        labels = numpy.zeros((10, 10), int)
-        workspace, module = self.make_workspace(labels, labels)
-        module.wants_per_parent_means.value = False
-        module.run(workspace)
-        m = workspace.measurements
-        parents_of = m.get_current_measurement(
-            CHILD_OBJECTS, "Parent_%s" % PARENT_OBJECTS
-        )
-        self.assertEqual(numpy.product(parents_of.shape), 0)
-        child_count = m.get_current_measurement(
-            PARENT_OBJECTS, "Children_%s_Count" % CHILD_OBJECTS
-        )
-        self.assertEqual(numpy.product(child_count.shape), 0)
-        self.features_and_columns_match(workspace)
+def test_02_01_relate_zeros():
+    """Relate a field of empty parents to empty children"""
+    labels = numpy.zeros((10, 10), int)
+    workspace, module = make_workspace(labels, labels)
+    module.wants_per_parent_means.value = False
+    module.run(workspace)
+    m = workspace.measurements
+    parents_of = m.get_current_measurement(
+        CHILD_OBJECTS, "Parent_%s" % PARENT_OBJECTS
+    )
+    assert(numpy.product(parents_of.shape) == 0)
+    child_count = m.get_current_measurement(
+        PARENT_OBJECTS, "Children_%s_Count" % CHILD_OBJECTS
+    )
+    assert(numpy.product(child_count.shape) == 0)
+    features_and_columns_match(workspace)
 
-    def test_02_01_relate_one(self):
-        """Relate one parent to one child"""
-        parent_labels = numpy.ones((10, 10), int)
-        child_labels = numpy.zeros((10, 10), int)
-        child_labels[3:5, 4:7] = 1
-        workspace, module = self.make_workspace(parent_labels, child_labels)
-        module.wants_per_parent_means.value = False
-        module.run(workspace)
-        m = workspace.measurements
-        parents_of = m.get_current_measurement(
-            CHILD_OBJECTS, "Parent_%s" % PARENT_OBJECTS
-        )
-        self.assertEqual(numpy.product(parents_of.shape), 1)
-        self.assertEqual(parents_of[0], 1)
-        child_count = m.get_current_measurement(
-            PARENT_OBJECTS, "Children_%s_Count" % CHILD_OBJECTS
-        )
-        self.assertEqual(numpy.product(child_count.shape), 1)
-        self.assertEqual(child_count[0], 1)
-        self.features_and_columns_match(workspace)
+def test_02_01_relate_one():
+    """Relate one parent to one child"""
+    parent_labels = numpy.ones((10, 10), int)
+    child_labels = numpy.zeros((10, 10), int)
+    child_labels[3:5, 4:7] = 1
+    workspace, module = make_workspace(parent_labels, child_labels)
+    module.wants_per_parent_means.value = False
+    module.run(workspace)
+    m = workspace.measurements
+    parents_of = m.get_current_measurement(
+        CHILD_OBJECTS, "Parent_%s" % PARENT_OBJECTS
+    )
+    assert(numpy.product(parents_of.shape) == 1)
+    assert(parents_of[0] == 1)
+    child_count = m.get_current_measurement(
+        PARENT_OBJECTS, "Children_%s_Count" % CHILD_OBJECTS
+    )
+    assert(numpy.product(child_count.shape) == 1)
+    assert(child_count[0] == 1)
+    features_and_columns_match(workspace)
 
-    def test_02_02_relate_wrong_size(self):
-        """Regression test of IMG-961
+def test_02_02_relate_wrong_size():
+    """Regression test of IMG-961
 
-        Perhaps someone is trying to relate cells to wells and the grid
-        doesn't completely cover the labels matrix.
-        """
-        parent_labels = numpy.ones((20, 10), int)
-        parent_labels[10:, :] = 0
-        child_labels = numpy.zeros((10, 20), int)
-        child_labels[3:5, 4:7] = 1
-        workspace, module = self.make_workspace(parent_labels, child_labels)
-        module.wants_per_parent_means.value = False
-        module.run(workspace)
-        m = workspace.measurements
-        parents_of = m.get_current_measurement(
-            CHILD_OBJECTS, "Parent_%s" % PARENT_OBJECTS
-        )
-        self.assertEqual(numpy.product(parents_of.shape), 1)
-        self.assertEqual(parents_of[0], 1)
-        child_count = m.get_current_measurement(
-            PARENT_OBJECTS, "Children_%s_Count" % CHILD_OBJECTS
-        )
-        self.assertEqual(numpy.product(child_count.shape), 1)
-        self.assertEqual(child_count[0], 1)
-        self.features_and_columns_match(workspace)
+    Perhaps someone is trying to relate cells to wells and the grid
+    doesn't completely cover the labels matrix.
+    """
+    parent_labels = numpy.ones((20, 10), int)
+    parent_labels[10:, :] = 0
+    child_labels = numpy.zeros((10, 20), int)
+    child_labels[3:5, 4:7] = 1
+    workspace, module = make_workspace(parent_labels, child_labels)
+    module.wants_per_parent_means.value = False
+    module.run(workspace)
+    m = workspace.measurements
+    parents_of = m.get_current_measurement(
+        CHILD_OBJECTS, "Parent_%s" % PARENT_OBJECTS
+    )
+    assert(numpy.product(parents_of.shape) == 1)
+    assert(parents_of[0] == 1)
+    child_count = m.get_current_measurement(
+        PARENT_OBJECTS, "Children_%s_Count" % CHILD_OBJECTS
+    )
+    assert(numpy.product(child_count.shape) == 1)
+    assert(child_count[0] == 1)
+    features_and_columns_match(workspace)
 
-    def test_02_03_relate_ijv(self):
-        """Regression test of IMG-1317: relating objects in ijv form"""
+def test_02_03_relate_ijv():
+    """Regression test of IMG-1317: relating objects in ijv form"""
 
-        child_ijv = numpy.array([[5, 5, 1], [5, 6, 2], [20, 15, 3]])
-        parent_ijv = numpy.array([[5, 5, 1], [5, 6, 1], [20, 15, 2]])
-        workspace, module = self.make_workspace(parent_ijv, child_ijv)
-        module.wants_per_parent_means.value = False
-        module.run(workspace)
-        m = workspace.measurements
-        parents_of = m.get_current_measurement(
-            CHILD_OBJECTS, "Parent_%s" % PARENT_OBJECTS
-        )
-        self.assertEqual(numpy.product(parents_of.shape), 3)
-        self.assertTrue(parents_of[0], 1)
-        self.assertEqual(parents_of[1], 1)
-        self.assertEqual(parents_of[2], 2)
-        child_count = m.get_current_measurement(
-            PARENT_OBJECTS, "Children_%s_Count" % CHILD_OBJECTS
-        )
-        self.assertEqual(numpy.product(child_count.shape), 2)
-        self.assertEqual(child_count[0], 2)
-        self.assertEqual(child_count[1], 1)
+    child_ijv = numpy.array([[5, 5, 1], [5, 6, 2], [20, 15, 3]])
+    parent_ijv = numpy.array([[5, 5, 1], [5, 6, 1], [20, 15, 2]])
+    workspace, module = make_workspace(parent_ijv, child_ijv)
+    module.wants_per_parent_means.value = False
+    module.run(workspace)
+    m = workspace.measurements
+    parents_of = m.get_current_measurement(
+        CHILD_OBJECTS, "Parent_%s" % PARENT_OBJECTS
+    )
+    assert(numpy.product(parents_of.shape) == 3)
+    assert(parents_of[0] == 1)
+    assert(parents_of[1] == 1)
+    assert(parents_of[2] == 2)
+    child_count = m.get_current_measurement(
+        PARENT_OBJECTS, "Children_%s_Count" % CHILD_OBJECTS
+    )
+    assert(numpy.product(child_count.shape) == 2)
+    assert(child_count[0] == 2)
+    assert(child_count[1] == 1)
 
-    def test_03_01_mean(self):
-        """Compute the mean for two parents and four children"""
-        i, j = numpy.mgrid[0:20, 0:20]
-        parent_labels = (i / 10 + 1).astype(int)
-        child_labels = (i / 10).astype(int) + (j / 10).astype(int) * 2 + 1
-        workspace, module = self.make_workspace(
-            parent_labels, child_labels, fake_measurement=True
-        )
-        module.wants_per_parent_means.value = True
-        m = workspace.measurements
-        self.assertTrue(isinstance(m,cellprofiler_core.measurement.Measurements))
-        m.add_measurement(CHILD_OBJECTS, MEASUREMENT, numpy.array([1.0, 2.0, 3.0, 4.0]))
-        m.add_measurement(CHILD_OBJECTS, IGNORED_MEASUREMENT, numpy.array([1, 2, 3, 4]))
-        expected = numpy.array([2.0, 3.0])
-        module.run(workspace)
-        name = "Mean_%s_%s" % (CHILD_OBJECTS, MEASUREMENT)
-        self.assertTrue(name in m.get_feature_names(PARENT_OBJECTS))
-        data = m.get_current_measurement(PARENT_OBJECTS, name)
-        self.assertTrue(numpy.all(data == expected))
-        self.features_and_columns_match(workspace)
-        name = "Mean_%s_%s" % (CHILD_OBJECTS, IGNORED_MEASUREMENT)
-        self.assertFalse(name in m.get_feature_names(PARENT_OBJECTS))
+def test_03_01_mean():
+    """Compute the mean for two parents and four children"""
+    i, j = numpy.mgrid[0:20, 0:20]
+    parent_labels = (i / 10 + 1).astype(int)
+    child_labels = (i / 10).astype(int) + (j / 10).astype(int) * 2 + 1
+    workspace, module = make_workspace(
+        parent_labels, child_labels, fake_measurement=True
+    )
+    module.wants_per_parent_means.value = True
+    m = workspace.measurements
+    assert(isinstance(m,cellprofiler_core.measurement.Measurements))
+    m.add_measurement(CHILD_OBJECTS, MEASUREMENT, numpy.array([1.0, 2.0, 3.0, 4.0]))
+    m.add_measurement(CHILD_OBJECTS, IGNORED_MEASUREMENT, numpy.array([1, 2, 3, 4]))
+    expected = numpy.array([2.0, 3.0])
+    module.run(workspace)
+    name = "Mean_%s_%s" % (CHILD_OBJECTS, MEASUREMENT)
+    assert(name in m.get_feature_names(PARENT_OBJECTS))
+    data = m.get_current_measurement(PARENT_OBJECTS, name)
+    assert(numpy.all(data == expected))
+    features_and_columns_match(workspace)
+    name = "Mean_%s_%s" % (CHILD_OBJECTS, IGNORED_MEASUREMENT)
+    assert(name not in m.get_feature_names(PARENT_OBJECTS))
 
-    def test_03_02_empty_mean(self):
-        # Regression test - if there are no children, the per-parent means
-        #                   should still be populated
-        i, j = numpy.mgrid[0:20, 0:20]
-        parent_labels = (i / 10 + 1).astype(int)
-        child_labels = numpy.zeros(parent_labels.shape, int)
-        workspace, module = self.make_workspace(
-            parent_labels, child_labels, fake_measurement=True
-        )
-        module.wants_per_parent_means.value = True
-        m = workspace.measurements
-        self.assertTrue(isinstance(m,cellprofiler_core.measurement.Measurements))
-        m.add_measurement(CHILD_OBJECTS, MEASUREMENT, numpy.zeros(0))
-        m.add_measurement(CHILD_OBJECTS, IGNORED_MEASUREMENT, numpy.zeros(0, int))
-        module.run(workspace)
-        name = "Mean_%s_%s" % (CHILD_OBJECTS, MEASUREMENT)
-        self.assertTrue(name in m.get_feature_names(PARENT_OBJECTS))
-        data = m.get_current_measurement(PARENT_OBJECTS, name)
-        self.assertTrue(numpy.all(numpy.isnan(data)))
-        self.features_and_columns_match(workspace)
-        name = "Mean_%s_%s" % (CHILD_OBJECTS, IGNORED_MEASUREMENT)
-        self.assertFalse(name in m.get_feature_names(PARENT_OBJECTS))
+def test_03_02_empty_mean():
+    # Regression test - if there are no children, the per-parent means
+    #                   should still be populated
+    i, j = numpy.mgrid[0:20, 0:20]
+    parent_labels = (i / 10 + 1).astype(int)
+    child_labels = numpy.zeros(parent_labels.shape, int)
+    workspace, module = make_workspace(
+        parent_labels, child_labels, fake_measurement=True
+    )
+    module.wants_per_parent_means.value = True
+    m = workspace.measurements
+    assert(isinstance(m,cellprofiler_core.measurement.Measurements))
+    m.add_measurement(CHILD_OBJECTS, MEASUREMENT, numpy.zeros(0))
+    m.add_measurement(CHILD_OBJECTS, IGNORED_MEASUREMENT, numpy.zeros(0, int))
+    module.run(workspace)
+    name = "Mean_%s_%s" % (CHILD_OBJECTS, MEASUREMENT)
+    assert(name in m.get_feature_names(PARENT_OBJECTS))
+    data = m.get_current_measurement(PARENT_OBJECTS, name)
+    assert(numpy.all(numpy.isnan(data)))
+    features_and_columns_match(workspace)
+    name = "Mean_%s_%s" % (CHILD_OBJECTS, IGNORED_MEASUREMENT)
+    assert(name not in m.get_feature_names(PARENT_OBJECTS))
 
-    def test_04_00_distance_empty(self):
-        """Make sure we can handle labels matrices that are all zero"""
-        empty_labels = numpy.zeros((10, 20), int)
-        some_labels = numpy.zeros((10, 20), int)
-        some_labels[2:7, 3:8] = 1
-        some_labels[3:8, 12:17] = 2
-        for parent_labels, child_labels, n in (
-            (empty_labels, empty_labels, 0),
-            (some_labels, empty_labels, 0),
-            (empty_labels, some_labels, 2),
-        ):
-            workspace, module = self.make_workspace(parent_labels, child_labels)
-            self.assertTrue(
-                isinstance(module, cellprofiler.modules.relateobjects.Relate)
-            )
-            module.find_parent_child_distances.value = (
-                cellprofiler.modules.relateobjects.D_BOTH
-            )
-            module.run(workspace)
-            self.features_and_columns_match(workspace)
-            meas = workspace.measurements
-            for feature in (
-                cellprofiler.modules.relateobjects.FF_CENTROID,
-                cellprofiler.modules.relateobjects.FF_MINIMUM,
-            ):
-                m = feature % PARENT_OBJECTS
-                v = meas.get_current_measurement(CHILD_OBJECTS, m)
-                self.assertEqual(len(v), n)
-                if n > 0:
-                    self.assertTrue(numpy.all(numpy.isnan(v)))
-
-    def test_04_01_distance_centroids(self):
-        """Check centroid-centroid distance calculation"""
-        i, j = numpy.mgrid[0:14, 0:30]
-        parent_labels = (i >= 7) * 1 + (j >= 15) * 2 + 1
-        # Centers should be at i=3 and j=7
-        parent_centers = numpy.array([[3, 7], [10, 7], [3, 22], [10, 22]], float)
-        child_labels = numpy.zeros(i.shape)
-        numpy.random.seed(0)
-        # Take 12 random points and label them
-        child_centers = numpy.random.permutation(numpy.prod(i.shape))[:12]
-        child_centers = numpy.vstack(
-            (i.flatten()[child_centers], j.flatten()[child_centers])
+def test_04_00_distance_empty():
+    """Make sure we can handle labels matrices that are all zero"""
+    empty_labels = numpy.zeros((10, 20), int)
+    some_labels = numpy.zeros((10, 20), int)
+    some_labels[2:7, 3:8] = 1
+    some_labels[3:8, 12:17] = 2
+    for parent_labels, child_labels, n in (
+        (empty_labels, empty_labels, 0),
+        (some_labels, empty_labels, 0),
+        (empty_labels, some_labels, 2),
+    ):
+        workspace, module = make_workspace(parent_labels, child_labels)
+        assert(
+            isinstance(module, cellprofiler.modules.relateobjects.Relate)
         )
-        child_labels[child_centers[0], child_centers[1]] = numpy.arange(1, 13)
-        parent_indexes = parent_labels[child_centers[0], child_centers[1]] - 1
-        expected = numpy.sqrt(
-            numpy.sum(
-                (parent_centers[parent_indexes, :] - child_centers.transpose()) ** 2, 1
-            )
-        )
-
-        workspace, module = self.make_workspace(parent_labels, child_labels)
-        self.assertTrue(isinstance(module, cellprofiler.modules.relateobjects.Relate))
         module.find_parent_child_distances.value = (
             cellprofiler.modules.relateobjects.D_BOTH
         )
         module.run(workspace)
-        self.features_and_columns_match(workspace)
+        features_and_columns_match(workspace)
         meas = workspace.measurements
-        v = meas.get_current_measurement(
-            CHILD_OBJECTS,
-            cellprofiler.modules.relateobjects.FF_CENTROID % PARENT_OBJECTS,
+        for feature in (
+            cellprofiler.modules.relateobjects.FF_CENTROID,
+            cellprofiler.modules.relateobjects.FF_MINIMUM,
+        ):
+            m = feature % PARENT_OBJECTS
+            v = meas.get_current_measurement(CHILD_OBJECTS, m)
+            assert(len(v) == n)
+            if n > 0:
+                assert(numpy.all(numpy.isnan(v)))
+
+def test_04_01_distance_centroids():
+    """Check centroid-centroid distance calculation"""
+    i, j = numpy.mgrid[0:14, 0:30]
+    parent_labels = (i >= 7) * 1 + (j >= 15) * 2 + 1
+    # Centers should be at i=3 and j=7
+    parent_centers = numpy.array([[3, 7], [10, 7], [3, 22], [10, 22]], float)
+    child_labels = numpy.zeros(i.shape)
+    numpy.random.seed(0)
+    # Take 12 random points and label them
+    child_centers = numpy.random.permutation(numpy.prod(i.shape))[:12]
+    child_centers = numpy.vstack(
+        (i.flatten()[child_centers], j.flatten()[child_centers])
+    )
+    child_labels[child_centers[0], child_centers[1]] = numpy.arange(1, 13)
+    parent_indexes = parent_labels[child_centers[0], child_centers[1]] - 1
+    expected = numpy.sqrt(
+        numpy.sum(
+            (parent_centers[parent_indexes, :] - child_centers.transpose()) ** 2, 1
         )
-        assert v.shape[0] == 12
-        assert numpy.all(numpy.abs(v - expected) < 0.0001)
+    )
 
-    def test_distance_minima(self):
-        parents = numpy.zeros((11, 11), dtype=numpy.uint8)
+    workspace, module = make_workspace(parent_labels, child_labels)
+    assert(isinstance(module, cellprofiler.modules.relateobjects.Relate))
+    module.find_parent_child_distances.value = (
+        cellprofiler.modules.relateobjects.D_BOTH
+    )
+    module.run(workspace)
+    features_and_columns_match(workspace)
+    meas = workspace.measurements
+    v = meas.get_current_measurement(
+        CHILD_OBJECTS,
+        cellprofiler.modules.relateobjects.FF_CENTROID % PARENT_OBJECTS,
+    )
+    assert v.shape[0] == 12
+    assert numpy.all(numpy.abs(v - expected) < 0.0001)
 
-        children = numpy.zeros_like(parents)
+def test_distance_minima():
+    parents = numpy.zeros((11, 11), dtype=numpy.uint8)
 
-        parents[1:10, 1:10] = 1
+    children = numpy.zeros_like(parents)
 
-        children[2:3, 2:3] = 1
+    parents[1:10, 1:10] = 1
 
-        children[3:8, 3:8] = 2
+    children[2:3, 2:3] = 1
 
-        workspace, module = self.make_workspace(parents, children)
+    children[3:8, 3:8] = 2
 
-        module.find_parent_child_distances.value = (
-            cellprofiler.modules.relateobjects.D_MINIMUM
+    workspace, module = make_workspace(parents, children)
+
+    module.find_parent_child_distances.value = (
+        cellprofiler.modules.relateobjects.D_MINIMUM
+    )
+
+    module.run(workspace)
+
+    expected = [1, 4]
+
+    actual = workspace.measurements.get_current_measurement(
+        CHILD_OBJECTS,
+        cellprofiler.modules.relateobjects.FF_MINIMUM % PARENT_OBJECTS,
+    )
+
+    numpy.testing.assert_array_equal(actual, expected)
+
+def test_means_of_distances():
+    #
+    # Regression test of issue #1409
+    #
+    # Make sure means of minimum and mean distances of children
+    # are recorded properly
+    #
+    i, j = numpy.mgrid[0:14, 0:30]
+    #
+    # Make the objects different sizes to exercise more code
+    #
+    parent_labels = (i >= 7) * 1 + (j >= 15) * 2 + 1
+    child_labels = numpy.zeros(i.shape)
+    numpy.random.seed(0)
+    # Take 12 random points and label them
+    child_centers = numpy.random.permutation(numpy.prod(i.shape))[:12]
+    child_centers = numpy.vstack(
+        (i.flatten()[child_centers], j.flatten()[child_centers])
+    )
+    child_labels[child_centers[0], child_centers[1]] = numpy.arange(1, 13)
+    parent_centers = numpy.array([[3, 7], [10, 7], [3, 22], [10, 22]], float)
+    parent_indexes = parent_labels[child_centers[0], child_centers[1]] - 1
+    expected = numpy.sqrt(
+        numpy.sum(
+            (parent_centers[parent_indexes, :] - child_centers.transpose()) ** 2, 1
         )
+    )
 
-        module.run(workspace)
+    workspace, module = make_workspace(parent_labels, child_labels)
+    assert isinstance(module, cellprofiler.modules.relateobjects.Relate)
+    module.find_parent_child_distances.value = (
+        cellprofiler.modules.relateobjects.D_CENTROID
+    )
+    module.wants_per_parent_means.value = True
+    mnames = module.get_measurements(
+        workspace.pipeline,
+        PARENT_OBJECTS,
+        "_".join((cellprofiler.modules.relateobjects.C_MEAN, CHILD_OBJECTS)),
+    )
+    assert cellprofiler.modules.relateobjects.FF_CENTROID % PARENT_OBJECTS in mnames
+    feat_mean = cellprofiler.modules.relateobjects.FF_MEAN % (
+        CHILD_OBJECTS,
+        cellprofiler.modules.relateobjects.FF_CENTROID % PARENT_OBJECTS,
+    )
+    mcolumns = module.get_measurement_columns(workspace.pipeline)
+    assert any([c[0] == PARENT_OBJECTS and c[1] == feat_mean for c in mcolumns])
+    m = workspace.measurements
+    m[CHILD_OBJECTS, M_LOCATION_CENTER_X, 1] = child_centers[1]
+    m[CHILD_OBJECTS, M_LOCATION_CENTER_Y, 1] = child_centers[0]
+    module.run(workspace)
 
-        expected = [1, 4]
+    v = m[PARENT_OBJECTS, feat_mean, 1]
 
-        actual = workspace.measurements.get_current_measurement(
-            CHILD_OBJECTS,
-            cellprofiler.modules.relateobjects.FF_MINIMUM % PARENT_OBJECTS,
-        )
+    plabel = m[
+        CHILD_OBJECTS, "_".join((C_PARENT, PARENT_OBJECTS)), 1,
+    ]
 
-        numpy.testing.assert_array_equal(actual, expected)
-
-    def test_means_of_distances(self):
-        #
-        # Regression test of issue #1409
-        #
-        # Make sure means of minimum and mean distances of children
-        # are recorded properly
-        #
-        i, j = numpy.mgrid[0:14, 0:30]
-        #
-        # Make the objects different sizes to exercise more code
-        #
-        parent_labels = (i >= 7) * 1 + (j >= 15) * 2 + 1
-        child_labels = numpy.zeros(i.shape)
-        numpy.random.seed(0)
-        # Take 12 random points and label them
-        child_centers = numpy.random.permutation(numpy.prod(i.shape))[:12]
-        child_centers = numpy.vstack(
-            (i.flatten()[child_centers], j.flatten()[child_centers])
-        )
-        child_labels[child_centers[0], child_centers[1]] = numpy.arange(1, 13)
-        parent_centers = numpy.array([[3, 7], [10, 7], [3, 22], [10, 22]], float)
-        parent_indexes = parent_labels[child_centers[0], child_centers[1]] - 1
-        expected = numpy.sqrt(
-            numpy.sum(
-                (parent_centers[parent_indexes, :] - child_centers.transpose()) ** 2, 1
+    assert len(v) == 4
+    for idx in range(4):
+        if numpy.any(plabel == idx + 1):
+            assert (
+                round(abs(v[idx] - numpy.mean(expected[plabel == idx + 1])), 4) == 0
             )
-        )
 
-        workspace, module = self.make_workspace(parent_labels, child_labels)
-        assert isinstance(module, cellprofiler.modules.relateobjects.Relate)
-        module.find_parent_child_distances.value = (
-            cellprofiler.modules.relateobjects.D_CENTROID
-        )
-        module.wants_per_parent_means.value = True
-        mnames = module.get_measurements(
-            workspace.pipeline,
-            PARENT_OBJECTS,
-            "_".join((cellprofiler.modules.relateobjects.C_MEAN, CHILD_OBJECTS)),
-        )
-        assert cellprofiler.modules.relateobjects.FF_CENTROID % PARENT_OBJECTS in mnames
-        feat_mean = cellprofiler.modules.relateobjects.FF_MEAN % (
-            CHILD_OBJECTS,
-            cellprofiler.modules.relateobjects.FF_CENTROID % PARENT_OBJECTS,
-        )
-        mcolumns = module.get_measurement_columns(workspace.pipeline)
-        assert any([c[0] == PARENT_OBJECTS and c[1] == feat_mean for c in mcolumns])
-        m = workspace.measurements
-        m[CHILD_OBJECTS, M_LOCATION_CENTER_X, 1] = child_centers[1]
-        m[CHILD_OBJECTS, M_LOCATION_CENTER_Y, 1] = child_centers[0]
-        module.run(workspace)
+def test_calculate_centroid_distances_volume():
+    parents = numpy.zeros((9, 11, 11), dtype=numpy.uint8)
 
-        v = m[PARENT_OBJECTS, feat_mean, 1]
+    children = numpy.zeros_like(parents)
 
-        plabel = m[
-            CHILD_OBJECTS, "_".join((C_PARENT, PARENT_OBJECTS)), 1,
-        ]
+    k, i, j = numpy.mgrid[0:9, 0:11, 0:11]
 
-        assert len(v) == 4
-        for idx in range(4):
-            if numpy.any(plabel == idx + 1):
-                assert (
-                    round(abs(v[idx] - numpy.mean(expected[plabel == idx + 1])), 4) == 0
-                )
+    parents[(k - 4) ** 2 + (i - 5) ** 2 + (j - 5) ** 2 <= 16] = 1
 
-    def test_calculate_centroid_distances_volume(self):
-        parents = numpy.zeros((9, 11, 11), dtype=numpy.uint8)
+    children[(k - 3) ** 2 + (i - 3) ** 2 + (j - 3) ** 2 <= 4] = 1
 
-        children = numpy.zeros_like(parents)
+    children[(k - 4) ** 2 + (i - 7) ** 2 + (j - 7) ** 2 <= 4] = 2
 
-        k, i, j = numpy.mgrid[0:9, 0:11, 0:11]
+    workspace, module = make_workspace(parents, children)
 
-        parents[(k - 4) ** 2 + (i - 5) ** 2 + (j - 5) ** 2 <= 16] = 1
+    module.find_parent_child_distances.value = (
+        cellprofiler.modules.relateobjects.D_CENTROID
+    )
 
-        children[(k - 3) ** 2 + (i - 3) ** 2 + (j - 3) ** 2 <= 4] = 1
+    module.run(workspace)
 
-        children[(k - 4) ** 2 + (i - 7) ** 2 + (j - 7) ** 2 <= 4] = 2
+    expected = [3, numpy.sqrt(8)]
 
-        workspace, module = self.make_workspace(parents, children)
+    actual = workspace.measurements.get_current_measurement(
+        CHILD_OBJECTS,
+        cellprofiler.modules.relateobjects.FF_CENTROID % PARENT_OBJECTS,
+    )
 
-        module.find_parent_child_distances.value = (
-            cellprofiler.modules.relateobjects.D_CENTROID
-        )
+    numpy.testing.assert_array_equal(actual, expected)
 
-        module.run(workspace)
+def test_calculate_minimum_distances_volume():
+    parents = numpy.zeros((9, 11, 11), dtype=numpy.uint8)
 
-        expected = [3, numpy.sqrt(8)]
+    children = numpy.zeros_like(parents)
 
-        actual = workspace.measurements.get_current_measurement(
-            CHILD_OBJECTS,
-            cellprofiler.modules.relateobjects.FF_CENTROID % PARENT_OBJECTS,
-        )
+    parents[1:8, 1:10, 1:10] = 1
 
-        numpy.testing.assert_array_equal(actual, expected)
+    children[3:6, 2:3, 2:3] = 1
 
-    def test_calculate_minimum_distances_volume(self):
-        parents = numpy.zeros((9, 11, 11), dtype=numpy.uint8)
+    children[4:7, 3:8, 3:8] = 2
 
-        children = numpy.zeros_like(parents)
+    workspace, module = make_workspace(parents, children)
 
-        parents[1:8, 1:10, 1:10] = 1
+    module.find_parent_child_distances.value = (
+        cellprofiler.modules.relateobjects.D_MINIMUM
+    )
 
-        children[3:6, 2:3, 2:3] = 1
+    module.run(workspace)
 
-        children[4:7, 3:8, 3:8] = 2
+    expected = [1, 2]
 
-        workspace, module = self.make_workspace(parents, children)
+    actual = workspace.measurements.get_current_measurement(
+        CHILD_OBJECTS,
+        cellprofiler.modules.relateobjects.FF_MINIMUM % PARENT_OBJECTS,
+    )
 
-        module.find_parent_child_distances.value = (
-            cellprofiler.modules.relateobjects.D_MINIMUM
-        )
+    numpy.testing.assert_array_equal(actual, expected)
 
-        module.run(workspace)
+def test_relate_zeros_with_step_parent():
+    # https://github.com/CellProfiler/CellProfiler/issues/2441
+    parents = numpy.zeros((10, 10), dtype=numpy.uint8)
 
-        expected = [1, 2]
+    children = numpy.zeros_like(parents)
 
-        actual = workspace.measurements.get_current_measurement(
-            CHILD_OBJECTS,
-            cellprofiler.modules.relateobjects.FF_MINIMUM % PARENT_OBJECTS,
-        )
+    step_parents = numpy.zeros_like(parents)
 
-        numpy.testing.assert_array_equal(actual, expected)
+    step_parents_object = cellprofiler_core.object.Objects()
 
-    def test_relate_zeros_with_step_parent(self):
-        # https://github.com/CellProfiler/CellProfiler/issues/2441
-        parents = numpy.zeros((10, 10), dtype=numpy.uint8)
+    step_parents_object.segmented = step_parents
 
-        children = numpy.zeros_like(parents)
+    workspace, module = make_workspace(parents, children)
 
-        step_parents = numpy.zeros_like(parents)
+    workspace.measurements.add_measurement("Step", FF_PARENT % PARENT_OBJECTS, [])
 
-        step_parents_object = cellprofiler_core.object.Objects()
+    module.step_parent_names[0].step_parent_name.value = "Step"
 
-        step_parents_object.segmented = step_parents
+    workspace.object_set.add_objects(step_parents_object, "Step")
 
-        workspace, module = self.make_workspace(parents, children)
+    module.wants_step_parent_distances.value = True
 
-        workspace.measurements.add_measurement("Step", FF_PARENT % PARENT_OBJECTS, [])
+    module.find_parent_child_distances.value = (
+        cellprofiler.modules.relateobjects.D_MINIMUM
+    )
 
-        module.step_parent_names[0].step_parent_name.value = "Step"
+    module.run(workspace)
 
-        workspace.object_set.add_objects(step_parents_object, "Step")
+    expected = []
 
-        module.wants_step_parent_distances.value = True
+    actual = workspace.measurements.get_current_measurement(
+        CHILD_OBJECTS, cellprofiler.modules.relateobjects.FF_MINIMUM % "Step"
+    )
+    numpy.testing.assert_array_equal(actual, expected)
 
-        module.find_parent_child_distances.value = (
-            cellprofiler.modules.relateobjects.D_MINIMUM
-        )
+def test_relate_and_make_new_objects():
+    """Relate one parent to one child, but save children as a new set"""
+    parent_labels = numpy.ones((10, 10), int)
+    child_labels = numpy.zeros((10, 10), int)
+    child_labels[3:5, 4:7] = 1
+    workspace, module = make_workspace(parent_labels, child_labels)
+    module.wants_child_objects_saved.value = True
+    module.output_child_objects_name.value = "outputobjects"
+    module.wants_per_parent_means.value = False
+    module.run(workspace)
+    m = workspace.measurements
+    parents_of = m.get_current_measurement(
+        CHILD_OBJECTS, "Parent_%s" % PARENT_OBJECTS
+    )
+    assert(numpy.product(parents_of.shape )== 1)
+    assert(parents_of[0] == 1)
+    child_count = m.get_current_measurement(
+        PARENT_OBJECTS, "Children_%s_Count" % CHILD_OBJECTS
+    )
+    assert(numpy.product(child_count.shape) == 1)
+    assert(child_count[0] == 1)
+    features_and_columns_match(workspace)
 
-        module.run(workspace)
+@pytest.fixture(scope="function")
+def init_parent_and_child():
+    parent = numpy.zeros((20, 20), int)
+    child = numpy.zeros((20, 20), int)
+    return parent, child
 
-        expected = []
 
-        actual = workspace.measurements.get_current_measurement(
-            CHILD_OBJECTS, cellprofiler.modules.relateobjects.FF_MINIMUM % "Step"
-        )
-        numpy.testing.assert_array_equal(actual, expected)
+@pytest.fixture(scope="function")
+def parent_has_extra_objects_top(init_parent_and_child):
+    parent, child = init_parent_and_child
+    parent = parent.copy() # needed to avoid mutating the fixture
+    child = child.copy() # needed to avoid mutating the fixture
+    parent[1:5, 1:5] = 1
+    parent[1:5, 6:10] = 2
+    parent[1:5, 11:15] = 3
+    parent[1:5, 16:20] = 4
 
-    def test_relate_and_make_new_objects(self):
-        """Relate one parent to one child, but save children as a new set"""
-        parent_labels = numpy.ones((10, 10), int)
-        child_labels = numpy.zeros((10, 10), int)
-        child_labels[3:5, 4:7] = 1
-        workspace, module = self.make_workspace(parent_labels, child_labels)
-        module.wants_child_objects_saved.value = True
-        module.output_child_objects_name.value = "outputobjects"
-        module.wants_per_parent_means.value = False
-        module.run(workspace)
-        m = workspace.measurements
-        parents_of = m.get_current_measurement(
-            CHILD_OBJECTS, "Parent_%s" % PARENT_OBJECTS
-        )
-        self.assertEqual(numpy.product(parents_of.shape), 1)
-        self.assertEqual(parents_of[0], 1)
-        child_count = m.get_current_measurement(
-            PARENT_OBJECTS, "Children_%s_Count" % CHILD_OBJECTS
-        )
-        self.assertEqual(numpy.product(child_count.shape), 1)
-        self.assertEqual(child_count[0], 1)
-        self.features_and_columns_match(workspace)
+    parent[6:10, 1:5] = 5
+    parent[6:10, 6:10] = 6
+    parent[6:10, 11:15] = 7
+    parent[6:10, 16:20] = 8
+
+    child[6:10, 1:5] = 1
+    child[6:10, 6:10] = 2
+    child[6:10, 11:15] = 3
+    child[6:10, 16:20] = 4
+
+    expected_child = numpy.zeros(child.shape, int)
+    expected_child[6:10, 1:5] = 1
+    expected_child[6:10, 6:10] = 2
+    expected_child[6:10, 11:15] = 3
+    expected_child[6:10, 16:20] = 4
+
+    return (parent, child), expected_child
+
+@pytest.fixture(scope="function")
+def parent_has_extra_objects_bottom(init_parent_and_child):
+    parent, child = init_parent_and_child
+    parent = parent.copy() # needed to avoid mutating the fixture
+    child = child.copy() # needed to avoid mutating the fixture
+    parent[1:5, 1:5] = 1
+    parent[1:5, 6:10] = 2
+    parent[1:5, 11:15] = 3
+    parent[1:5, 16:20] = 4
+
+    parent[6:10, 1:5] = 5
+    parent[6:10, 6:10] = 6
+    parent[6:10, 11:15] = 7
+    parent[6:10, 16:20] = 8
+
+    child[1:5, 1:5] = 1
+    child[1:5, 6:10] = 2
+    child[1:5, 11:15] = 3
+    child[1:5, 16:20] = 4
+
+    return (parent, child), child
+
+@pytest.fixture(scope="function")
+def child_has_extra_objects_top(init_parent_and_child):
+    parent, child = init_parent_and_child
+    parent = parent.copy() # needed to avoid mutating the fixture
+    child = child.copy()
+
+    parent[6:10, 1:5] = 1
+    parent[6:10, 6:10] = 2
+    parent[6:10, 11:15] = 3
+    parent[6:10, 16:20] = 4
+
+    child[1:5, 1:5] = 1
+    child[1:5, 6:10] = 2
+    child[1:5, 11:15] = 3
+    child[1:5, 16:20] = 4
+
+    child[6:10, 1:5] = 5
+    child[6:10, 6:10] = 6
+    child[6:10, 11:15] = 7
+    child[6:10, 16:20] = 8
+
+    expected_child = numpy.zeros(child.shape, int)
+    expected_child[6:10, 1:5] = 1
+    expected_child[6:10, 6:10] = 2
+    expected_child[6:10, 11:15] = 3
+    expected_child[6:10, 16:20] = 4
+
+    return (parent, child), expected_child
+
+@pytest.fixture(scope="function")
+def child_has_extra_objects_bottom(init_parent_and_child):
+    parent, child = init_parent_and_child
+    parent = parent.copy() # needed to avoid mutating the fixture
+    child = child.copy()
+
+    parent[1:5, 1:5] = 1
+    parent[1:5, 6:10] = 2
+    parent[1:5, 16:20] = 3
+
+    child[1:5, 1:5] = 1
+    child[1:5, 6:10] = 2
+    child[1:5, 11:15] = 3
+    child[1:5, 16:20] = 4
+
+    child[6:10, 1:5] = 5
+    child[6:10, 6:10] = 6
+    child[6:10, 11:15] = 7
+    child[6:10, 16:20] = 8
+
+    expected_child = numpy.zeros(child.shape, int)
+    expected_child[1:5, 1:5] = 1
+    expected_child[1:5, 6:10] = 2
+    expected_child[1:5, 16:20] = 3
+
+    return (parent, child), expected_child
+
+@pytest.fixture(scope="function")
+def two_parents_overlap_one_child(init_parent_and_child):
+    parent, child = init_parent_and_child
+    parent = parent.copy() # needed to avoid mutating the fixture
+    child = child.copy()
+
+    parent[1:5, 1:5] = 1
+    parent[1:5, 6:10] = 2
+
+    child[1:5, 2:10] = 1
+
+    expected_child = numpy.zeros(child.shape, int)
+    expected_child[1:5, 2:10] = 1
+
+    return (parent, child), expected_child
+
+@pytest.fixture(scope="function")
+def two_children_overlap_one_parent(init_parent_and_child):
+    parent, child = init_parent_and_child
+    parent = parent.copy() # needed to avoid mutating the fixture
+    child = child.copy()
+
+    parent[1:5, 1:10] = 1
+
+    child[1:5, 1:5] = 1
+    child[1:5, 6:10] = 2
+
+    expected_child = numpy.zeros(child.shape, int)
+    expected_child[1:5, 1:5] = 1
+    expected_child[1:5, 6:10] = 2
+
+    return (parent, child), expected_child
+
+
+@pytest.fixture
+def edge_case_fixtures(
+    parent_has_extra_objects_top,
+    parent_has_extra_objects_bottom,
+    child_has_extra_objects_top,
+    child_has_extra_objects_bottom,
+    two_parents_overlap_one_child,
+    two_children_overlap_one_parent
+    ):
+    return {
+        'parent_has_extra_objects_top': parent_has_extra_objects_top,
+        'parent_has_extra_objects_bottom': parent_has_extra_objects_bottom,
+        'child_has_extra_objects_top': child_has_extra_objects_top,
+        'child_has_extra_objects_bottom': child_has_extra_objects_bottom,
+        'two_parents_overlap_one_child': two_parents_overlap_one_child,
+        'two_children_overlap_one_parent': two_children_overlap_one_parent
+    }
+
+@pytest.mark.parametrize(
+        'fixture_name', 
+        [
+            'parent_has_extra_objects_top', 
+            'parent_has_extra_objects_bottom',
+            'child_has_extra_objects_top',
+            'child_has_extra_objects_bottom',
+            'two_parents_overlap_one_child',
+            'two_children_overlap_one_parent'
+            ])
+def test_run_missing_objects(edge_case_fixtures, fixture_name):
+    (edge_case_parent, edge_case_child), expected_child = edge_case_fixtures[fixture_name]
+    workspace, module = make_workspace(edge_case_parent, edge_case_child)
+    module.wants_child_objects_saved.value = True
+    module.output_child_objects_name.value = "outputobjects"
+    module.wants_per_parent_means.value = False
+    module.run(workspace)
+
+    output_child = workspace.object_set.get_objects("outputobjects")
+
+    assert(numpy.all(output_child.segmented == expected_child))
+
+ 
+


### PR DESCRIPTION
Bug:
FilterObjects did not respect parent-child relationship when filtering.

Changes:
1. Introduced a new setting to allow keeping/removing unassociated child objects.
2. Updated logic to utilize parent object number from measurements (if available) to determine which child objects to keep
3. Added new tests to capture the bug