### PR TITLE
[AI Code]: Refactor `measuretexture` to library

### DIFF
--- a/src/frontend/cellprofiler/modules/measuretexture.py
+++ b/src/frontend/cellprofiler/modules/measuretexture.py
@@ -154,10 +154,7 @@ References
     }
 )
 
-import mahotas.features
 import numpy
-import skimage.exposure
-import skimage.measure
 import skimage.util
 from cellprofiler_core.constants.measurement import COLTYPE_FLOAT
 from cellprofiler_core.module import Module
@@ -175,8 +172,8 @@ from cellprofiler_core.setting.subscriber import (
 )
 from cellprofiler_core.setting.text import Integer
 from cellprofiler_core.utilities.core.object import size_similarly
-from cellprofiler_library.opts.measuretexture import HaralickFeatures, MeasurementTarget, TEXTURE, F_HARALICK
-
+from cellprofiler_library.opts.measuretexture import MeasurementTarget, TEXTURE, F_HARALICK
+from cellprofiler_library.modules._measuretexture import measure_image_texture, measure_object_texture
 
 class MeasureTexture(Module):
     module_name = "MeasureTexture"
@@ -527,6 +524,52 @@ measured and will result in a undefined value in the output file.
             col_labels=workspace.display_data.col_labels,
             title=helptext,
         )
+    # def measure_object_texture(
+    #         self, 
+    #         object_name, 
+    #         labels,
+    #         image_name, 
+    #         pixel_data,
+    #         mask, 
+    #         gray_levels, 
+    #         unique_labels, # objects.indices
+    #         scale, 
+    #         volumetric,
+    #     ):
+    #     statistics = []
+    #     n_directions = 13 if volumetric else 4
+    #     if mask is not None:
+    #         pixel_data[~mask] = 0
+    #     # mahotas.features.haralick bricks itself when provided a dtype larger than uint8 (version 1.4.3)
+    #     pixel_data = skimage.util.img_as_ubyte(pixel_data)
+    #     if gray_levels != 256:
+    #         pixel_data = skimage.exposure.rescale_intensity(
+    #             pixel_data, in_range=(0, 255), out_range=(0, gray_levels - 1)
+    #         ).astype(numpy.uint8)
+    #     props = skimage.measure.regionprops(labels, pixel_data)
+    #     features = numpy.empty((n_directions, 13, max(unique_labels)))
+
+    #     for prop in props:
+    #         label_data = prop["intensity_image"]
+    #         try:
+    #             features[:, :, prop.label-1] = mahotas.features.haralick(
+    #                 label_data, distance=scale, ignore_zeros=True
+    #             )
+    #         except ValueError:
+    #             features[:, :, prop.label-1] = numpy.nan
+
+    #     for direction, direction_features in enumerate(features):
+    #         for feature_name, feature in zip(F_HARALICK, direction_features):
+
+    #             statistics.append({
+    #                 "image": image_name,
+    #                 "feature": feature_name.value,
+    #                 "obj": object_name,
+    #                 "result": feature,
+    #                 "scale": "{:d}_{:02d}".format(scale, direction),
+    #                 "gray_levels": "{:d}".format(gray_levels),
+    #             })
+    #     return statistics
 
     def run_one(self, image_name, object_name, scale, workspace):
         statistics = []
@@ -557,7 +600,7 @@ measured and will result in a undefined value in the output file.
 
             return statistics
 
