### PR TITLE
Fix Nix build

### DIFF
--- a/nix/cellprofiler_library.nix
+++ b/nix/cellprofiler_library.nix
@@ -13,6 +13,7 @@
   mahotas,
   scikit-image,
   scipy,
+  pydantic,
   packaging,
   cp_version,
   python3Packages,
@@ -52,6 +53,7 @@ buildPythonPackage rec {
     mahotas
     centrosome
     matplotlib
+    pydantic
     packaging
   ];
 


### PR DESCRIPTION
The Nix package is currently failing to build, and throws an error saying that `pydantic is not installed`.
So I added pydantic to nix definitions dependency list (`cellprofiler_library.nix`).