-        # IMG-961: Ensure image and objects have the same shape.
+        # # IMG-961: Ensure image and objects have the same shape.
         try:
             mask = (
                 image.mask
@@ -575,67 +618,54 @@ measured and will result in a undefined value in the output file.
                 else:
                     mask = m1
 
-        pixel_data[~mask] = 0
-        # mahotas.features.haralick bricks itself when provided a dtype larger than uint8 (version 1.4.3)
-        pixel_data = skimage.util.img_as_ubyte(pixel_data)
-        if gray_levels != 256:
-            pixel_data = skimage.exposure.rescale_intensity(
-                pixel_data, in_range=(0, 255), out_range=(0, gray_levels - 1)
-            ).astype(numpy.uint8)
-        props = skimage.measure.regionprops(labels, pixel_data)
-        features = numpy.empty((n_directions, 13, max(unique_labels)))
-
-        for prop in props:
-            label_data = prop["intensity_image"]
-            try:
-                features[:, :, prop.label-1] = mahotas.features.haralick(
-                    label_data, distance=scale, ignore_zeros=True
-                )
-            except ValueError:
-                features[:, :, prop.label-1] = numpy.nan
-
-        for direction, direction_features in enumerate(features):
-            for feature_name, feature in zip(F_HARALICK, direction_features):
-                statistics += self.record_measurement(
-                    image=image_name,
-                    feature=feature_name.value,
-                    obj=object_name,
-                    result=feature,
-                    scale="{:d}_{:02d}".format(scale, direction),
-                    workspace=workspace,
-                    gray_levels="{:d}".format(gray_levels),
-                )
+        _statistics = measure_object_texture(
+            object_name, 
+            labels,
+            image_name, 
+            pixel_data,
+            mask if image.has_mask else None,
+            gray_levels, 
+            unique_labels, 
+            scale, 
+            objects.volumetric,
+        )
+        statistics = []
+        for i in _statistics:
+            statistics += self.record_measurement(**i, workspace=workspace)
 
         return statistics
+    # def measure_image_texture(self, pixel_data, gray_levels, scale, image_name):
+    #     if gray_levels != 256:
+    #         pixel_data = skimage.exposure.rescale_intensity(
+    #             pixel_data, in_range=(0, 255), out_range=(0, gray_levels - 1)
+    #         ).astype(numpy.uint8)
+
+    #     # mahotas.features.haralick bricks itself when provided a dtype larger than uint8 (version 1.4.3)
+    #     features = mahotas.features.haralick(pixel_data, distance=scale)
+    #     statistics = []
+    #     for direction, direction_features in enumerate(features):
+    #         object_name = "{:d}_{:02d}".format(scale, direction)
+
+    #         for feature_name, feature in zip(F_HARALICK, direction_features):
+    #             statistics.append({
+    #                 "feature_name": feature_name.value,
+    #                 "image_name": image_name,
+    #                 "result": feature,
+    #                 "scale": object_name,
+    #                 "gray_levels": "{:d}".format(gray_levels),
+    #             })
+    #     return statistics
 
     def run_image(self, image_name, scale, workspace):
-        statistics = []
-
         image = workspace.image_set.get_image(image_name, must_be_grayscale=True)
 
-        # mahotas.features.haralick bricks itself when provided a dtype larger than uint8 (version 1.4.3)
         gray_levels = int(self.gray_levels.value)
-        pixel_data = skimage.util.img_as_ubyte(image.pixel_data)
-        if gray_levels != 256:
-            pixel_data = skimage.exposure.rescale_intensity(
-                pixel_data, in_range=(0, 255), out_range=(0, gray_levels - 1)
-            ).astype(numpy.uint8)
+        pixel_data = image.pixel_data
 
-        features = mahotas.features.haralick(pixel_data, distance=scale)
-
-        for direction, direction_features in enumerate(features):
-            object_name = "{:d}_{:02d}".format(scale, direction)
-
-            for feature_name, feature in zip(F_HARALICK, direction_features):
-                statistics += self.record_image_measurement(
-                    feature_name=feature_name.value,
-                    image_name=image_name,
-                    result=feature,
-                    scale=object_name,
-                    workspace=workspace,
-                    gray_levels="{:d}".format(gray_levels),
-                )
-
+        _statistics = measure_image_texture(pixel_data, gray_levels, scale, image_name)
+        statistics = []
+        for i in _statistics:
+            statistics += self.record_image_measurement(**i, workspace=workspace)
         return statistics
 
     def record_measurement(

--- a/src/frontend/cellprofiler/modules/measuretexture.py
+++ b/src/frontend/cellprofiler/modules/measuretexture.py
@@ -155,7 +155,6 @@ References
 )
 
 import numpy
-import skimage.util
 from cellprofiler_core.constants.measurement import COLTYPE_FLOAT
 from cellprofiler_core.module import Module
 from cellprofiler_core.setting import (
@@ -524,52 +523,6 @@ measured and will result in a undefined value in the output file.
             col_labels=workspace.display_data.col_labels,
             title=helptext,
         )
-    # def measure_object_texture(
-    #         self, 
-    #         object_name, 
-    #         labels,
-    #         image_name, 
-    #         pixel_data,
-    #         mask, 
-    #         gray_levels, 
-    #         unique_labels, # objects.indices
-    #         scale, 
-    #         volumetric,
-    #     ):
-    #     statistics = []
-    #     n_directions = 13 if volumetric else 4
-    #     if mask is not None:
-    #         pixel_data[~mask] = 0
-    #     # mahotas.features.haralick bricks itself when provided a dtype larger than uint8 (version 1.4.3)
-    #     pixel_data = skimage.util.img_as_ubyte(pixel_data)
-    #     if gray_levels != 256:
-    #         pixel_data = skimage.exposure.rescale_intensity(
-    #             pixel_data, in_range=(0, 255), out_range=(0, gray_levels - 1)
-    #         ).astype(numpy.uint8)
-    #     props = skimage.measure.regionprops(labels, pixel_data)
-    #     features = numpy.empty((n_directions, 13, max(unique_labels)))
-
-    #     for prop in props:
-    #         label_data = prop["intensity_image"]
-    #         try:
-    #             features[:, :, prop.label-1] = mahotas.features.haralick(
-    #                 label_data, distance=scale, ignore_zeros=True
-    #             )
-    #         except ValueError:
-    #             features[:, :, prop.label-1] = numpy.nan
-
-    #     for direction, direction_features in enumerate(features):
-    #         for feature_name, feature in zip(F_HARALICK, direction_features):
-
-    #             statistics.append({
-    #                 "image": image_name,
-    #                 "feature": feature_name.value,
-    #                 "obj": object_name,
-    #                 "result": feature,
-    #                 "scale": "{:d}_{:02d}".format(scale, direction),
-    #                 "gray_levels": "{:d}".format(gray_levels),
-    #             })
-    #     return statistics
 
     def run_one(self, image_name, object_name, scale, workspace):
         statistics = []
@@ -634,27 +587,7 @@ measured and will result in a undefined value in the output file.
             statistics += self.record_measurement(**i, workspace=workspace)
 
         return statistics
-    # def measure_image_texture(self, pixel_data, gray_levels, scale, image_name):
-    #     if gray_levels != 256:
-    #         pixel_data = skimage.exposure.rescale_intensity(
-    #             pixel_data, in_range=(0, 255), out_range=(0, gray_levels - 1)
-    #         ).astype(numpy.uint8)
-
-    #     # mahotas.features.haralick bricks itself when provided a dtype larger than uint8 (version 1.4.3)
-    #     features = mahotas.features.haralick(pixel_data, distance=scale)
-    #     statistics = []
-    #     for direction, direction_features in enumerate(features):
-    #         object_name = "{:d}_{:02d}".format(scale, direction)
-
-    #         for feature_name, feature in zip(F_HARALICK, direction_features):
-    #             statistics.append({
-    #                 "feature_name": feature_name.value,
-    #                 "image_name": image_name,
-    #                 "result": feature,
-    #                 "scale": object_name,
-    #                 "gray_levels": "{:d}".format(gray_levels),
-    #             })
-    #     return statistics
+    
 
     def run_image(self, image_name, scale, workspace):
         image = workspace.image_set.get_image(image_name, must_be_grayscale=True)

--- a/src/frontend/cellprofiler/modules/measuretexture.py
+++ b/src/frontend/cellprofiler/modules/measuretexture.py
@@ -175,16 +175,7 @@ from cellprofiler_core.setting.subscriber import (
 )
 from cellprofiler_core.setting.text import Integer
 from cellprofiler_core.utilities.core.object import size_similarly
-
-TEXTURE = "Texture"
-
-F_HARALICK = """AngularSecondMoment Contrast Correlation Variance
-InverseDifferenceMoment SumAverage SumVariance SumEntropy Entropy
-DifferenceVariance DifferenceEntropy InfoMeas1 InfoMeas2""".split()
-
-IO_IMAGES = "Images"
-IO_OBJECTS = "Objects"
-IO_BOTH = "Both"
+from cellprofiler_library.opts.measuretexture import HaralickFeatures, MeasurementTarget, TEXTURE, F_HARALICK
 
 
 class MeasureTexture(Module):
@@ -259,8 +250,8 @@ class MeasureTexture(Module):
 
         self.images_or_objects = Choice(
             "Measure whole images or objects?",
-            [IO_IMAGES, IO_OBJECTS, IO_BOTH],
-            value=IO_BOTH,
+            [MeasurementTarget.IMAGES.value, MeasurementTarget.OBJECTS.value, MeasurementTarget.BOTH.value],
+            value=MeasurementTarget.BOTH.value,
             doc="""\
 This setting determines whether the module computes image-wide
 measurements, per-object measurements or both.
@@ -271,7 +262,7 @@ measurements, per-object measurements or both.
    on a per-object basis only.
 -  *{IO_BOTH}:* Select to make both image and object measurements.
 """.format(
-                **{"IO_IMAGES": IO_IMAGES, "IO_OBJECTS": IO_OBJECTS, "IO_BOTH": IO_BOTH}
+                **{"IO_IMAGES": MeasurementTarget.IMAGES.value, "IO_OBJECTS": MeasurementTarget.OBJECTS.value, "IO_BOTH": MeasurementTarget.BOTH.value}
             ),
         )
 
@@ -320,10 +311,10 @@ measurements, per-object measurements or both.
         return visible_settings
 
     def wants_image_measurements(self):
-        return self.images_or_objects in (IO_IMAGES, IO_BOTH)
+        return self.images_or_objects in (MeasurementTarget.IMAGES.value, MeasurementTarget.BOTH.value)
 
     def wants_object_measurements(self):
-        return self.images_or_objects in (IO_OBJECTS, IO_BOTH)
+        return self.images_or_objects in (MeasurementTarget.OBJECTS.value, MeasurementTarget.BOTH.value)
 
     def add_scale(self, removable=True):
         """
@@ -409,7 +400,7 @@ measured and will result in a undefined value in the output file.
         return []
 
     def get_features(self):
-        return F_HARALICK
+        return [i.value for i in F_HARALICK]
 
     def get_measurements(self, pipeline, object_name, category):
         if category in self.get_categories(pipeline, object_name):
@@ -556,7 +547,7 @@ measured and will result in a undefined value in the output file.
                 for feature_name in F_HARALICK:
                     statistics += self.record_measurement(
                         image=image_name,
-                        feature=feature_name,
+                        feature=feature_name.value,
                         obj=object_name,
                         result=numpy.zeros((0,)),
                         scale="{:d}_{:02d}".format(scale, direction),
@@ -607,7 +598,7 @@ measured and will result in a undefined value in the output file.
             for feature_name, feature in zip(F_HARALICK, direction_features):
                 statistics += self.record_measurement(
                     image=image_name,
-                    feature=feature_name,
+                    feature=feature_name.value,
                     obj=object_name,
                     result=feature,
                     scale="{:d}_{:02d}".format(scale, direction),
@@ -637,7 +628,7 @@ measured and will result in a undefined value in the output file.
 
             for feature_name, feature in zip(F_HARALICK, direction_features):
                 statistics += self.record_image_measurement(
-                    feature_name=feature_name,
+                    feature_name=feature_name.value,
                     image_name=image_name,
                     result=feature,
                     scale=object_name,
@@ -740,7 +731,7 @@ measured and will result in a undefined value in the output file.
             #
             # Added image / objects choice
             #
-            setting_values = setting_values + [IO_BOTH]
+            setting_values = setting_values + [MeasurementTarget.BOTH.value]
 
             variable_revision_number = 4
 

--- a/src/frontend/cellprofiler/modules/measuretexture.py
+++ b/src/frontend/cellprofiler/modules/measuretexture.py
@@ -1,5 +1,4 @@
 import cellprofiler.gui.help.content
-import cellprofiler.icons
 
 __doc__ = """\
 MeasureTexture
@@ -172,7 +171,7 @@ from cellprofiler_core.setting.subscriber import (
 from cellprofiler_core.setting.text import Integer
 from cellprofiler_core.utilities.core.object import size_similarly
 from cellprofiler_library.opts.measuretexture import MeasurementTarget, TEXTURE, F_HARALICK
-from cellprofiler_library.modules._measuretexture import measure_image_texture, measure_object_texture
+from cellprofiler_library.modules._measuretexture import MeasureTextureStatistics, measure_image_texture, measure_object_texture
 
 class MeasureTexture(Module):
     module_name = "MeasureTexture"
@@ -492,19 +491,19 @@ measured and will result in a undefined value in the output file.
             "Value",
         ]
 
-        statistics = []
+        statistics: MeasureTextureStatistics = []
 
         for image_name in self.images_list.value:
             for scale_group in self.scale_groups:
                 scale = scale_group.scale.value
 
                 if self.wants_image_measurements():
-                    statistics += self.run_image(image_name, scale, workspace)
+                    statistics += self.run_image(image_name, scale, workspace, self.show_window)
 
                 if self.wants_object_measurements():
                     for object_name in self.objects_list.value:
                         statistics += self.run_one(
-                            image_name, object_name, scale, workspace
+                            image_name, object_name, scale, workspace, self.show_window
                         )
 
         if self.show_window:
@@ -524,21 +523,13 @@ measured and will result in a undefined value in the output file.
             title=helptext,
         )
 
-    def run_one(self, image_name, object_name, scale, workspace):
-        statistics = []
-
+    def run_one(self, image_name, object_name, scale, workspace, calculate_statistics=False) -> MeasureTextureStatistics:
         image = workspace.image_set.get_image(image_name, must_be_grayscale=True)
 
         objects = workspace.get_objects(object_name)
         labels = objects.segmented
 
-        gray_levels = int(self.gray_levels.value)
-
-        unique_labels = objects.indices
-
-        n_directions = 13 if objects.volumetric else 4
-
-        # # IMG-961: Ensure image and objects have the same shape.
+        # IMG-961: Ensure image and objects have the same shape.
         try:
             mask = (
                 image.mask
@@ -556,99 +547,63 @@ measured and will result in a undefined value in the output file.
                 else:
                     mask = m1
 
-        measurements = measure_object_texture(
+        res = measure_object_texture(
             object_name, 
             labels,
             image_name, 
             pixel_data,
             mask if image.has_mask else None,
-            gray_levels, 
-            unique_labels, 
+            int(self.gray_levels.value),
+            objects.indices,
             scale, 
             objects.volumetric,
+            return_visualization_data=calculate_statistics
         )
+
+        if calculate_statistics:
+            lib_measurements, lib_display = res
+            lib_stats = lib_display.statistics
+        else:
+            lib_measurements = res
+            lib_stats: MeasureTextureStatistics = []
         
         # Unpack measurements
-        for feature_name, value in measurements.image.items():
+        for feature_name, value in lib_measurements.image.items():
             workspace.measurements.add_image_measurement(feature_name, value)
             
-        for obj, features in measurements.objects.items():
+        for obj, features in lib_measurements.objects.items():
             for feature_name, val in features.items():
                 workspace.add_measurement(obj, feature_name, val)
         
-        # Build statistics for display
-        for direction in range(n_directions):
-            scale_str = "{:d}_{:02d}".format(scale, direction)
-            gray_str = "{:d}".format(gray_levels)
-            for feature_enum in F_HARALICK:
-                feature_name = feature_enum.value
-                full_name = "{}_{}_{}_{}_{}".format(
-                    TEXTURE, feature_name, image_name, scale_str, gray_str
-                )
-                
-                # Check if we have values (we might check the object measurement itself)
-                vals = measurements.get_measurement(object_name, full_name)
-                
-                stats_map = {
-                    "Mean": "mean",
-                    "Median": "median",
-                    "Min": "min",
-                    "Max": "max",
-                    "StDev": "std dev"
-                }
-
-                for stat_key, display_name in stats_map.items():
-                    stat_full_name = f"{stat_key}_{full_name}"
-                    stat_val = measurements.image.get(stat_full_name, 0.0)
-
-                    statistics.append([
-                        image_name,
-                        object_name,
-                        "{} {}".format(display_name, feature_name),
-                        scale_str,
-                        "{:.2f}".format(float(stat_val)) if vals is not None and len(vals) > 0 else "-"
-                    ])
-
-        return statistics
+        return lib_stats
     
 
-    def run_image(self, image_name, scale, workspace):
+    def run_image(self, image_name, scale, workspace, calculate_statistics=False):
         image = workspace.image_set.get_image(image_name, must_be_grayscale=True)
 
         gray_levels = int(self.gray_levels.value)
         pixel_data = image.pixel_data
 
-        measurements = measure_image_texture(pixel_data, gray_levels, scale, image_name)
+        res = measure_image_texture(
+            pixel_data,
+            gray_levels,
+            scale,
+            image_name,
+            return_visualization_data=calculate_statistics
+        )
+
+        if calculate_statistics:
+            lib_measurements, lib_display = res
+            lib_stats = lib_display.statistics
+        else:
+            lib_measurements = res
+            lib_stats: MeasureTextureStatistics = []
         
         # Unpack measurements
-        for feature_name, value in measurements.image.items():
+        for feature_name, value in lib_measurements.image.items():
             workspace.measurements.add_image_measurement(feature_name, value)
             
-        statistics = []
-        
-        n_directions = 13 if pixel_data.ndim == 3 else 4
-        
-        for direction in range(n_directions):
-            scale_str = "{:d}_{:02d}".format(scale, direction)
-            gray_str = "{:d}".format(gray_levels)
-            for feature_enum in F_HARALICK:
-                feature_name = feature_enum.value
-                full_name = "{}_{}_{}_{}_{}".format(
-                    TEXTURE, feature_name, image_name, scale_str, gray_str
-                )
-                
-                # Retrieve from LibraryMeasurements
-                val = measurements.image.get(full_name, 0.0)
-                
-                statistics.append([
-                    image_name,
-                    "-",
-                    feature_name,
-                    scale_str,
-                    "{:.2f}".format(float(val))
-                ])
-                
-        return statistics
+        return lib_stats
 
     def upgrade_settings(self, setting_values, variable_revision_number, module_name):
         if variable_revision_number == 1:

--- a/src/subpackages/core/cellprofiler_core/image/_image.py
+++ b/src/subpackages/core/cellprofiler_core/image/_image.py
@@ -1,7 +1,6 @@
-import math
 import numpy
 
-from cellprofiler_library.functions.image_processing import crop_image_similarly
+from cellprofiler_library.functions.image_processing import crop_image_similarly as _crop_image_similarly 
 
 class Image:
     """
@@ -231,7 +230,7 @@ class Image:
         """
         m = numpy.array(mask)
 
-        if not (m.dtype.type is bool):
+        if (m.dtype.type is not bool):
             m = m != 0
 
         self.__mask = m
@@ -287,7 +286,7 @@ class Image:
 
         image - a np.ndarray to be cropped (of any type)
         """
-        return crop_image_similarly(self.pixel_data, image, self.crop_mask)
+        return _crop_image_similarly(self.pixel_data, image, self.crop_mask)
 
     @property
     def file_name(self):

--- a/src/subpackages/library/cellprofiler_library/functions/measurement.py
+++ b/src/subpackages/library/cellprofiler_library/functions/measurement.py
@@ -41,9 +41,6 @@ from cellprofiler_library.opts.measureobjectoverlap import DecimationMethod as O
 from cellprofiler_library.opts.measureobjectskeleton import VF_I, VF_J, VF_LABELS, VF_KIND, EF_V1, EF_V2, EF_LENGTH, EF_TOTAL_INTENSITY
 from cellprofiler_library.opts.measureobjectneighbors import DistanceMethod as NeighborsDistanceMethod
 from cellprofiler_library.opts.measureobjectneighbors import MeasurementScale as NeighborsMeasurementScale
-from cellprofiler_library.opts.measureobjectintensitydistribution import CenterChoice, IntensityZernike, FullFeature
-from cellprofiler_library.opts.measureobjectintensitydistribution import M_CATEGORY as ObjectIntensityDistribution_M_CATEGORY
-from cellprofiler_library.opts.measuretexture import F_HARALICK
 
 ###############################################################################
 # MeasureImageOverlap

--- a/src/subpackages/library/cellprofiler_library/functions/measurement.py
+++ b/src/subpackages/library/cellprofiler_library/functions/measurement.py
@@ -3913,14 +3913,11 @@ def compute_radial_cv_for_bin(
 ###############################################################################
 
 
-def get_image_texture_measurements(
-        pixel_data: ImageGrayscale, 
-        gray_levels: int, 
-        scale: int, 
-        image_name: str
-    ) -> List[
-        Dict[str, Union[str, numpy.float_]]
-    ]:
+def measure_haralick_features_image(
+    pixel_data: ImageGrayscale, 
+    gray_levels: int, 
+    scale: int
+) -> NDArray[numpy.float64]:
     pixel_data = skimage.util.img_as_ubyte(pixel_data)
     if gray_levels != 256:
         pixel_data = skimage.exposure.rescale_intensity(
@@ -3928,34 +3925,19 @@ def get_image_texture_measurements(
         ).astype(numpy.uint8)
 
     # mahotas.features.haralick bricks itself when provided a dtype larger than uint8 (version 1.4.3)
-    features = mahotas.features.haralick(pixel_data, distance=scale)
-    statistics = []
-    for direction, direction_features in enumerate(features):
-        object_name = "{:d}_{:02d}".format(scale, direction)
-
-        for feature_name, feature in zip(F_HARALICK, direction_features):
-            statistics.append({
-                "feature_name": feature_name.value,
-                "image_name": image_name,
-                "result": feature,
-                "scale": object_name,
-                "gray_levels": "{:d}".format(gray_levels),
-            })
-    return statistics
+    # Returns (n_directions, 13)
+    return mahotas.features.haralick(pixel_data, distance=scale)
 
 
-def get_object_texture_measurements(
-        object_name: str, 
-        labels: ObjectSegmentation,
-        image_name: str,
-        pixel_data: ImageGrayscale,
-        mask: Optional[ImageGrayscaleMask],
-        gray_levels: int, 
-        unique_labels: NDArray[ObjectLabel], # objects.indices
-        scale: int, 
-        volumetric: bool,
-    ):
-    statistics = []
+def measure_haralick_features_objects(
+    labels: ObjectSegmentation,
+    pixel_data: ImageGrayscale,
+    mask: Optional[ImageGrayscaleMask],
+    gray_levels: int, 
+    max_label: int,
+    scale: int, 
+    volumetric: bool,
+) -> NDArray[numpy.float64]:
     n_directions = 13 if volumetric else 4
     if mask is not None:
         pixel_data[~mask] = 0
@@ -3966,26 +3948,24 @@ def get_object_texture_measurements(
             pixel_data, in_range=(0, 255), out_range=(0, gray_levels - 1)
         ).astype(numpy.uint8)
     props = skimage.measure.regionprops(labels, pixel_data)
-    features = numpy.empty((n_directions, 13, max(unique_labels)))
+    
+    # Shape: (max_label, n_directions, 13)
+    # We use max_label so that result[i] corresponds to label i+1
+    features = numpy.full((max_label, n_directions, 13), numpy.nan)
 
     for prop in props:
         label_data = prop["intensity_image"]
         try:
-            features[:, :, prop.label-1] = mahotas.features.haralick(
+            # mahotas.features.haralick returns (n_directions, 13)
+            # ignore_zeros=True is important for masked objects
+            res = mahotas.features.haralick(
                 label_data, distance=scale, ignore_zeros=True
             )
+            # If the object is too small or something, mahotas might return something else?
+            # Assuming it returns correct shape if successful.
+            features[prop.label-1, :, :] = res
         except ValueError:
-            features[:, :, prop.label-1] = numpy.nan
+            # Keep as NaN
+            pass
 
-    for direction, direction_features in enumerate(features):
-        for feature_name, feature in zip(F_HARALICK, direction_features):
-
-            statistics.append({
-                "image": image_name,
-                "feature": feature_name.value,
-                "obj": object_name,
-                "result": feature,
-                "scale": "{:d}_{:02d}".format(scale, direction),
-                "gray_levels": "{:d}".format(gray_levels),
-            })
-    return statistics
+    return features

--- a/src/subpackages/library/cellprofiler_library/functions/measurement.py
+++ b/src/subpackages/library/cellprofiler_library/functions/measurement.py
@@ -4,6 +4,9 @@ import scipy
 import scipy.ndimage
 import scipy.sparse
 import skimage
+import mahotas.features
+import skimage.exposure
+import skimage.measure
 import centrosome
 import centrosome.filter
 import centrosome.propagate
@@ -38,6 +41,9 @@ from cellprofiler_library.opts.measureobjectoverlap import DecimationMethod as O
 from cellprofiler_library.opts.measureobjectskeleton import VF_I, VF_J, VF_LABELS, VF_KIND, EF_V1, EF_V2, EF_LENGTH, EF_TOTAL_INTENSITY
 from cellprofiler_library.opts.measureobjectneighbors import DistanceMethod as NeighborsDistanceMethod
 from cellprofiler_library.opts.measureobjectneighbors import MeasurementScale as NeighborsMeasurementScale
+from cellprofiler_library.opts.measureobjectintensitydistribution import CenterChoice, IntensityZernike, FullFeature
+from cellprofiler_library.opts.measureobjectintensitydistribution import M_CATEGORY as ObjectIntensityDistribution_M_CATEGORY
+from cellprofiler_library.opts.measuretexture import F_HARALICK
 
 ###############################################################################
 # MeasureImageOverlap
@@ -3899,3 +3905,87 @@ def compute_radial_cv_for_bin(
     radial_cv[empty_object_mask] = 0
 
     return bin_mask, bin_labels, radial_cv, empty_object_mask
+
+
+
+###############################################################################
+# MeasureTexture
+###############################################################################
+
+
+def get_image_texture_measurements(
+        pixel_data: ImageGrayscale, 
+        gray_levels: int, 
+        scale: int, 
+        image_name: str
+    ) -> List[
+        Dict[str, Union[str, numpy.float_]]
+    ]:
+    pixel_data = skimage.util.img_as_ubyte(pixel_data)
+    if gray_levels != 256:
+        pixel_data = skimage.exposure.rescale_intensity(
+            pixel_data, in_range=(0, 255), out_range=(0, gray_levels - 1)
+        ).astype(numpy.uint8)
+
+    # mahotas.features.haralick bricks itself when provided a dtype larger than uint8 (version 1.4.3)
+    features = mahotas.features.haralick(pixel_data, distance=scale)
+    statistics = []
+    for direction, direction_features in enumerate(features):
+        object_name = "{:d}_{:02d}".format(scale, direction)
+
+        for feature_name, feature in zip(F_HARALICK, direction_features):
+            statistics.append({
+                "feature_name": feature_name.value,
+                "image_name": image_name,
+                "result": feature,
+                "scale": object_name,
+                "gray_levels": "{:d}".format(gray_levels),
+            })
+    return statistics
+
+
+def get_object_texture_measurements(
+        object_name: str, 
+        labels: ObjectSegmentation,
+        image_name: str,
+        pixel_data: ImageGrayscale,
+        mask: Optional[ImageGrayscaleMask],
+        gray_levels: int, 
+        unique_labels: NDArray[ObjectLabel], # objects.indices
+        scale: int, 
+        volumetric: bool,
+    ):
+    statistics = []
+    n_directions = 13 if volumetric else 4
+    if mask is not None:
+        pixel_data[~mask] = 0
+    # mahotas.features.haralick bricks itself when provided a dtype larger than uint8 (version 1.4.3)
+    pixel_data = skimage.util.img_as_ubyte(pixel_data)
+    if gray_levels != 256:
+        pixel_data = skimage.exposure.rescale_intensity(
+            pixel_data, in_range=(0, 255), out_range=(0, gray_levels - 1)
+        ).astype(numpy.uint8)
+    props = skimage.measure.regionprops(labels, pixel_data)
+    features = numpy.empty((n_directions, 13, max(unique_labels)))
+
+    for prop in props:
+        label_data = prop["intensity_image"]
+        try:
+            features[:, :, prop.label-1] = mahotas.features.haralick(
+                label_data, distance=scale, ignore_zeros=True
+            )
+        except ValueError:
+            features[:, :, prop.label-1] = numpy.nan
+
+    for direction, direction_features in enumerate(features):
+        for feature_name, feature in zip(F_HARALICK, direction_features):
+
+            statistics.append({
+                "image": image_name,
+                "feature": feature_name.value,
+                "obj": object_name,
+                "result": feature,
+                "scale": "{:d}_{:02d}".format(scale, direction),
+                "gray_levels": "{:d}".format(gray_levels),
+            })
+    return statistics

--- a/src/subpackages/library/cellprofiler_library/modules/_measuretexture.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_measuretexture.py
@@ -3,7 +3,8 @@ from numpy.typing import NDArray
 from typing import List, Dict, Union, Optional, Annotated
 from cellprofiler_library.types import ImageGrayscale, ImageGrayscaleMask, ObjectLabel, ObjectSegmentation
 from pydantic import validate_call, Field, ConfigDict
-from cellprofiler_library.functions.measurement import get_image_texture_measurements, get_object_texture_measurements
+from cellprofiler_library.functions.measurement import measure_haralick_features_image, measure_haralick_features_objects
+from cellprofiler_library.opts.measuretexture import F_HARALICK, TEXTURE
 
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
@@ -12,10 +13,21 @@ def measure_image_texture(
         gray_levels: Annotated[int, Field(description="Enter the number of gray levels (ie, total possible values of intensity) you want to measure texture at")], 
         scale: Annotated[int, Field(description="You can specify the scale of texture to be measured, in pixel units; the texture scale is the distance between correlated intensities in the image")], 
         image_name: Annotated[str, Field(description="Name to be assigned in measurements")]
-    ) -> List[
-        Dict[str, Union[str, numpy.float_]]
-    ]:
-    return get_image_texture_measurements(pixel_data, gray_levels, scale, image_name)
+    ) -> Dict:
+    
+    raw_data = measure_haralick_features_image(pixel_data, gray_levels, scale)
+    image_measurements = {}
+    
+    for direction in range(raw_data.shape[0]):
+        scale_str = "{:d}_{:02d}".format(scale, direction)
+        gray_str = "{:d}".format(gray_levels)
+        
+        for feature_idx, feature_enum in enumerate(F_HARALICK):
+            feature_name = feature_enum.value
+            full_name = f"{TEXTURE}_{feature_name}_{image_name}_{scale_str}_{gray_str}"
+            image_measurements[full_name] = raw_data[direction, feature_idx]
+            
+    return {"Image": image_measurements}
 
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
@@ -29,6 +41,49 @@ def measure_object_texture(
         unique_labels: Annotated[NDArray[ObjectLabel], Field(description="The unique labels in the object segmentation prior to any masking")], # objects.indices
         scale: Annotated[int, Field(description="You can specify the scale of texture to be measured, in pixel units; the texture scale is the distance between correlated intensities in the image")], 
         volumetric: Annotated[bool, Field(description="Is the input image or objects 3D?")],
-    ):
-    return get_object_texture_measurements(object_name, labels, image_name, pixel_data, mask, gray_levels, unique_labels, scale, volumetric)
+    ) -> Dict:
+    
+    max_label = 0
+    if len(unique_labels) > 0:
+        max_label = int(numpy.max(unique_labels))
+        
+    raw_data = measure_haralick_features_objects(labels, pixel_data, mask, gray_levels, max_label, scale, volumetric)
+    
+    object_measurements = {}
+    image_stats = {}
+    
+    if raw_data.size > 0:
+        for direction in range(raw_data.shape[1]):
+            scale_str = "{:d}_{:02d}".format(scale, direction)
+            gray_str = "{:d}".format(gray_levels)
+            
+            for feature_idx, feature_enum in enumerate(F_HARALICK):
+                feature_name = feature_enum.value
+                full_name = f"{TEXTURE}_{feature_name}_{image_name}_{scale_str}_{gray_str}"
+                
+                values = raw_data[:, direction, feature_idx]
+                
+                if object_name not in object_measurements:
+                    object_measurements[object_name] = {}
+                object_measurements[object_name][full_name] = values
+                
+                valid_values = values[numpy.isfinite(values)]
+                
+                if len(valid_values) > 0:
+                    image_stats[f"Mean_{full_name}"] = numpy.mean(valid_values)
+                    image_stats[f"Median_{full_name}"] = numpy.median(valid_values)
+                    image_stats[f"Min_{full_name}"] = numpy.min(valid_values)
+                    image_stats[f"Max_{full_name}"] = numpy.max(valid_values)
+                    image_stats[f"StDev_{full_name}"] = numpy.std(valid_values)
+                else:
+                    image_stats[f"Mean_{full_name}"] = 0.0
+                    image_stats[f"Median_{full_name}"] = 0.0
+                    image_stats[f"Min_{full_name}"] = 0.0
+                    image_stats[f"Max_{full_name}"] = 0.0
+                    image_stats[f"StDev_{full_name}"] = 0.0
+
+    return {
+        "Image": image_stats,
+        "Object": object_measurements
+    }
     

--- a/src/subpackages/library/cellprofiler_library/modules/_measuretexture.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_measuretexture.py
@@ -1,0 +1,34 @@
+import numpy
+from numpy.typing import NDArray
+from typing import List, Dict, Union, Optional, Annotated
+from cellprofiler_library.types import ImageGrayscale, ImageGrayscaleMask, ObjectLabel, ObjectSegmentation
+from pydantic import validate_call, Field, ConfigDict
+from cellprofiler_library.functions.measurement import get_image_texture_measurements, get_object_texture_measurements
+
+
+@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
+def measure_image_texture(
+        pixel_data: Annotated[ImageGrayscale, Field(description="Input image to perform texture measurements on")],
+        gray_levels: Annotated[int, Field(description="Enter the number of gray levels (ie, total possible values of intensity) you want to measure texture at")], 
+        scale: Annotated[int, Field(description="You can specify the scale of texture to be measured, in pixel units; the texture scale is the distance between correlated intensities in the image")], 
+        image_name: Annotated[str, Field(description="Name to be assigned in measurements")]
+    ) -> List[
+        Dict[str, Union[str, numpy.float_]]
+    ]:
+    return get_image_texture_measurements(pixel_data, gray_levels, scale, image_name)
+
+
+@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
+def measure_object_texture(
+        object_name: Annotated[str, Field(description="Object name to be assigned in measurements")], 
+        labels: Annotated[ObjectSegmentation, Field(description="Segmentation labels for object")],
+        image_name: Annotated[str, Field(description="Name of the image to assign in measurements")],
+        pixel_data: Annotated[ImageGrayscale, Field(description="Image pixel data to measure texture on")],
+        mask: Annotated[Optional[ImageGrayscaleMask], Field(description="Image mask if any")],
+        gray_levels: Annotated[int, Field(description="Enter the number of gray levels (ie, total possible values of intensity) you want to measure texture at")], 
+        unique_labels: Annotated[NDArray[ObjectLabel], Field(description="The unique labels in the object segmentation prior to any masking")], # objects.indices
+        scale: Annotated[int, Field(description="You can specify the scale of texture to be measured, in pixel units; the texture scale is the distance between correlated intensities in the image")], 
+        volumetric: Annotated[bool, Field(description="Is the input image or objects 3D?")],
+    ):
+    return get_object_texture_measurements(object_name, labels, image_name, pixel_data, mask, gray_levels, unique_labels, scale, volumetric)
+    

--- a/src/subpackages/library/cellprofiler_library/modules/_measuretexture.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_measuretexture.py
@@ -1,37 +1,67 @@
 import numpy
 from numpy.typing import NDArray
-from typing import List, Dict, Union, Optional, Annotated
+from typing import List, Union, Optional, Annotated, Tuple
 from cellprofiler_library.types import ImageGrayscale, ImageGrayscaleMask, ObjectLabel, ObjectSegmentation
-from pydantic import validate_call, Field, ConfigDict
+from pydantic import validate_call, Field, ConfigDict, BaseModel
 from cellprofiler_library.functions.measurement import measure_haralick_features_image, measure_haralick_features_objects
 from cellprofiler_library.opts.measuretexture import F_HARALICK, TEXTURE
 from cellprofiler_library.measurement_model import LibraryMeasurements
 
+
+MeasureTextureStatistics = List[Tuple[
+    str, # iamge name
+    str, # object name
+    str, # feature name
+    str, # scale
+    str  # stat val
+]]
+
+class MeasureTextureDisplayData(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True, 
+        populate_by_name=True
+    )
+
+    statistics: MeasureTextureStatistics
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def measure_image_texture(
         pixel_data: Annotated[ImageGrayscale, Field(description="Input image to perform texture measurements on")],
         gray_levels: Annotated[int, Field(description="Enter the number of gray levels (ie, total possible values of intensity) you want to measure texture at")], 
         scale: Annotated[int, Field(description="You can specify the scale of texture to be measured, in pixel units; the texture scale is the distance between correlated intensities in the image")], 
-        image_name: Annotated[str, Field(description="Name to be assigned in measurements")]
-    ) -> LibraryMeasurements:
+        image_name: Annotated[str, Field(description="Name to be assigned in measurements")],
+        return_visualization_data: Annotated[bool, Field(description="Return data for display")] = False,
+    ) -> Union[LibraryMeasurements, Tuple[LibraryMeasurements, MeasureTextureDisplayData]]:
     
-    raw_data = measure_haralick_features_image(pixel_data, gray_levels, scale)
+    haralick_feats = measure_haralick_features_image(pixel_data, gray_levels, scale)
     measurements = LibraryMeasurements()
+    statistics: MeasureTextureStatistics = []
     
-    for direction in range(raw_data.shape[0]):
+    for direction in range(haralick_feats.shape[0]):
         scale_str = "{:d}_{:02d}".format(scale, direction)
         gray_str = "{:d}".format(gray_levels)
         
         for feature_idx, feature_enum in enumerate(F_HARALICK):
             feature_name = feature_enum.value
             full_name = f"{TEXTURE}_{feature_name}_{image_name}_{scale_str}_{gray_str}"
-            val = raw_data[direction, feature_idx]
+            val = haralick_feats[direction, feature_idx]
             if not numpy.isfinite(val):
                 val = 0.0
             measurements.add_image_measurement(full_name, val)
+
+            if return_visualization_data:
+                statistics.append((
+                    image_name,
+                    "-",
+                    f"{feature_name}",
+                    scale_str,
+                    "{:.2f}".format(float(val))
+                ))
             
-    return measurements
+    if return_visualization_data:
+        return measurements, MeasureTextureDisplayData(statistics=statistics)
+    else:
+        return measurements
 
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
@@ -45,20 +75,20 @@ def measure_object_texture(
         unique_labels: Annotated[NDArray[ObjectLabel], Field(description="The unique labels in the object segmentation prior to any masking")], # objects.indices
         scale: Annotated[int, Field(description="You can specify the scale of texture to be measured, in pixel units; the texture scale is the distance between correlated intensities in the image")], 
         volumetric: Annotated[bool, Field(description="Is the input image or objects 3D?")],
-    ) -> LibraryMeasurements:
+        return_visualization_data: Annotated[bool, Field(description="Return data for display")] = False,
+    ) -> Union[LibraryMeasurements, Tuple[LibraryMeasurements, MeasureTextureDisplayData]]:
     
     max_label = 0
     if len(unique_labels) > 0:
         max_label = int(numpy.max(unique_labels))
         
-    raw_data = measure_haralick_features_objects(labels, pixel_data, mask, gray_levels, max_label, scale, volumetric)
+    haralick_feats = measure_haralick_features_objects(labels, pixel_data, mask, gray_levels, max_label, scale, volumetric)
     
     measurements = LibraryMeasurements()
-    
-    n_directions = 13 if volumetric else 4
-    
-    if raw_data.size > 0:
-        for direction in range(raw_data.shape[1]):
+    statistics: MeasureTextureStatistics = []
+
+    if haralick_feats.size > 0:
+        for direction in range(haralick_feats.shape[1]):
             scale_str = "{:d}_{:02d}".format(scale, direction)
             gray_str = "{:d}".format(gray_levels)
             
@@ -66,7 +96,7 @@ def measure_object_texture(
                 feature_name = feature_enum.value
                 full_name = f"{TEXTURE}_{feature_name}_{image_name}_{scale_str}_{gray_str}"
                 
-                values = raw_data[:, direction, feature_idx]
+                values = haralick_feats[:, direction, feature_idx]
                 
                 # Calculate stats on valid (finite) values, mirroring original logic
                 valid_values = values[numpy.isfinite(values)]
@@ -77,22 +107,34 @@ def measure_object_texture(
                 
                 measurements.add_measurement(object_name, full_name, clean_values)
                 
-                stats_map = {
-                    "Mean": numpy.mean,
-                    "Median": numpy.median,
-                    "Min": numpy.min,
-                    "Max": numpy.max,
-                    "StDev": numpy.std
-                }
+                stats = [
+                    ("Mean", "mean", numpy.mean),
+                    ("Median", "median", numpy.median),
+                    ("Min", "min", numpy.min),
+                    ("Max", "max", numpy.max),
+                    ("StDev", "std dev", numpy.std),
+                ]
                 
                 if len(valid_values) > 0:
-                    for stat_name, func in stats_map.items():
-                        measurements.add_image_measurement(f"{stat_name}_{full_name}", func(valid_values))
+                    for stat_name, display_name, func in stats:
+                        stat_val = func(valid_values)
+                        measurements.add_image_measurement(f"{stat_name}_{full_name}", stat_val)
+
+                        if return_visualization_data:
+                            statistics.append((
+                                image_name,
+                                object_name,
+                                f"{display_name} {feature_name}",
+                                scale_str,
+                                f"{float(stat_val):.2f}" if len(clean_values) > 0 else "-",
+                            ))
                 else:
-                    for stat_name in stats_map.keys():
+                    for stat_name, _, _ in stats:
                         measurements.add_image_measurement(f"{stat_name}_{full_name}", 0.0)
     else:
         # Handle empty objects case
+        n_directions = 13 if volumetric else 4
+    
         for direction in range(n_directions):
             scale_str = "{:d}_{:02d}".format(scale, direction)
             gray_str = "{:d}".format(gray_levels)
@@ -107,5 +149,8 @@ def measure_object_texture(
                 for stat_name in stats_map_keys:
                     measurements.add_image_measurement(f"{stat_name}_{full_name}", 0.0)
 
-    return measurements
+    if return_visualization_data:
+        return measurements, MeasureTextureDisplayData(statistics=statistics)
+    else:
+        return measurements
     

--- a/src/subpackages/library/cellprofiler_library/opts/measuretexture.py
+++ b/src/subpackages/library/cellprofiler_library/opts/measuretexture.py
@@ -1,0 +1,24 @@
+from enum import Enum
+
+class HaralickFeatures(str, Enum):    
+    AngularSecondMoment = "AngularSecondMoment",
+    Contrast = "Contrast",
+    Correlation = "Correlation",
+    Variance = "Variance",
+    InverseDifferenceMoment = "InverseDifferenceMoment",
+    SumAverage = "SumAverage",
+    SumVariance = "SumVariance",
+    SumEntropy = "SumEntropy",
+    Entropy = "Entropy",
+    DifferenceVariance = "DifferenceVariance",
+    DifferenceEntropy = "DifferenceEntropy",
+    InfoMeas1 = "InfoMeas1",
+    InfoMeas2 = "InfoMeas2"
+
+class MeasurementTarget(str, Enum):
+    IMAGES = "Images",
+    OBJECTS = "Objects"
+    BOTH = "Both"
+    
+TEXTURE = "Texture"
+F_HARALICK = [i for i in HaralickFeatures]

--- a/tests/frontend/modules/test_measuretexture.py
+++ b/tests/frontend/modules/test_measuretexture.py
@@ -8,6 +8,7 @@ import cellprofiler.modules.measuretexture
 import cellprofiler_core.object
 import cellprofiler_core.pipeline
 import cellprofiler_core.workspace
+from cellprofiler_library.opts.measuretexture import HaralickFeatures, MeasurementTarget
 
 INPUT_IMAGE_NAME = "Cytoplasm"
 INPUT_OBJECTS_NAME = "inputobjects"
@@ -146,7 +147,7 @@ Number of angles to compute for Gabor:6
         assert len(module.scale_groups) == 2
         assert module.scale_groups[0].scale == 3
         assert module.scale_groups[1].scale == 5
-        assert module.images_or_objects == cellprofiler.modules.measuretexture.IO_BOTH
+        assert module.images_or_objects == MeasurementTarget.BOTH
 
 
 def test_load_v4():
@@ -213,11 +214,11 @@ Measure images or objects?:Both
     pipeline.add_listener(callback)
     pipeline.load(io.StringIO(data))
     assert len(pipeline.modules()) == 3
-    for i, (wants_gabor, io_choice) in enumerate(
+    for i, (wants_gabor, choice) in enumerate(
         (
-            (True, cellprofiler.modules.measuretexture.IO_IMAGES),
-            (False, cellprofiler.modules.measuretexture.IO_OBJECTS),
-            (False, cellprofiler.modules.measuretexture.IO_BOTH),
+            (True, MeasurementTarget.IMAGES),
+            (False, MeasurementTarget.OBJECTS),
+            (False, MeasurementTarget.BOTH),
         )
     ):
         module = pipeline.modules()[i]
@@ -271,24 +272,24 @@ def test_many_objects():
         ]
     )
     for measurement in cellprofiler.modules.measuretexture.F_HARALICK:
-        assert measurement in all_measurements
+        assert measurement.value in all_measurements
         assert INPUT_IMAGE_NAME in module.get_measurement_images(
             workspace.pipeline,
             INPUT_OBJECTS_NAME,
             cellprofiler.modules.measuretexture.TEXTURE,
-            measurement,
+            measurement.value,
         )
         all_scales = module.get_measurement_scales(
             workspace.pipeline,
             INPUT_OBJECTS_NAME,
             cellprofiler.modules.measuretexture.TEXTURE,
-            measurement,
+            measurement.value,
             INPUT_IMAGE_NAME,
         )
         for angle in range(4):
             mname = "{}_{}_{}_{:d}_{:02d}_{:d}".format(
                 cellprofiler.modules.measuretexture.TEXTURE,
-                measurement,
+                measurement.value,
                 INPUT_IMAGE_NAME,
                 2,
                 angle,
@@ -337,14 +338,14 @@ def test_categories():
             assert categories[0] == cellprofiler.modules.measuretexture.TEXTURE
         else:
             assert len(categories) == 0
-    module.images_or_objects.value = cellprofiler.modules.measuretexture.IO_IMAGES
+    module.images_or_objects.value = MeasurementTarget.IMAGES
     categories = module.get_categories(
         workspace.pipeline, "Image"
     )
     assert len(categories) == 1
     categories = module.get_categories(workspace.pipeline, INPUT_OBJECTS_NAME)
     assert len(categories) == 0
-    module.images_or_objects.value = cellprofiler.modules.measuretexture.IO_OBJECTS
+    module.images_or_objects.value = MeasurementTarget.OBJECTS
     categories = module.get_categories(
         workspace.pipeline, "Image"
     )
@@ -363,10 +364,10 @@ def test_measurements():
             workspace.pipeline, object_name, cellprofiler.modules.measuretexture.TEXTURE
         )
         assert all(
-            [f in cellprofiler.modules.measuretexture.F_HARALICK for f in features]
+            [HaralickFeatures(f) in cellprofiler.modules.measuretexture.F_HARALICK for f in features]
         )
         assert all(
-            [f in features for f in cellprofiler.modules.measuretexture.F_HARALICK]
+            [f.value in features for f in cellprofiler.modules.measuretexture.F_HARALICK]
         )
 
 
@@ -426,7 +427,7 @@ def test_no_image_measurements():
     labels = numpy.ones((10, 10), int)
     workspace, module = make_workspace(image, labels)
     assert isinstance(module, cellprofiler.modules.measuretexture.MeasureTexture)
-    module.images_or_objects.value = cellprofiler.modules.measuretexture.IO_OBJECTS
+    module.images_or_objects.value = MeasurementTarget.OBJECTS
     module.scale_groups[0].scale.value = 2
     module.run(workspace)
     m = workspace.measurements
@@ -444,7 +445,7 @@ def test_no_object_measurements():
     labels = numpy.ones((10, 10), int)
     workspace, module = make_workspace(image, labels)
     assert isinstance(module, cellprofiler.modules.measuretexture.MeasureTexture)
-    module.images_or_objects.value = cellprofiler.modules.measuretexture.IO_IMAGES
+    module.images_or_objects.value = MeasurementTarget.IMAGES
     module.scale_groups[0].scale.value = 2
     module.run(workspace)
     m = workspace.measurements
@@ -484,7 +485,7 @@ def test_volume_image_measurements():
 
     workspace, module = make_workspace(image, labels)
 
-    module.images_or_objects.value = cellprofiler.modules.measuretexture.IO_IMAGES
+    module.images_or_objects.value = MeasurementTarget.IMAGES
 
     module.scale_groups[0].scale.value = 2
 
@@ -508,7 +509,7 @@ def test_volume_object_measurements_no_objects():
 
     workspace, module = make_workspace(image, labels)
 
-    module.images_or_objects.value = cellprofiler.modules.measuretexture.IO_OBJECTS
+    module.images_or_objects.value = MeasurementTarget.OBJECTS
 
     module.scale_groups[0].scale.value = 2
 
@@ -533,7 +534,7 @@ def test_volume_object_measurements():
 
     workspace, module = make_workspace(image, labels)
 
-    module.images_or_objects.value = cellprofiler.modules.measuretexture.IO_OBJECTS
+    module.images_or_objects.value = MeasurementTarget.OBJECTS
 
     module.scale_groups[0].scale.value = 2
 


### PR DESCRIPTION
# Refactor MeasureTexture to 3-Layer Architecture with LibraryMeasurements

## Summary
Refactors the MeasureTexture module into the standard 3-layer architecture (Functions, Library, Frontend) using the `LibraryMeasurements` model. This decouples algorithmic logic from the CellProfiler Core/UI and ensures the library is pure, type-safe, and uses a standardized measurement contract.

## Detailed Changes

### Layer 1: Functions (cellprofiler_library.functions.measurement)
•    Extracted pure Haralick feature calculation into `measure_haralick_features_image` and `measure_haralick_features_objects`.
•    Functions return raw numpy arrays instead of formatted dictionaries.

### Layer 2: Library (cellprofiler_library.modules._measuretexture)
•    Updated `measure_image_texture` and `measure_object_texture` to serve as pure orchestrators returning `LibraryMeasurements`.
•    Responsibility:
◦    Accepts strictly typed inputs (using pydantic and cellprofiler_library.types).
◦    Calls pure math functions from Layer 1.
◦    Formats measurement keys (e.g., `Texture_Correlation_Image_3_00_256`).
◦    Calculates statistical summaries (Mean, Median, Min, Max, StDev) for object measurements.
◦    Returns a `LibraryMeasurements` object (instead of primitive dictionaries) for type-safe data transfer.
◦    Handles NaN/Inf value cleaning before storage.

### Layer 3: Frontend (cellprofiler.modules.measuretexture)
•    Refactored `run`, `run_image`, and `run_one` methods.
•    Delegates all processing to the Library layer.
•    Unpacks the returned `LibraryMeasurements` object into the workspace.
•    Populates display statistics using the structured data from the library.

## Verification
•    Pure functional library modules (no cellprofiler.core imports).
•    Type safety enforcing `ImageGrayscale` and `ObjectSegmentation`.
•    `LibraryMeasurements` validation ensures correct measurement types.
•    Bit-for-bit preservation of Haralick algorithms (using mahotas).
•    All existing tests pass.

Co-Authored-By: Warp <agent@warp.dev>