### PR TITLE
Move `makeprojection` to library

### DIFF
--- a/src/frontend/cellprofiler/modules/makeprojection.py
+++ b/src/frontend/cellprofiler/modules/makeprojection.py
@@ -193,7 +193,7 @@ slices."""
     def prepare_group(self, workspace, grouping, image_numbers):
         """Reset the aggregate image at the start of group processing"""
         if len(image_numbers) > 0:
-            provider = ImageProvider(
+            provider = ImageProvider.create(
                 self.projection_image_name.value,
                 self.projection_type.value,
                 self.frequency.value,
@@ -266,37 +266,6 @@ slices."""
 class ImageProvider(AbstractImage):
     """Provide the image after averaging but before dilation and smoothing"""
 
-    def __init__(self, name, how_to_accumulate, frequency=6):
-        """Construct using a parent provider that does the real work
-
-        name - name of the image provided
-        """
-        super(ImageProvider, self).__init__()
-        self.__name = name
-        self.frequency = frequency
-        self.__image = None
-        self.__how_to_accumulate = how_to_accumulate
-        self.__image_count = None
-        self.__cached_image = None
-        #
-        # Variance needs image squared as float64, image sum and count
-        #
-        self.__vsquared = None
-        self.__vsum = None
-        #
-        # Power needs a running sum (reuse vsum), a power image of the mask
-        # and a complex-values image
-        #
-        self.__power_image = None
-        self.__power_mask = None
-        self.__stack_number = 0
-        #
-        # Brightfield needs a maximum and minimum image
-        #
-        self.__bright_max = None
-        self.__bright_min = None
-        self.__norm0 = None
-
     D_NAME = "name"
     D_FREQUENCY = "frequency"
     D_IMAGE = "image"
@@ -311,24 +280,49 @@ class ImageProvider(AbstractImage):
     D_BRIGHT_MIN = "brightmin"
     D_NORM0 = "norm0"
 
+    def __init__(self, name, how_to_accumulate, frequency=6):
+        """Construct using a parent provider that does the real work
+
+        name - name of the image provided
+        """
+        super(ImageProvider, self).__init__()
+        self._name = name
+        self.frequency = frequency
+        self._how_to_accumulate = how_to_accumulate
+        self._image_count = None
+        self._cached_image = None
+
+    @staticmethod
+    def create(name, how_to_accumulate, frequency=6):
+        """Factory method to create the appropriate ImageProvider subclass based on the accumulation method."""
+        providers = {
+            P_AVERAGE: AverageProvider,
+            P_MAXIMUM: MaximumProvider,
+            P_MINIMUM: MinimumProvider,
+            P_SUM: SumProvider,
+            P_VARIANCE: VarianceProvider,
+            P_POWER: PowerProvider,
+            P_BRIGHTFIELD: BrightfieldProvider,
+            P_MASK: MaskProvider,
+        }
+
+        provider_class = providers.get(how_to_accumulate)
+        if provider_class:
+            return provider_class(name, how_to_accumulate, frequency)
+
+        raise NotImplementedError(
+            "No such accumulation method: %s" % how_to_accumulate
+        )
+
     def save_state(self, d):
         """Save the provider state to a dictionary
 
         d - store state in this dictionary
         """
-        d[self.D_NAME] = self.__name
+        d[self.D_NAME] = self._name
         d[self.D_FREQUENCY] = self.frequency
-        d[self.D_IMAGE] = self.__image
-        d[self.D_HOW_TO_ACCUMULATE] = self.__how_to_accumulate
-        d[self.D_IMAGE_COUNT] = self.__image_count
-        d[self.D_VSQUARED] = self.__vsquared
-        d[self.D_VSUM] = self.__vsum
-        d[self.D_POWER_IMAGE] = self.__power_image
-        d[self.D_POWER_MASK] = self.__power_mask
-        d[self.D_STACK_NUMBER] = self.__stack_number
-        d[self.D_BRIGHT_MIN] = self.__bright_min
-        d[self.D_BRIGHT_MAX] = self.__bright_max
-        d[self.D_NORM0] = self.__norm0
+        d[self.D_HOW_TO_ACCUMULATE] = self._how_to_accumulate
+        d[self.D_IMAGE_COUNT] = self._image_count
 
     @staticmethod
     def restore_from_state(d):
@@ -341,183 +335,460 @@ class ImageProvider(AbstractImage):
         name = d[ImageProvider.D_NAME]
         frequency = d[ImageProvider.D_FREQUENCY]
         how_to_accumulate = d[ImageProvider.D_HOW_TO_ACCUMULATE]
-        image_provider = ImageProvider(name, how_to_accumulate, frequency)
-        image_provider.__image = d[ImageProvider.D_IMAGE]
-        image_provider.__image_count = d[ImageProvider.D_IMAGE_COUNT]
-        image_provider.__vsquared = d[ImageProvider.D_VSQUARED]
-        image_provider.__vsum = d[ImageProvider.D_VSUM]
-        image_provider.__power_image = d[ImageProvider.D_POWER_IMAGE]
-        image_provider.__power_mask = d[ImageProvider.D_POWER_MASK]
-        image_provider.__stack_number = d[ImageProvider.D_STACK_NUMBER]
-        image_provider.__bright_min = d[ImageProvider.D_BRIGHT_MIN]
-        image_provider.__bright_max = d[ImageProvider.D_BRIGHT_MAX]
-        image_provider.__norm0 = d[ImageProvider.D_NORM0]
+        image_provider = ImageProvider.create(name, how_to_accumulate, frequency)
+        image_provider.restore(d)
         return image_provider
+
+    def restore(self, d):
+        self._image_count = d[self.D_IMAGE_COUNT]
 
     def reset(self):
         """Reset accumulator at start of groups"""
-        self.__image_count = None
-        self.__image = None
-        self.__cached_image = None
-        self.__vsquared = None
-        self.__vsum = None
-        self.__power_image = None
-        self.__power_mask = None
-        self.__stack_number = 0
-        self.__bright_max = None
-        self.__bright_min = None
+        self._image_count = None
+        self._cached_image = None
 
     @property
     def has_image(self):
-        return self.__image_count is not None
+        return self._image_count is not None
 
     @property
     def count(self):
-        return self.__image_count
+        return self._image_count
 
     def set_image(self, image):
-        self.__cached_image = None
+        self._cached_image = None
         if image.has_mask:
-            self.__image_count = image.mask.astype(int)
+            self._image_count = image.mask.astype(int)
         else:
-            self.__image_count = numpy.ones(image.pixel_data.shape[:2], int)
-
-        if self.__how_to_accumulate == P_VARIANCE:
-            self.__vsum = image.pixel_data.copy()
-            self.__vsum[~image.mask] = 0
-            self.__image_count = image.mask.astype(int)
-            self.__vsquared = self.__vsum.astype(numpy.float64) ** 2.0
-            return
-
-        if self.__how_to_accumulate == P_POWER:
-            self.__vsum = image.pixel_data.copy()
-            self.__vsum[~image.mask] = 0
-            self.__image_count = image.mask.astype(int)
-            #
-            # e**0 = 1, so the first image is always in the real plane
-            #
-            self.__power_mask = self.__image_count.astype(numpy.complex128).copy()
-            self.__power_image = image.pixel_data.astype(numpy.complex128).copy()
-            self.__stack_number = 1
-            return
-        if self.__how_to_accumulate == P_BRIGHTFIELD:
-            self.__bright_max = image.pixel_data.copy()
-            self.__bright_min = image.pixel_data.copy()
-            self.__norm0 = numpy.mean(image.pixel_data)
-            return
-
-        if self.__how_to_accumulate == P_MASK:
-            self.__image = image.mask
-            return
-
-        self.__image = image.pixel_data.copy()
-        if image.has_mask:
-            nan_value = 1 if self.__how_to_accumulate == P_MINIMUM else 0
-            self.__image[~image.mask] = nan_value
+            self._image_count = numpy.ones(image.pixel_data.shape[:2], int)
+        self._set_image_impl(image)
 
     def accumulate_image(self, image):
-        self.__cached_image = None
+        self._cached_image = None
         if image.has_mask:
-            self.__image_count += image.mask.astype(int)
+            self._image_count += image.mask.astype(int)
         else:
-            self.__image_count += 1
-        if self.__how_to_accumulate in [P_AVERAGE, P_SUM]:
-            if image.has_mask:
-                self.__image[image.mask] += image.pixel_data[image.mask]
-            else:
-                self.__image += image.pixel_data
-        elif self.__how_to_accumulate == P_MAXIMUM:
-            if image.has_mask:
-                self.__image[image.mask] = numpy.maximum(
-                    self.__image[image.mask], image.pixel_data[image.mask]
-                )
-            else:
-                self.__image = numpy.maximum(image.pixel_data, self.__image)
-        elif self.__how_to_accumulate == P_MINIMUM:
-            if image.has_mask:
-                self.__image[image.mask] = numpy.minimum(
-                    self.__image[image.mask], image.pixel_data[image.mask]
-                )
-            else:
-                self.__image = numpy.minimum(image.pixel_data, self.__image)
-        elif self.__how_to_accumulate == P_VARIANCE:
-            mask = image.mask
-            self.__vsum[mask] += image.pixel_data[mask]
-            self.__vsquared[mask] += image.pixel_data[mask].astype(numpy.float64) ** 2
-        elif self.__how_to_accumulate == P_POWER:
-            multiplier = numpy.exp(
-                2j * numpy.pi * float(self.__stack_number) / self.frequency
-            )
-            self.__stack_number += 1
-            mask = image.mask
-            self.__vsum[mask] += image.pixel_data[mask]
-            self.__power_image[mask] += multiplier * image.pixel_data[mask]
-            self.__power_mask[mask] += multiplier
-        elif self.__how_to_accumulate == P_BRIGHTFIELD:
-            mask = image.mask
-            norm = numpy.mean(image.pixel_data)
-            pixel_data = image.pixel_data * self.__norm0 / norm
-            max_mask = (self.__bright_max < pixel_data) & mask
-            min_mask = (self.__bright_min > pixel_data) & mask
-            self.__bright_min[min_mask] = pixel_data[min_mask]
-            self.__bright_max[max_mask] = pixel_data[max_mask]
-            self.__bright_min[max_mask] = self.__bright_max[max_mask]
-        elif self.__how_to_accumulate == P_MASK:
-            self.__image = self.__image & image.mask
-        else:
-            raise NotImplementedError(
-                "No such accumulation method: %s" % self.__how_to_accumulate
-            )
+            self._image_count += 1
+        self._accumulate_image_impl(image)
 
     def provide_image(self, image_set):
-        image_count = self.__image_count
-        mask_2d = image_count > 0
-        if self.__how_to_accumulate == P_VARIANCE:
-            ndim_image = self.__vsquared
-        elif self.__how_to_accumulate == P_POWER:
-            ndim_image = self.__power_image
-        elif self.__how_to_accumulate == P_BRIGHTFIELD:
-            ndim_image = self.__bright_max
-        else:
-            ndim_image = self.__image
-        if ndim_image.ndim == 3:
-            image_count = numpy.dstack([image_count] * ndim_image.shape[2])
-        mask = image_count > 0
-        if self.__cached_image is not None:
-            return self.__cached_image
-        if self.__how_to_accumulate == P_AVERAGE:
-            cached_image = self.__image / image_count
-        elif self.__how_to_accumulate == P_VARIANCE:
-            cached_image = numpy.zeros(self.__vsquared.shape, numpy.float32)
-            cached_image[mask] = self.__vsquared[mask] / image_count[mask]
-            cached_image[mask] -= self.__vsum[mask] ** 2 / (image_count[mask] ** 2)
-        elif self.__how_to_accumulate == P_POWER:
-            cached_image = numpy.zeros(image_count.shape, numpy.complex128)
-            cached_image[mask] = self.__power_image[mask]
-            cached_image[mask] -= (
-                self.__vsum[mask] * self.__power_mask[mask] / image_count[mask]
-            )
-            cached_image = (cached_image * numpy.conj(cached_image)).real.astype(
-                numpy.float32
-            )
-        elif self.__how_to_accumulate == P_BRIGHTFIELD:
-            cached_image = numpy.zeros(image_count.shape, numpy.float32)
-            cached_image[mask] = self.__bright_max[mask] - self.__bright_min[mask]
-        elif self.__how_to_accumulate == P_MINIMUM and numpy.any(~mask):
-            cached_image = self.__image.copy()
-            cached_image[~mask] = 0
-        else:
-            cached_image = self.__image
-        cached_image[~mask] = 0
-        if numpy.all(mask) or self.__how_to_accumulate == P_MASK:
-            self.__cached_image = Image(cached_image)
-        else:
-            self.__cached_image = Image(cached_image, mask=mask_2d)
-        return self.__cached_image
+        """Return the final projected image."""
+        raise NotImplementedError
 
     def get_name(self):
-        return self.__name
+        """Return the name of the output image."""
+        return self._name
 
     def release_memory(self):
         """Don't discard the image at end of image set"""
         pass
+
+    def _set_image_impl(self, image):
+        """Abstract method: Initialize the accumulator with the first image."""
+        raise NotImplementedError
+
+    def _wrap_image(self, pixel_data, mask):
+        """Helper to wrap pixel data in an Image object, handling 2D/3D masks."""
+        if numpy.all(mask):
+            return Image(pixel_data)
+
+        if mask.ndim == 3:
+            mask = mask[:, :, 0]
+
+        return Image(pixel_data, mask=mask)
+
+    def _accumulate_image_impl(self, image):
+        """Abstract method: Accumulate a subsequent image into the provider."""
+        raise NotImplementedError
+
+
+class SumProvider(ImageProvider):
+    """Accumulates the sum of pixel intensities."""
+
+    def __init__(self, name, how_to_accumulate, frequency=6):
+        super(SumProvider, self).__init__(name, how_to_accumulate, frequency)
+        self._image = None
+
+    def save_state(self, d):
+        super(SumProvider, self).save_state(d)
+        d[self.D_IMAGE] = self._image
+
+    def restore(self, d):
+        super(SumProvider, self).restore(d)
+        self._image = d[self.D_IMAGE]
+
+    def reset(self):
+        super(SumProvider, self).reset()
+        self._image = None
+
+    def _set_image_impl(self, image):
+        self._image = image.pixel_data.copy()
+        if image.has_mask:
+            self._image[~image.mask] = 0
+
+    def _accumulate_image_impl(self, image):
+        if image.has_mask:
+            self._image[image.mask] += image.pixel_data[image.mask]
+        else:
+            self._image += image.pixel_data
+
+    def provide_image(self, image_set):
+        if self._cached_image is not None:
+            return self._cached_image
+
+        image_count = self._image_count
+        mask = image_count > 0
+
+        if numpy.any(~mask):
+            cached_image = self._image.copy()
+            cached_image[~mask] = 0
+        else:
+            cached_image = self._image
+
+        if numpy.all(mask):
+            self._cached_image = Image(cached_image)
+        else:
+            self._cached_image = Image(cached_image, mask=mask)
+        return self._cached_image
+
+
+class AverageProvider(SumProvider):
+    """Accumulates the sum, then divides by count to get the average."""
+
+    def provide_image(self, image_set):
+        if self._cached_image is not None:
+            return self._cached_image
+
+        image_count = self._image_count
+        if self._image.ndim == 3:
+             image_count = numpy.dstack([image_count] * self._image.shape[2])
+        mask = image_count > 0
+
+        cached_image = self._image / image_count
+        if cached_image.ndim == 3 and mask.ndim == 2:
+            cached_image[~mask, :] = 0
+        else:
+            cached_image[~mask] = 0
+
+        self._cached_image = self._wrap_image(cached_image, mask)
+        return self._cached_image
+
+
+class MaximumProvider(ImageProvider):
+    """Keeps the maximum pixel intensity at each position."""
+
+    def __init__(self, name, how_to_accumulate, frequency=6):
+        super(MaximumProvider, self).__init__(name, how_to_accumulate, frequency)
+        self._image = None
+
+    def save_state(self, d):
+        super(MaximumProvider, self).save_state(d)
+        d[self.D_IMAGE] = self._image
+
+    def restore(self, d):
+        super(MaximumProvider, self).restore(d)
+        self._image = d[self.D_IMAGE]
+
+    def reset(self):
+        super(MaximumProvider, self).reset()
+        self._image = None
+
+    def _set_image_impl(self, image):
+        self._image = image.pixel_data.copy()
+        if image.has_mask:
+            self._image[~image.mask] = 0
+
+    def _accumulate_image_impl(self, image):
+        if image.has_mask:
+            self._image[image.mask] = numpy.maximum(
+                self._image[image.mask], image.pixel_data[image.mask]
+            )
+        else:
+            self._image = numpy.maximum(image.pixel_data, self._image)
+
+    def provide_image(self, image_set):
+        if self._cached_image is not None:
+            return self._cached_image
+
+        image_count = self._image_count
+        mask = image_count > 0
+
+        if numpy.any(~mask):
+            cached_image = self._image.copy()
+            cached_image[~mask] = 0
+        else:
+            cached_image = self._image
+
+        self._cached_image = self._wrap_image(cached_image, mask)
+        return self._cached_image
+
+
+class MinimumProvider(ImageProvider):
+    """Keeps the minimum pixel intensity at each position."""
+
+    def __init__(self, name, how_to_accumulate, frequency=6):
+        super(MinimumProvider, self).__init__(name, how_to_accumulate, frequency)
+        self._image = None
+
+    def save_state(self, d):
+        super(MinimumProvider, self).save_state(d)
+        d[self.D_IMAGE] = self._image
+
+    def restore(self, d):
+        super(MinimumProvider, self).restore(d)
+        self._image = d[self.D_IMAGE]
+
+    def reset(self):
+        super(MinimumProvider, self).reset()
+        self._image = None
+
+    def _set_image_impl(self, image):
+        self._image = image.pixel_data.copy()
+        if image.has_mask:
+            self._image[~image.mask] = 1
+
+    def _accumulate_image_impl(self, image):
+        if image.has_mask:
+            self._image[image.mask] = numpy.minimum(
+                self._image[image.mask], image.pixel_data[image.mask]
+            )
+        else:
+            self._image = numpy.minimum(image.pixel_data, self._image)
+
+    def provide_image(self, image_set):
+        if self._cached_image is not None:
+            return self._cached_image
+
+        image_count = self._image_count
+        mask = image_count > 0
+
+        if numpy.any(~mask):
+            cached_image = self._image.copy()
+            cached_image[~mask] = 0
+        else:
+            cached_image = self._image
+
+        self._cached_image = self._wrap_image(cached_image, mask)
+        return self._cached_image
+
+
+class VarianceProvider(ImageProvider):
+    """Calculates pixel variance across the image stack."""
+
+    def __init__(self, name, how_to_accumulate, frequency=6):
+        super(VarianceProvider, self).__init__(name, how_to_accumulate, frequency)
+        self._vsum = None
+        self._vsquared = None
+
+    def save_state(self, d):
+        super(VarianceProvider, self).save_state(d)
+        d[self.D_VSUM] = self._vsum
+        d[self.D_VSQUARED] = self._vsquared
+
+    def restore(self, d):
+        super(VarianceProvider, self).restore(d)
+        self._vsum = d[self.D_VSUM]
+        self._vsquared = d[self.D_VSQUARED]
+
+    def reset(self):
+        super(VarianceProvider, self).reset()
+        self._vsum = None
+        self._vsquared = None
+
+    def _set_image_impl(self, image):
+        self._vsum = image.pixel_data.copy()
+        self._vsum[~image.mask] = 0
+        self._vsquared = self._vsum.astype(numpy.float64) ** 2.0
+
+    def _accumulate_image_impl(self, image):
+        mask = image.mask
+        self._vsum[mask] += image.pixel_data[mask]
+        self._vsquared[mask] += image.pixel_data[mask].astype(numpy.float64) ** 2
+
+    def provide_image(self, image_set):
+        if self._cached_image is not None:
+            return self._cached_image
+
+        image_count = self._image_count
+        mask_2d = image_count > 0
+
+        if self._vsquared.ndim == 3:
+            image_count = numpy.dstack([image_count] * self._vsquared.shape[2])
+            
+        mask = image_count > 0
+
+        cached_image = numpy.zeros(self._vsquared.shape, numpy.float32)
+        cached_image[mask] = self._vsquared[mask] / image_count[mask]
+        cached_image[mask] -= self._vsum[mask] ** 2 / (image_count[mask] ** 2)
+
+        cached_image[~mask] = 0
+
+        self._cached_image = self._wrap_image(cached_image, mask_2d)
+        return self._cached_image
+
+
+class PowerProvider(ImageProvider):
+    """Calculates power at a specific frequency across the stack."""
+
+    def __init__(self, name, how_to_accumulate, frequency=6):
+        super(PowerProvider, self).__init__(name, how_to_accumulate, frequency)
+        self._vsum = None
+        self._power_image = None
+        self._power_mask = None
+        self._stack_number = 0
+
+    def save_state(self, d):
+        super(PowerProvider, self).save_state(d)
+        d[self.D_VSUM] = self._vsum
+        d[self.D_POWER_IMAGE] = self._power_image
+        d[self.D_POWER_MASK] = self._power_mask
+        d[self.D_STACK_NUMBER] = self._stack_number
+
+    def restore(self, d):
+        super(PowerProvider, self).restore(d)
+        self._vsum = d[self.D_VSUM]
+        self._power_image = d[self.D_POWER_IMAGE]
+        self._power_mask = d[self.D_POWER_MASK]
+        self._stack_number = d[self.D_STACK_NUMBER]
+
+    def reset(self):
+        super(PowerProvider, self).reset()
+        self._vsum = None
+        self._power_image = None
+        self._power_mask = None
+        self._stack_number = 0
+
+    def _set_image_impl(self, image):
+        self._vsum = image.pixel_data.copy()
+        self._vsum[~image.mask] = 0
+        self._power_mask = self._image_count.astype(numpy.complex128).copy()
+        self._power_image = image.pixel_data.astype(numpy.complex128).copy()
+        self._stack_number = 1
+
+    def _accumulate_image_impl(self, image):
+        multiplier = numpy.exp(
+            2j * numpy.pi * float(self._stack_number) / self.frequency
+        )
+        self._stack_number += 1
+        mask = image.mask
+        self._vsum[mask] += image.pixel_data[mask]
+        self._power_image[mask] += multiplier * image.pixel_data[mask]
+        self._power_mask[mask] += multiplier
+
+    def provide_image(self, image_set):
+        if self._cached_image is not None:
+            return self._cached_image
+
+        image_count = self._image_count
+        mask_2d = image_count > 0
+
+        if self._power_image.ndim == 3:
+            image_count = numpy.dstack([image_count] * self._power_image.shape[2])
+        mask = image_count > 0
+
+        cached_image = numpy.zeros(image_count.shape, numpy.complex128)
+        cached_image[mask] = self._power_image[mask]
+        cached_image[mask] -= (
+            self._vsum[mask] * self._power_mask[mask] / image_count[mask]
+        )
+        cached_image = (cached_image * numpy.conj(cached_image)).real.astype(
+            numpy.float32
+        )
+        cached_image[~mask] = 0
+
+        self._cached_image = self._wrap_image(cached_image, mask_2d)
+        return self._cached_image
+
+
+class BrightfieldProvider(ImageProvider):
+    """Performs brightfield projection (focus metric based on max-min difference)."""
+
+    def __init__(self, name, how_to_accumulate, frequency=6):
+        super(BrightfieldProvider, self).__init__(name, how_to_accumulate, frequency)
+        self._bright_max = None
+        self._bright_min = None
+        self._norm0 = None
+
+    def save_state(self, d):
+        super(BrightfieldProvider, self).save_state(d)
+        d[self.D_BRIGHT_MAX] = self._bright_max
+        d[self.D_BRIGHT_MIN] = self._bright_min
+        d[self.D_NORM0] = self._norm0
+
+    def restore(self, d):
+        super(BrightfieldProvider, self).restore(d)
+        self._bright_max = d[self.D_BRIGHT_MAX]
+        self._bright_min = d[self.D_BRIGHT_MIN]
+        self._norm0 = d[self.D_NORM0]
+
+    def reset(self):
+        super(BrightfieldProvider, self).reset()
+        self._bright_max = None
+        self._bright_min = None
+        self._norm0 = None
+
+    def _set_image_impl(self, image):
+        self._bright_max = image.pixel_data.copy()
+        self._bright_min = image.pixel_data.copy()
+        self._norm0 = numpy.mean(image.pixel_data)
+
+    def _accumulate_image_impl(self, image):
+        mask = image.mask
+        norm = numpy.mean(image.pixel_data)
+        pixel_data = image.pixel_data * self._norm0 / norm
+        max_mask = (self._bright_max < pixel_data) & mask
+        min_mask = (self._bright_min > pixel_data) & mask
+        self._bright_min[min_mask] = pixel_data[min_mask]
+        self._bright_max[max_mask] = pixel_data[max_mask]
+        self._bright_min[max_mask] = self._bright_max[max_mask]
+
+    def provide_image(self, image_set):
+        if self._cached_image is not None:
+            return self._cached_image
+
+        image_count = self._image_count
+        mask_2d = image_count > 0
+
+        if self._bright_max.ndim == 3:
+            image_count = numpy.dstack([image_count] * self._bright_max.shape[2])
+        mask = image_count > 0
+
+        cached_image = numpy.zeros(image_count.shape, numpy.float32)
+        cached_image[mask] = self._bright_max[mask] - self._bright_min[mask]
+        cached_image[~mask] = 0
+
+        self._cached_image = self._wrap_image(cached_image, mask_2d)
+        return self._cached_image
+
+
+class MaskProvider(ImageProvider):
+    """Computes the intersection of all masks."""
+
+    def __init__(self, name, how_to_accumulate, frequency=6):
+        super(MaskProvider, self).__init__(name, how_to_accumulate, frequency)
+        self._image = None
+
+    def save_state(self, d):
+        super(MaskProvider, self).save_state(d)
+        d[self.D_IMAGE] = self._image
+
+    def restore(self, d):
+        super(MaskProvider, self).restore(d)
+        self._image = d[self.D_IMAGE]
+
+    def reset(self):
+        super(MaskProvider, self).reset()
+        self._image = None
+
+    def _set_image_impl(self, image):
+        self._image = image.mask
+
+    def _accumulate_image_impl(self, image):
+        self._image = self._image & image.mask
+
+    def provide_image(self, image_set):
+        if self._cached_image is not None:
+            return self._cached_image
+
+        self._cached_image = Image(self._image)
+        return self._cached_image

--- a/src/frontend/cellprofiler/modules/makeprojection.py
+++ b/src/frontend/cellprofiler/modules/makeprojection.py
@@ -63,8 +63,8 @@ from cellprofiler_core.setting.subscriber import ImageSubscriber
 from cellprofiler_core.setting.text import ImageName
 from cellprofiler_core.setting.text.number import Float
 
-from cellprofiler_library.modules._makeprojection import accumulate_projection, calculate_final_projection
-from cellprofiler_library.opts.makeprojection import ProjectionType
+from cellprofiler_library.modules._makeprojection import accumulate_projection, calculate_final_projection, set_projection
+from cellprofiler_library.opts.makeprojection import ProjectionType, StateKey
 
 P_AVERAGE = ProjectionType.AVERAGE.value
 P_MAXIMUM = ProjectionType.MAXIMUM.value
@@ -298,10 +298,10 @@ class ImageProvider(AbstractImage):
 
         d - store state in this dictionary
         """
-        d[self.D_NAME] = self._name
-        d[self.D_FREQUENCY] = self.frequency
-        d[self.D_METHOD] = self.method.value
-        d[self.D_LIBRARY_STATE] = self.library_state
+        d[ImageProvider.D_NAME] = self._name
+        d[ImageProvider.D_FREQUENCY] = self.frequency
+        d[ImageProvider.D_METHOD] = self.method.value
+        d[ImageProvider.D_LIBRARY_STATE] = self.library_state
 
     @staticmethod
     def restore_from_state(d):
@@ -331,12 +331,17 @@ class ImageProvider(AbstractImage):
 
     @property
     def count(self):
-        return self.library_state.get("image_count")
+        return self.library_state.get(StateKey.IMAGE_COUNT)
 
     def set_image(self, image):
         self._cached_image = None
         self.library_state = {}
-        self.accumulate_image(image)
+        set_projection(
+            image.pixel_data, 
+            image.mask,
+            self.library_state,
+            self.method
+        )
 
     def accumulate_image(self, image):
         self._cached_image = None

--- a/src/frontend/cellprofiler/modules/makeprojection.py
+++ b/src/frontend/cellprofiler/modules/makeprojection.py
@@ -319,14 +319,6 @@ class ImageProvider(AbstractImage):
     def has_image(self):
         return self.library_accumulator is not None
 
-    @property
-    def count(self):
-        if self.library_accumulator is None:
-            return 0
-        else:
-            _, _, agg_image_count = self.library_accumulator.finalize()
-            return agg_image_count
-
     def set_image(self, image):
         self._cached_image = None
         self.library_accumulator = makeprojection(
@@ -349,7 +341,7 @@ class ImageProvider(AbstractImage):
         if self._cached_image is not None:
             return self._cached_image
             
-        pixels, mask, _ = self.library_accumulator.finalize()
+        pixels, mask = self.library_accumulator.finalize()
         
         if numpy.all(mask):
             self._cached_image = Image(pixels)

--- a/src/frontend/cellprofiler/modules/makeprojection.py
+++ b/src/frontend/cellprofiler/modules/makeprojection.py
@@ -53,7 +53,6 @@ See also
 See also the help for the **Input** modules.
 """
 
-
 import numpy
 from cellprofiler_core.image import AbstractImage
 from cellprofiler_core.image import Image
@@ -63,8 +62,8 @@ from cellprofiler_core.setting.subscriber import ImageSubscriber
 from cellprofiler_core.setting.text import ImageName
 from cellprofiler_core.setting.text.number import Float
 
-from cellprofiler_library.modules._makeprojection import accumulate_projection, calculate_final_projection, set_projection
-from cellprofiler_library.opts.makeprojection import ProjectionType, StateKey, P_ALL
+from cellprofiler_library.modules._makeprojection import makeprojection
+from cellprofiler_library.opts.makeprojection import ProjectionType, P_ALL
 
 K_PROVIDER = "Provider"
 
@@ -265,7 +264,7 @@ class ImageProvider(AbstractImage):
     D_NAME = "name"
     D_FREQUENCY = "frequency"
     D_METHOD = "method"
-    D_LIBRARY_STATE = "library_state"
+    D_LIBRARY_STATE = "library_accumulator"
 
     def __init__(self, name, method, frequency=6.0):
         """Construct using a parent provider that does the real work
@@ -276,7 +275,7 @@ class ImageProvider(AbstractImage):
         self._name = name
         self.method = ProjectionType(method)
         self.frequency = frequency
-        self.library_state = {}
+        self.library_accumulator = None
         self._cached_image = None
 
     @staticmethod
@@ -292,7 +291,7 @@ class ImageProvider(AbstractImage):
         d[ImageProvider.D_NAME] = self._name
         d[ImageProvider.D_FREQUENCY] = self.frequency
         d[ImageProvider.D_METHOD] = self.method.value
-        d[ImageProvider.D_LIBRARY_STATE] = self.library_state
+        d[ImageProvider.D_LIBRARY_STATE] = self.library_accumulator
 
     @staticmethod
     def restore_from_state(d):
@@ -305,33 +304,36 @@ class ImageProvider(AbstractImage):
         name = d[ImageProvider.D_NAME]
         frequency = d[ImageProvider.D_FREQUENCY]
         method = d[ImageProvider.D_METHOD]
-        library_state = d.get(ImageProvider.D_LIBRARY_STATE, {})
+        library_accumulator = d.get(ImageProvider.D_LIBRARY_STATE, None)
         
         provider = ImageProvider.create(name, method, frequency)
-        provider.library_state = library_state
+        provider.library_accumulator = library_accumulator
         return provider
 
     def reset(self):
         """Reset accumulator at start of groups"""
-        self.library_state = {}
+        self.library_accumulator = None
         self._cached_image = None
 
     @property
     def has_image(self):
-        return len(self.library_state) > 0
+        return self.library_accumulator is not None
 
     @property
     def count(self):
-        return self.library_state.get(StateKey.IMAGE_COUNT)
+        if self.library_accumulator is None:
+            return 0
+        else:
+            _, _, agg_image_count = self.library_accumulator.finalize()
+            return agg_image_count
 
     def set_image(self, image):
         self._cached_image = None
-        self.library_state = {}
-        set_projection(
+        self.library_accumulator = makeprojection(
+            self.method,
             image.pixel_data, 
             image.mask,
-            self.library_state,
-            self.method
+            self.frequency,
         )
 
     def accumulate_image(self, image):
@@ -340,20 +342,14 @@ class ImageProvider(AbstractImage):
         pixels = image.pixel_data
         mask = image.mask if image.has_mask else None
         
-        self.library_state = accumulate_projection(
-            pixels, 
-            mask, 
-            self.library_state, 
-            self.method, 
-            self.frequency
-        )
+        self.library_accumulator = self.library_accumulator.accumulate(pixels, mask)
 
     def provide_image(self, image_set):
         """Return the final projected image."""
         if self._cached_image is not None:
             return self._cached_image
             
-        pixels, mask = calculate_final_projection(self.library_state, self.method)
+        pixels, mask, _ = self.library_accumulator.finalize()
         
         if numpy.all(mask):
             self._cached_image = Image(pixels)

--- a/src/frontend/cellprofiler/modules/makeprojection.py
+++ b/src/frontend/cellprofiler/modules/makeprojection.py
@@ -280,7 +280,7 @@ class ImageProvider(AbstractImage):
         self._cached_image = None
 
     @staticmethod
-    def create(name, how_to_accumulate, frequency=6):
+    def create(name, how_to_accumulate, frequency=6.0):
         """Factory method to create the appropriate ImageProvider."""
         return ImageProvider(name, how_to_accumulate, frequency)
 

--- a/src/frontend/cellprofiler/modules/makeprojection.py
+++ b/src/frontend/cellprofiler/modules/makeprojection.py
@@ -64,27 +64,7 @@ from cellprofiler_core.setting.text import ImageName
 from cellprofiler_core.setting.text.number import Float
 
 from cellprofiler_library.modules._makeprojection import accumulate_projection, calculate_final_projection, set_projection
-from cellprofiler_library.opts.makeprojection import ProjectionType, StateKey
-
-P_AVERAGE = ProjectionType.AVERAGE.value
-P_MAXIMUM = ProjectionType.MAXIMUM.value
-P_MINIMUM = ProjectionType.MINIMUM.value
-P_SUM = ProjectionType.SUM.value
-P_VARIANCE = ProjectionType.VARIANCE.value
-P_POWER = ProjectionType.POWER.value
-P_BRIGHTFIELD = ProjectionType.BRIGHTFIELD.value
-P_MASK = ProjectionType.MASK.value
-
-P_ALL = [
-    P_AVERAGE,
-    P_MAXIMUM,
-    P_MINIMUM,
-    P_SUM,
-    P_VARIANCE,
-    P_POWER,
-    P_BRIGHTFIELD,
-    P_MASK,
-]
+from cellprofiler_library.opts.makeprojection import ProjectionType, StateKey, P_ALL
 
 K_PROVIDER = "Provider"
 
@@ -107,18 +87,18 @@ class MakeProjection(Module):
             doc="""\
 The final projection image can be created by the following methods:
 
--  *%(P_AVERAGE)s:* Use the average pixel intensity at each pixel
+-  *{P_AVERAGE}:* Use the average pixel intensity at each pixel
    position.
--  *%(P_MAXIMUM)s:* Use the maximum pixel value at each pixel position.
--  *%(P_MINIMUM)s:* Use the minimum pixel value at each pixel position.
--  *%(P_SUM)s:* Add the pixel values at each pixel position.
--  *%(P_VARIANCE)s:* Compute the variance at each pixel position.
+-  *{P_MAXIMUM}:* Use the maximum pixel value at each pixel position.
+-  *{P_MINIMUM}:* Use the minimum pixel value at each pixel position.
+-  *{P_SUM}:* Add the pixel values at each pixel position.
+-  *{P_VARIANCE}:* Compute the variance at each pixel position.
    The variance method is described in Selinummi et al (2009). The
    method is designed to operate on a Z-stack of brightfield images
    taken at different focus planes. Background pixels will have
    relatively uniform illumination whereas cytoplasm pixels will have
    higher variance across the Z-stack.
--  *%(P_POWER)s:* Compute the power at a given frequency at each pixel
+-  *{P_POWER}:* Compute the power at a given frequency at each pixel
    position.
    The power method is experimental. The method computes the power at a
    given frequency through the Z-stack. It might be used with a phase
@@ -127,7 +107,7 @@ The final projection image can be created by the following methods:
    and pixels that vary with the given frequency will have a higher
    score than other pixels with similar variance, but different
    frequencies.
--  *%(P_BRIGHTFIELD)s:* Perform the brightfield projection at each
+-  *{P_BRIGHTFIELD}:* Perform the brightfield projection at each
    pixel position.
    Artifacts such as dust appear as black spots that are most strongly
    resolved at their focal plane with gradually increasing signals
@@ -135,7 +115,7 @@ The final projection image can be created by the following methods:
    appears in the early Z-stacks. These pixels have a high score for the
    variance method but have a reduced score when using the brightfield
    method.
--  *%(P_MASK)s:* Compute a binary image of the pixels that are masked
+-  *{P_MASK}:* Compute a binary image of the pixels that are masked
    in any of the input images.
    The mask method operates on any masks that might have been applied to
    the images in a group. The output is a binary image where the “1”
@@ -156,8 +136,17 @@ References
    4(10): e7497 `(link)`_.
 
 .. _(link): https://doi.org/10.1371/journal.pone.0007497
-"""
-            % globals(),
+""".format(
+            **{
+                "P_AVERAGE": ProjectionType.AVERAGE.value,
+                "P_MAXIMUM": ProjectionType.MAXIMUM.value,
+                "P_MINIMUM": ProjectionType.MINIMUM.value,
+                "P_SUM": ProjectionType.SUM.value,
+                "P_VARIANCE": ProjectionType.VARIANCE.value,
+                "P_POWER": ProjectionType.POWER.value,
+                "P_BRIGHTFIELD": ProjectionType.BRIGHTFIELD.value,
+                "P_MASK": ProjectionType.MASK.value,
+            })
         )
 
         self.projection_image_name = ImageName(
@@ -171,14 +160,16 @@ References
             6.0,
             minval=1.0,
             doc="""\
-*(Used only if "%(P_POWER)s" is selected as the projection method)*
+*(Used only if "{P_PROJECTION}" is selected as the projection method)*
 
 This setting controls the frequency at which the power is measured. A
 frequency of 2 will respond most strongly to pixels that alternate
 between dark and light in successive z-stack slices. A frequency of N
 will respond most strongly to pixels whose brightness cycles every N
-slices."""
-            % globals(),
+slices.""".format(**
+        {
+           "P_PROJECTION": ProjectionType.POWER.value,
+        })
         )
 
     def settings(self):
@@ -191,7 +182,7 @@ slices."""
 
     def visible_settings(self):
         result = [self.image_name, self.projection_type, self.projection_image_name]
-        if self.projection_type == P_POWER:
+        if self.projection_type == ProjectionType.POWER.value:
             result += [self.frequency]
         return result
 

--- a/src/subpackages/library/cellprofiler_library/functions/image_processing.py
+++ b/src/subpackages/library/cellprofiler_library/functions/image_processing.py
@@ -3105,7 +3105,3 @@ def apply_target_mask(x_data: ImageAny, masking_image: Union[ImageAny,ObjectSegm
     mask = masking_image.astype(bool)
     x_data[~mask] = 0
     return x_data
-
-
-
-

--- a/src/subpackages/library/cellprofiler_library/modules/_makeprojection.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_makeprojection.py
@@ -1,0 +1,321 @@
+from pydantic import validate_call, ConfigDict
+import numpy as np
+from typing import Dict, Any, Tuple, Optional, Union
+from ..opts.makeprojection import ProjectionType
+from ..opts.makeprojection import StateKey
+
+
+@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
+def accumulate_projection(
+    image: np.ndarray,
+    mask: Optional[np.ndarray],
+    state: Dict[str, Any],
+    method: ProjectionType,
+    frequency: float = 6.0
+) -> Dict[str, Any]:
+    """
+    Accumulate an image into the projection state.
+    
+    Args:
+        image: The pixel data of the image to accumulate.
+        mask: The mask of the image (True = valid). If None, all pixels are valid.
+        state: The current accumulation state. Empty dict for first image.
+        method: The projection method.
+        frequency: Frequency parameter for Power projection.
+    
+    Returns:
+        Updated state dictionary.
+    """
+    # Ensure mask exists
+    if mask is None:
+        mask = np.ones(image.shape[:2], dtype=bool)
+        
+    # Initialize if empty
+    is_first = len(state) == 0
+
+    if method == ProjectionType.AVERAGE or method == ProjectionType.SUM:
+        _accumulate_sum(image, mask, state, is_first)
+    elif method == ProjectionType.MAXIMUM:
+        _accumulate_maximum(image, mask, state, is_first)
+    elif method == ProjectionType.MINIMUM:
+        _accumulate_minimum(image, mask, state, is_first)
+    elif method == ProjectionType.VARIANCE:
+        _accumulate_variance(image, mask, state, is_first)
+    elif method == ProjectionType.POWER:
+        _accumulate_power(image, mask, state, is_first, frequency)
+    elif method == ProjectionType.BRIGHTFIELD:
+        _accumulate_brightfield(image, mask, state, is_first)
+    elif method == ProjectionType.MASK:
+        _accumulate_mask(image, mask, state, is_first)
+    else:
+        raise ValueError(f"Unknown projection method: {method}")
+        
+    return state
+
+@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
+def calculate_final_projection(
+    state: Dict[str, Any],
+    method: ProjectionType
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Calculate the final projection image from the state.
+    
+    Args:
+        state: The accumulation state.
+        method: The projection method.
+        
+    Returns:
+        Tuple of (pixel_data, mask).
+    """
+    if method == ProjectionType.AVERAGE:
+        return _finalize_average(state)
+    elif method == ProjectionType.SUM:
+        return _finalize_sum(state)
+    elif method == ProjectionType.MAXIMUM:
+        return _finalize_maximum(state)
+    elif method == ProjectionType.MINIMUM:
+        return _finalize_minimum(state)
+    elif method == ProjectionType.VARIANCE:
+        return _finalize_variance(state)
+    elif method == ProjectionType.POWER:
+        return _finalize_power(state)
+    elif method == ProjectionType.BRIGHTFIELD:
+        return _finalize_brightfield(state)
+    elif method == ProjectionType.MASK:
+        return _finalize_mask(state)
+    else:
+        raise ValueError(f"Unknown projection method: {method}")
+
+# --- Helper functions ---
+
+def _wrap_result(image: np.ndarray, mask: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """Helper to ensure mask compatibility and return tuple"""
+    # Original logic: _wrap_image
+    # If mask is 3D, take first slice
+    final_mask = mask
+    if mask.ndim == 3:
+        final_mask = mask[:, :, 0]
+    
+    # Original logic checks numpy.all(mask) but here we return mask always
+    return image, final_mask
+
+def _accumulate_sum(image: np.ndarray, mask: np.ndarray, state: Dict[str, Any], is_first: bool):
+    if is_first:
+        state[StateKey.IMAGE_COUNT.value] = mask.astype(int)
+        
+        # _set_image_impl for Sum
+        img_copy = image.copy()
+        img_copy[~mask] = 0
+        state[StateKey.IMAGE.value] = img_copy
+    else:
+        state[StateKey.IMAGE_COUNT.value] += mask.astype(int)
+        
+        state[StateKey.IMAGE.value][mask] += image[mask]
+
+def _finalize_sum(state: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray]:
+    image = state[StateKey.IMAGE.value]
+    image_count = state[StateKey.IMAGE_COUNT.value]
+    
+    mask = image_count > 0
+    
+    if np.any(~mask):
+        cached_image = image.copy()
+        cached_image[~mask] = 0
+    else:
+        cached_image = image
+        
+    return _wrap_result(cached_image, mask)
+
+def _finalize_average(state: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray]:
+    image = state[StateKey.IMAGE.value]
+    image_count = state[StateKey.IMAGE_COUNT.value]
+    
+    # Handle multi-channel image count broadcasting
+    if image.ndim == 3 and image_count.ndim == 2:
+        image_count = np.dstack([image_count] * image.shape[2])
+        
+    mask = image_count > 0
+    
+    # Avoid divide by zero
+    cached_image = np.zeros_like(image)
+    valid = image_count > 0
+    cached_image[valid] = image[valid] / image_count[valid]
+    
+    if cached_image.ndim == 3 and mask.ndim == 2:
+        cached_image[~mask, :] = 0
+    else:
+        cached_image[~mask] = 0
+        
+    return _wrap_result(cached_image, mask)
+
+def _accumulate_maximum(image: np.ndarray, mask: np.ndarray, state: Dict[str, Any], is_first: bool):
+    if is_first:
+        state[StateKey.IMAGE_COUNT.value] = mask.astype(int)
+        
+        img_copy = image.copy()
+        img_copy[~mask] = 0
+        state[StateKey.IMAGE.value] = img_copy
+    else:
+        state[StateKey.IMAGE_COUNT.value] += mask.astype(int)
+        
+        # _accumulate_image_impl
+        current_image = state[StateKey.IMAGE.value]
+        state[StateKey.IMAGE.value][mask] = np.maximum(current_image[mask], image[mask])
+
+def _finalize_maximum(state: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray]:
+    # Same finalization logic as SumProvider except it uses the max accumulated image
+    return _finalize_sum(state)
+
+def _accumulate_minimum(image: np.ndarray, mask: np.ndarray, state: Dict[str, Any], is_first: bool):
+    if is_first:
+        state[StateKey.IMAGE_COUNT.value] = mask.astype(int)
+        
+        img_copy = image.copy()
+        # Set all masked pixels to 1 so that they are not included in the minimum
+        img_copy[~mask] = 1 
+        state[StateKey.IMAGE.value] = img_copy
+    else:
+        state[StateKey.IMAGE_COUNT.value] += mask.astype(int)
+        
+        current_image = state[StateKey.IMAGE.value]
+        state[StateKey.IMAGE.value][mask] = np.minimum(current_image[mask], image[mask])
+
+def _finalize_minimum(state: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray]:
+    return _finalize_sum(state)
+
+def _accumulate_variance(image: np.ndarray, mask: np.ndarray, state: Dict[str, Any], is_first: bool):
+    if is_first:
+        state[StateKey.IMAGE_COUNT.value] = mask.astype(int)
+        
+        vsum = image.copy()
+        vsum[~mask] = 0
+        state[StateKey.VSUM.value] = vsum
+        state[StateKey.VSQUARED.value] = vsum.astype(np.float64) ** 2.0
+    else:
+        state[StateKey.IMAGE_COUNT.value] += mask.astype(int)
+        
+        state[StateKey.VSUM.value][mask] += image[mask]
+        state[StateKey.VSQUARED.value][mask] += image[mask].astype(np.float64) ** 2
+
+def _finalize_variance(state: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray]:
+    vsum = state[StateKey.VSUM.value]
+    vsquared = state[StateKey.VSQUARED.value]
+    image_count = state[StateKey.IMAGE_COUNT.value]
+    
+    if vsquared.ndim == 3 and image_count.ndim == 2:
+        image_count = np.dstack([image_count] * vsquared.shape[2])
+        
+    mask = image_count > 0
+    
+    cached_image = np.zeros(vsquared.shape, np.float32)
+    
+    # Calculate variance: E[x^2] - (E[x])^2
+    
+    valid = mask # logic alias
+    cached_image[valid] = vsquared[valid] / image_count[valid]
+    cached_image[valid] -= (vsum[valid] ** 2) / (image_count[valid] ** 2)
+    
+    cached_image[~mask] = 0
+    
+    return _wrap_result(cached_image, mask)
+
+def _accumulate_power(image: np.ndarray, mask: np.ndarray, state: Dict[str, Any], is_first: bool, frequency: float):
+    if is_first:
+        state[StateKey.IMAGE_COUNT.value] = mask.astype(int)
+        
+        vsum = image.copy()
+        vsum[~mask] = 0
+        state[StateKey.VSUM.value] = vsum
+        
+        state[StateKey.POWER_MASK.value] = state[StateKey.IMAGE_COUNT.value].astype(np.complex128).copy()
+        state[StateKey.POWER_IMAGE.value] = image.astype(np.complex128).copy()
+        state[StateKey.STACK_NUMBER.value] = 1
+    else:
+        state[StateKey.IMAGE_COUNT.value] += mask.astype(int)
+        
+        stack_number = state[StateKey.STACK_NUMBER.value]
+        multiplier = np.exp(2j * np.pi * float(stack_number) / frequency)
+        state[StateKey.STACK_NUMBER.value] += 1
+        
+        state[StateKey.VSUM.value][mask] += image[mask]
+        state[StateKey.POWER_IMAGE.value][mask] += multiplier * image[mask]
+        state[StateKey.POWER_MASK.value][mask] += multiplier
+
+def _finalize_power(state: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray]:
+    image_count = state[StateKey.IMAGE_COUNT.value]
+    power_image = state[StateKey.POWER_IMAGE.value]
+    vsum = state[StateKey.VSUM.value]
+    power_mask = state[StateKey.POWER_MASK.value]
+    
+    if power_image.ndim == 3 and image_count.ndim == 2:
+        image_count = np.dstack([image_count] * power_image.shape[2])
+        
+    mask = image_count > 0
+    
+    cached_image = np.zeros(image_count.shape, np.complex128)
+    cached_image[mask] = power_image[mask]
+    cached_image[mask] -= (vsum[mask] * power_mask[mask] / image_count[mask])
+    
+    # |z|^2 = z * conj(z)
+    cached_image = (cached_image * np.conj(cached_image)).real.astype(np.float32)
+    cached_image[~mask] = 0
+    
+    return _wrap_result(cached_image, mask)
+
+def _accumulate_brightfield(image: np.ndarray, mask: np.ndarray, state: Dict[str, Any], is_first: bool):
+    if is_first:
+        state[StateKey.IMAGE_COUNT.value] = mask.astype(int)
+        
+        state[StateKey.BRIGHT_MAX.value] = image.copy()
+        state[StateKey.BRIGHT_MIN.value] = image.copy()
+        state[StateKey.NORM0.value] = np.mean(image)
+    else:
+        state[StateKey.IMAGE_COUNT.value] += mask.astype(int)
+        
+        norm0 = state[StateKey.NORM0.value]
+        bright_max = state[StateKey.BRIGHT_MAX.value]
+        bright_min = state[StateKey.BRIGHT_MIN.value]
+        
+        norm = np.mean(image)
+        assert norm != 0, "norm is zero"
+        pixel_data = image * norm0 / norm
+        
+        max_mask = (bright_max < pixel_data) & mask
+        min_mask = (bright_min > pixel_data) & mask
+        
+        bright_min[min_mask] = pixel_data[min_mask]
+        bright_max[max_mask] = pixel_data[max_mask]
+        # Original: self._bright_min[max_mask] = self._bright_max[max_mask]
+        bright_min[max_mask] = bright_max[max_mask]
+
+def _finalize_brightfield(state: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray]:
+    image_count = state[StateKey.IMAGE_COUNT.value]
+    bright_max = state[StateKey.BRIGHT_MAX.value]
+    bright_min = state[StateKey.BRIGHT_MIN.value]
+    
+    if bright_max.ndim == 3 and image_count.ndim == 2:
+        image_count = np.dstack([image_count] * bright_max.shape[2])
+        
+    mask = image_count > 0
+    
+    cached_image = np.zeros(image_count.shape, np.float32)
+    cached_image[mask] = bright_max[mask] - bright_min[mask]
+    cached_image[~mask] = 0
+    
+    return _wrap_result(cached_image, mask)
+
+def _accumulate_mask(image: np.ndarray, mask: np.ndarray, state: Dict[str, Any], is_first: bool):
+    # For MaskProvider, "image" is actually the mask.
+    # So we are accumulating MASKS, not pixel data.
+    
+    if is_first:
+        state[StateKey.IMAGE_COUNT.value] = mask.astype(int)
+        state[StateKey.IMAGE.value] = mask # Accumulating the mask into StateKey.IMAGE.value
+    else:
+        state[StateKey.IMAGE.value] = state[StateKey.IMAGE.value] & mask
+
+def _finalize_mask(state: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray]:
+    final_mask = state[StateKey.IMAGE.value]
+    # MaskProvider returns Image(self._image), so pixel data IS the mask.    
+    return final_mask, np.ones(final_mask.shape, dtype=bool)
+

--- a/src/subpackages/library/cellprofiler_library/modules/_makeprojection.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_makeprojection.py
@@ -1,17 +1,22 @@
-from pydantic import validate_call, ConfigDict
+from pydantic import validate_call, ConfigDict, Field
 import numpy as np
-from typing import Dict, Any, Tuple, Optional, Union
+from typing import Dict, Any, Tuple, Optional, Union, Annotated
+from cellprofiler_library.types import Image2D, Image2DMask
 from ..opts.makeprojection import ProjectionType
 from ..opts.makeprojection import StateKey
 
+STATE_NOT_INITIALIZED = "Invalid state key. Please initialize the state dictionary with a call to set_projection before calling this function"
+POWER_FREQUENCY_NOT_PROVIDED = "Frequency must be provided for Power projection"
+PROJECTION_METHOD_INVALID = "Unknown projection method: %s"
+NORM_IS_ZERO = "Norm is zero. Please check your input images"
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def accumulate_projection(
-    image: np.ndarray,
-    mask: Optional[np.ndarray],
-    state: Dict[str, Any],
-    method: ProjectionType,
-    frequency: float = 6.0
+    image:      Annotated[Image2D, Field(description="The pixel data of the image to accumulate")],
+    mask:       Annotated[Optional[Image2DMask], Field(description="The mask of the image (True = valid). If None, all pixels are valid")],
+    state:      Annotated[Dict[str, Any], Field(description="The current accumulation state. Empty dict for first image")],
+    method:     Annotated[ProjectionType, Field(description="The projection method")],
+    frequency:  Annotated[Optional[float], Field(description="Frequency parameter for Power projection")] = 6.0
 ) -> Dict[str, Any]:
     """
     Accumulate an image into the projection state.
@@ -26,37 +31,90 @@ def accumulate_projection(
     Returns:
         Updated state dictionary.
     """
+    assert StateKey.IMAGE_COUNT.value in state, STATE_NOT_INITIALIZED
+    has_mask = mask is not None
+    if has_mask:
+        state[StateKey.IMAGE_COUNT.value] += mask.astype(int)
+    else:
+        state[StateKey.IMAGE_COUNT.value] += 1
     # Ensure mask exists
     if mask is None:
         mask = np.ones(image.shape[:2], dtype=bool)
         
     # Initialize if empty
-    is_first = len(state) == 0
 
     if method == ProjectionType.AVERAGE or method == ProjectionType.SUM:
-        _accumulate_sum(image, mask, state, is_first)
+        _accumulate_sum(image, mask, state)
     elif method == ProjectionType.MAXIMUM:
-        _accumulate_maximum(image, mask, state, is_first)
+        _accumulate_maximum(image, mask, state)
     elif method == ProjectionType.MINIMUM:
-        _accumulate_minimum(image, mask, state, is_first)
+        _accumulate_minimum(image, mask, state)
     elif method == ProjectionType.VARIANCE:
-        _accumulate_variance(image, mask, state, is_first)
+        _accumulate_variance(image, mask, state)
     elif method == ProjectionType.POWER:
-        _accumulate_power(image, mask, state, is_first, frequency)
+        assert frequency is not None, POWER_FREQUENCY_NOT_PROVIDED
+        _accumulate_power(image, mask, state, frequency)
     elif method == ProjectionType.BRIGHTFIELD:
-        _accumulate_brightfield(image, mask, state, is_first)
+        _accumulate_brightfield(image, mask, state)
     elif method == ProjectionType.MASK:
-        _accumulate_mask(image, mask, state, is_first)
+        _accumulate_mask(image, mask, state)
     else:
         raise ValueError(f"Unknown projection method: {method}")
         
     return state
 
+def set_projection(
+        image:  Annotated[Image2D, Field(description="The pixel data of the image to accumulate.")],
+        mask:   Annotated[Optional[Image2DMask], Field(description="The mask of the image (True = valid). If None, all pixels are valid")],
+        state:  Annotated[Dict[str, Any], Field(description="The current accumulation state. Empty dict for first image")],
+        method: Annotated[ProjectionType, Field(description="The projection method")],
+    ) -> Dict[str, Any]:
+    has_mask = mask is not None
+    if not has_mask:
+        mask = np.ones(image.shape[:2], dtype=bool)
+    state[StateKey.IMAGE_COUNT.value] = mask.astype(int)
+    
+    if method == ProjectionType.VARIANCE:
+        state[StateKey.VSUM.value] = image.copy()
+        state[StateKey.VSUM.value][~mask] = 0
+        state[StateKey.VSQUARED.value] = state[StateKey.VSUM.value].astype(np.float64) ** 2.0
+
+    elif method == ProjectionType.POWER:
+        state[StateKey.VSUM.value] = image.copy()
+        state[StateKey.VSUM.value][~mask] = 0
+        #
+        # e**0 = 1 so the first image is always in the real plane
+        #
+        state[StateKey.POWER_MASK.value] = state[StateKey.IMAGE_COUNT.value].astype(np.complex128).copy()
+        state[StateKey.POWER_IMAGE.value] = image.astype(np.complex128).copy()
+        state[StateKey.STACK_NUMBER.value] = 1
+
+    elif method == ProjectionType.BRIGHTFIELD:
+        state[StateKey.BRIGHT_MAX.value] = image.copy()
+        state[StateKey.BRIGHT_MIN.value] = image.copy()
+        state[StateKey.NORM0.value] = np.mean(image)
+
+    elif method == ProjectionType.MASK:
+        state[StateKey.IMAGE.value] = mask
+
+    elif method in (ProjectionType.AVERAGE, ProjectionType.SUM, ProjectionType.MAXIMUM, ProjectionType.MINIMUM):
+        state[StateKey.IMAGE.value] = image.copy()
+        if has_mask:
+            nan_value = 1 if method == ProjectionType.MINIMUM else 0
+            state[StateKey.IMAGE.value][~mask] = nan_value
+
+    else:
+        raise ValueError(PROJECTION_METHOD_INVALID % method)
+    
+    return state
+
+    
+
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def calculate_final_projection(
-    state: Dict[str, Any],
-    method: ProjectionType
-) -> Tuple[np.ndarray, np.ndarray]:
+    state: Annotated[Dict[str, Any], Field(description="The accumulation state.")],
+    method: Annotated[ProjectionType, Field(description="The projection method.")]
+) -> Tuple[Image2D, Image2DMask]:
     """
     Calculate the final projection image from the state.
     
@@ -84,11 +142,11 @@ def calculate_final_projection(
     elif method == ProjectionType.MASK:
         return _finalize_mask(state)
     else:
-        raise ValueError(f"Unknown projection method: {method}")
+        raise ValueError(PROJECTION_METHOD_INVALID % method)
 
 # --- Helper functions ---
 
-def _wrap_result(image: np.ndarray, mask: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+def _wrap_result(image: Image2D, mask: Image2DMask) -> Tuple[Image2D, Image2DMask]:
     """Helper to ensure mask compatibility and return tuple"""
     # Original logic: _wrap_image
     # If mask is 3D, take first slice
@@ -99,20 +157,13 @@ def _wrap_result(image: np.ndarray, mask: np.ndarray) -> Tuple[np.ndarray, np.nd
     # Original logic checks numpy.all(mask) but here we return mask always
     return image, final_mask
 
-def _accumulate_sum(image: np.ndarray, mask: np.ndarray, state: Dict[str, Any], is_first: bool):
-    if is_first:
-        state[StateKey.IMAGE_COUNT.value] = mask.astype(int)
-        
-        # _set_image_impl for Sum
-        img_copy = image.copy()
-        img_copy[~mask] = 0
-        state[StateKey.IMAGE.value] = img_copy
-    else:
-        state[StateKey.IMAGE_COUNT.value] += mask.astype(int)
-        
-        state[StateKey.IMAGE.value][mask] += image[mask]
+def _accumulate_sum(image: Image2D, mask: Image2DMask, state: Dict[str, Any]):
+    """This function is called by both sum and average projection methods"""
+    assert StateKey.IMAGE.value in state, STATE_NOT_INITIALIZED
+    state[StateKey.IMAGE.value][mask] += image[mask]
 
-def _finalize_sum(state: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray]:
+
+def _finalize_sum(state: Dict[str, Any]) -> Tuple[Image2D, Image2DMask]:
     image = state[StateKey.IMAGE.value]
     image_count = state[StateKey.IMAGE_COUNT.value]
     
@@ -126,7 +177,7 @@ def _finalize_sum(state: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray]:
         
     return _wrap_result(cached_image, mask)
 
-def _finalize_average(state: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray]:
+def _finalize_average(state: Dict[str, Any]) -> Tuple[Image2D, Image2DMask]:
     image = state[StateKey.IMAGE.value]
     image_count = state[StateKey.IMAGE_COUNT.value]
     
@@ -148,56 +199,30 @@ def _finalize_average(state: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray]:
         
     return _wrap_result(cached_image, mask)
 
-def _accumulate_maximum(image: np.ndarray, mask: np.ndarray, state: Dict[str, Any], is_first: bool):
-    if is_first:
-        state[StateKey.IMAGE_COUNT.value] = mask.astype(int)
-        
-        img_copy = image.copy()
-        img_copy[~mask] = 0
-        state[StateKey.IMAGE.value] = img_copy
-    else:
-        state[StateKey.IMAGE_COUNT.value] += mask.astype(int)
-        
-        # _accumulate_image_impl
-        current_image = state[StateKey.IMAGE.value]
-        state[StateKey.IMAGE.value][mask] = np.maximum(current_image[mask], image[mask])
+def _accumulate_maximum(image: Image2D, mask: Image2DMask, state: Dict[str, Any]):
+    assert StateKey.IMAGE.value in state, STATE_NOT_INITIALIZED
+    current_image = state[StateKey.IMAGE.value]
+    state[StateKey.IMAGE.value][mask] = np.maximum(current_image[mask], image[mask])
 
-def _finalize_maximum(state: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray]:
+def _finalize_maximum(state: Dict[str, Any]) -> Tuple[Image2D, Image2DMask]:
     # Same finalization logic as SumProvider except it uses the max accumulated image
     return _finalize_sum(state)
 
-def _accumulate_minimum(image: np.ndarray, mask: np.ndarray, state: Dict[str, Any], is_first: bool):
-    if is_first:
-        state[StateKey.IMAGE_COUNT.value] = mask.astype(int)
-        
-        img_copy = image.copy()
-        # Set all masked pixels to 1 so that they are not included in the minimum
-        img_copy[~mask] = 1 
-        state[StateKey.IMAGE.value] = img_copy
-    else:
-        state[StateKey.IMAGE_COUNT.value] += mask.astype(int)
-        
-        current_image = state[StateKey.IMAGE.value]
-        state[StateKey.IMAGE.value][mask] = np.minimum(current_image[mask], image[mask])
+def _accumulate_minimum(image: Image2D, mask: Image2DMask, state: Dict[str, Any]):
+    assert StateKey.IMAGE.value in state, STATE_NOT_INITIALIZED
+    current_image = state[StateKey.IMAGE.value]
+    state[StateKey.IMAGE.value][mask] = np.minimum(current_image[mask], image[mask])
 
-def _finalize_minimum(state: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray]:
+def _finalize_minimum(state: Dict[str, Any]) -> Tuple[Image2D, Image2DMask]:
     return _finalize_sum(state)
 
-def _accumulate_variance(image: np.ndarray, mask: np.ndarray, state: Dict[str, Any], is_first: bool):
-    if is_first:
-        state[StateKey.IMAGE_COUNT.value] = mask.astype(int)
-        
-        vsum = image.copy()
-        vsum[~mask] = 0
-        state[StateKey.VSUM.value] = vsum
-        state[StateKey.VSQUARED.value] = vsum.astype(np.float64) ** 2.0
-    else:
-        state[StateKey.IMAGE_COUNT.value] += mask.astype(int)
-        
-        state[StateKey.VSUM.value][mask] += image[mask]
-        state[StateKey.VSQUARED.value][mask] += image[mask].astype(np.float64) ** 2
+def _accumulate_variance(image: Image2D, mask: Image2DMask, state: Dict[str, Any]):
+    assert StateKey.VSUM.value in state, STATE_NOT_INITIALIZED
+    assert StateKey.VSQUARED.value in state, STATE_NOT_INITIALIZED
+    state[StateKey.VSUM.value][mask] += image[mask]
+    state[StateKey.VSQUARED.value][mask] += image[mask].astype(np.float64) ** 2
 
-def _finalize_variance(state: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray]:
+def _finalize_variance(state: Dict[str, Any]) -> Tuple[Image2D, Image2DMask]:
     vsum = state[StateKey.VSUM.value]
     vsquared = state[StateKey.VSQUARED.value]
     image_count = state[StateKey.IMAGE_COUNT.value]
@@ -219,29 +244,21 @@ def _finalize_variance(state: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray]:
     
     return _wrap_result(cached_image, mask)
 
-def _accumulate_power(image: np.ndarray, mask: np.ndarray, state: Dict[str, Any], is_first: bool, frequency: float):
-    if is_first:
-        state[StateKey.IMAGE_COUNT.value] = mask.astype(int)
-        
-        vsum = image.copy()
-        vsum[~mask] = 0
-        state[StateKey.VSUM.value] = vsum
-        
-        state[StateKey.POWER_MASK.value] = state[StateKey.IMAGE_COUNT.value].astype(np.complex128).copy()
-        state[StateKey.POWER_IMAGE.value] = image.astype(np.complex128).copy()
-        state[StateKey.STACK_NUMBER.value] = 1
-    else:
-        state[StateKey.IMAGE_COUNT.value] += mask.astype(int)
-        
-        stack_number = state[StateKey.STACK_NUMBER.value]
-        multiplier = np.exp(2j * np.pi * float(stack_number) / frequency)
-        state[StateKey.STACK_NUMBER.value] += 1
-        
-        state[StateKey.VSUM.value][mask] += image[mask]
-        state[StateKey.POWER_IMAGE.value][mask] += multiplier * image[mask]
-        state[StateKey.POWER_MASK.value][mask] += multiplier
+def _accumulate_power(image: Image2D, mask: Image2DMask, state: Dict[str, Any], frequency: float):     
+    assert StateKey.VSUM.value in state, STATE_NOT_INITIALIZED
+    assert StateKey.POWER_MASK.value in state, STATE_NOT_INITIALIZED
+    assert StateKey.POWER_IMAGE.value in state, STATE_NOT_INITIALIZED
+    assert StateKey.STACK_NUMBER.value in state, STATE_NOT_INITIALIZED
 
-def _finalize_power(state: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray]:
+    stack_number = state[StateKey.STACK_NUMBER.value]
+    multiplier = np.exp(2j * np.pi * float(stack_number) / frequency)
+    state[StateKey.STACK_NUMBER.value] += 1
+    
+    state[StateKey.VSUM.value][mask] += image[mask]
+    state[StateKey.POWER_IMAGE.value][mask] += multiplier * image[mask]
+    state[StateKey.POWER_MASK.value][mask] += multiplier
+
+def _finalize_power(state: Dict[str, Any]) -> Tuple[Image2D, Image2DMask]:
     image_count = state[StateKey.IMAGE_COUNT.value]
     power_image = state[StateKey.POWER_IMAGE.value]
     vsum = state[StateKey.VSUM.value]
@@ -262,33 +279,29 @@ def _finalize_power(state: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray]:
     
     return _wrap_result(cached_image, mask)
 
-def _accumulate_brightfield(image: np.ndarray, mask: np.ndarray, state: Dict[str, Any], is_first: bool):
-    if is_first:
-        state[StateKey.IMAGE_COUNT.value] = mask.astype(int)
-        
-        state[StateKey.BRIGHT_MAX.value] = image.copy()
-        state[StateKey.BRIGHT_MIN.value] = image.copy()
-        state[StateKey.NORM0.value] = np.mean(image)
-    else:
-        state[StateKey.IMAGE_COUNT.value] += mask.astype(int)
-        
-        norm0 = state[StateKey.NORM0.value]
-        bright_max = state[StateKey.BRIGHT_MAX.value]
-        bright_min = state[StateKey.BRIGHT_MIN.value]
-        
-        norm = np.mean(image)
-        assert norm != 0, "norm is zero"
-        pixel_data = image * norm0 / norm
-        
-        max_mask = (bright_max < pixel_data) & mask
-        min_mask = (bright_min > pixel_data) & mask
-        
-        bright_min[min_mask] = pixel_data[min_mask]
-        bright_max[max_mask] = pixel_data[max_mask]
-        # Original: self._bright_min[max_mask] = self._bright_max[max_mask]
-        bright_min[max_mask] = bright_max[max_mask]
+def _accumulate_brightfield(image: Image2D, mask: Image2DMask, state: Dict[str, Any]):
+    assert StateKey.BRIGHT_MAX.value in state, STATE_NOT_INITIALIZED
+    assert StateKey.BRIGHT_MIN.value in state, STATE_NOT_INITIALIZED
+    assert StateKey.NORM0.value in state, STATE_NOT_INITIALIZED
 
-def _finalize_brightfield(state: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray]:
+    norm0 = state[StateKey.NORM0.value]
+    bright_max = state[StateKey.BRIGHT_MAX.value]
+    bright_min = state[StateKey.BRIGHT_MIN.value]
+    
+    norm = np.mean(image)
+    assert norm != 0, NORM_IS_ZERO
+    pixel_data = image * norm0 / norm
+    
+    max_mask = (bright_max < pixel_data) & mask
+    min_mask = (bright_min > pixel_data) & mask
+    
+    bright_min[min_mask] = pixel_data[min_mask]
+    bright_max[max_mask] = pixel_data[max_mask]
+    bright_min[max_mask] = bright_max[max_mask]
+    state[StateKey.BRIGHT_MAX.value] = bright_max
+    state[StateKey.BRIGHT_MIN.value] = bright_min  
+
+def _finalize_brightfield(state: Dict[str, Any]) -> Tuple[Image2D, Image2DMask]:
     image_count = state[StateKey.IMAGE_COUNT.value]
     bright_max = state[StateKey.BRIGHT_MAX.value]
     bright_min = state[StateKey.BRIGHT_MIN.value]
@@ -304,18 +317,11 @@ def _finalize_brightfield(state: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray
     
     return _wrap_result(cached_image, mask)
 
-def _accumulate_mask(image: np.ndarray, mask: np.ndarray, state: Dict[str, Any], is_first: bool):
-    # For MaskProvider, "image" is actually the mask.
-    # So we are accumulating MASKS, not pixel data.
-    
-    if is_first:
-        state[StateKey.IMAGE_COUNT.value] = mask.astype(int)
-        state[StateKey.IMAGE.value] = mask # Accumulating the mask into StateKey.IMAGE.value
-    else:
-        state[StateKey.IMAGE.value] = state[StateKey.IMAGE.value] & mask
+def _accumulate_mask(image: Image2D, mask: Image2DMask, state: Dict[str, Any]):
+    assert StateKey.IMAGE.value in state, STATE_NOT_INITIALIZED
+    state[StateKey.IMAGE.value] = state[StateKey.IMAGE.value] & mask
 
-def _finalize_mask(state: Dict[str, Any]) -> Tuple[np.ndarray, np.ndarray]:
+def _finalize_mask(state: Dict[str, Any]) -> Tuple[Image2D, Image2DMask]:
     final_mask = state[StateKey.IMAGE.value]
-    # MaskProvider returns Image(self._image), so pixel data IS the mask.    
     return final_mask, np.ones(final_mask.shape, dtype=bool)
 

--- a/src/subpackages/library/cellprofiler_library/modules/_makeprojection.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_makeprojection.py
@@ -125,37 +125,32 @@ def calculate_final_projection(
     Returns:
         Tuple of (pixel_data, mask).
     """
+    
+    image_count = state[StateKey.IMAGE_COUNT.value]
+    mask_2d = image_count > 0
+    final_projection = None
     if method == ProjectionType.AVERAGE:
-        return _finalize_average(state)
+        final_projection = _finalize_average(state)
     elif method == ProjectionType.SUM:
-        return _finalize_sum(state)
+        final_projection = _finalize_sum(state)
     elif method == ProjectionType.MAXIMUM:
-        return _finalize_maximum(state)
+        final_projection = _finalize_maximum(state)
     elif method == ProjectionType.MINIMUM:
-        return _finalize_minimum(state)
+        final_projection = _finalize_minimum(state)
     elif method == ProjectionType.VARIANCE:
-        return _finalize_variance(state)
+        final_projection = _finalize_variance(state)
     elif method == ProjectionType.POWER:
-        return _finalize_power(state)
+        final_projection = _finalize_power(state)
     elif method == ProjectionType.BRIGHTFIELD:
-        return _finalize_brightfield(state)
+        final_projection = _finalize_brightfield(state)
     elif method == ProjectionType.MASK:
-        return _finalize_mask(state)
+        final_projection = _finalize_mask(state)
     else:
         raise ValueError(PROJECTION_METHOD_INVALID % method)
 
-# --- Helper functions ---
+    return final_projection, mask_2d
 
-def _wrap_result(image: Image2D, mask: Image2DMask) -> Tuple[Image2D, Image2DMask]:
-    """Helper to ensure mask compatibility and return tuple"""
-    # Original logic: _wrap_image
-    # If mask is 3D, take first slice
-    final_mask = mask
-    if mask.ndim == 3:
-        final_mask = mask[:, :, 0]
-    
-    # Original logic checks numpy.all(mask) but here we return mask always
-    return image, final_mask
+# --- Helper functions ---
 
 def _accumulate_sum(image: Image2D, mask: Image2DMask, state: Dict[str, Any]):
     """This function is called by both sum and average projection methods"""
@@ -163,7 +158,7 @@ def _accumulate_sum(image: Image2D, mask: Image2DMask, state: Dict[str, Any]):
     state[StateKey.IMAGE.value][mask] += image[mask]
 
 
-def _finalize_sum(state: Dict[str, Any]) -> Tuple[Image2D, Image2DMask]:
+def _finalize_sum(state: Dict[str, Any]) -> Image2D:
     image = state[StateKey.IMAGE.value]
     image_count = state[StateKey.IMAGE_COUNT.value]
     
@@ -175,12 +170,11 @@ def _finalize_sum(state: Dict[str, Any]) -> Tuple[Image2D, Image2DMask]:
     else:
         cached_image = image
         
-    return _wrap_result(cached_image, mask)
+    return cached_image
 
-def _finalize_average(state: Dict[str, Any]) -> Tuple[Image2D, Image2DMask]:
+def _finalize_average(state: Dict[str, Any]) -> Image2D:
     image = state[StateKey.IMAGE.value]
     image_count = state[StateKey.IMAGE_COUNT.value]
-    
     # Handle multi-channel image count broadcasting
     if image.ndim == 3 and image_count.ndim == 2:
         image_count = np.dstack([image_count] * image.shape[2])
@@ -197,14 +191,14 @@ def _finalize_average(state: Dict[str, Any]) -> Tuple[Image2D, Image2DMask]:
     else:
         cached_image[~mask] = 0
         
-    return _wrap_result(cached_image, mask)
+    return cached_image
 
 def _accumulate_maximum(image: Image2D, mask: Image2DMask, state: Dict[str, Any]):
     assert StateKey.IMAGE.value in state, STATE_NOT_INITIALIZED
     current_image = state[StateKey.IMAGE.value]
     state[StateKey.IMAGE.value][mask] = np.maximum(current_image[mask], image[mask])
 
-def _finalize_maximum(state: Dict[str, Any]) -> Tuple[Image2D, Image2DMask]:
+def _finalize_maximum(state: Dict[str, Any]) -> Image2D:
     # Same finalization logic as SumProvider except it uses the max accumulated image
     return _finalize_sum(state)
 
@@ -213,7 +207,7 @@ def _accumulate_minimum(image: Image2D, mask: Image2DMask, state: Dict[str, Any]
     current_image = state[StateKey.IMAGE.value]
     state[StateKey.IMAGE.value][mask] = np.minimum(current_image[mask], image[mask])
 
-def _finalize_minimum(state: Dict[str, Any]) -> Tuple[Image2D, Image2DMask]:
+def _finalize_minimum(state: Dict[str, Any]) -> Image2D:
     return _finalize_sum(state)
 
 def _accumulate_variance(image: Image2D, mask: Image2DMask, state: Dict[str, Any]):
@@ -222,7 +216,7 @@ def _accumulate_variance(image: Image2D, mask: Image2DMask, state: Dict[str, Any
     state[StateKey.VSUM.value][mask] += image[mask]
     state[StateKey.VSQUARED.value][mask] += image[mask].astype(np.float64) ** 2
 
-def _finalize_variance(state: Dict[str, Any]) -> Tuple[Image2D, Image2DMask]:
+def _finalize_variance(state: Dict[str, Any]) -> Image2D:
     vsum = state[StateKey.VSUM.value]
     vsquared = state[StateKey.VSQUARED.value]
     image_count = state[StateKey.IMAGE_COUNT.value]
@@ -242,7 +236,7 @@ def _finalize_variance(state: Dict[str, Any]) -> Tuple[Image2D, Image2DMask]:
     
     cached_image[~mask] = 0
     
-    return _wrap_result(cached_image, mask)
+    return cached_image
 
 def _accumulate_power(image: Image2D, mask: Image2DMask, state: Dict[str, Any], frequency: float):     
     assert StateKey.VSUM.value in state, STATE_NOT_INITIALIZED
@@ -258,7 +252,7 @@ def _accumulate_power(image: Image2D, mask: Image2DMask, state: Dict[str, Any], 
     state[StateKey.POWER_IMAGE.value][mask] += multiplier * image[mask]
     state[StateKey.POWER_MASK.value][mask] += multiplier
 
-def _finalize_power(state: Dict[str, Any]) -> Tuple[Image2D, Image2DMask]:
+def _finalize_power(state: Dict[str, Any]) -> Image2D:
     image_count = state[StateKey.IMAGE_COUNT.value]
     power_image = state[StateKey.POWER_IMAGE.value]
     vsum = state[StateKey.VSUM.value]
@@ -277,7 +271,7 @@ def _finalize_power(state: Dict[str, Any]) -> Tuple[Image2D, Image2DMask]:
     cached_image = (cached_image * np.conj(cached_image)).real.astype(np.float32)
     cached_image[~mask] = 0
     
-    return _wrap_result(cached_image, mask)
+    return cached_image
 
 def _accumulate_brightfield(image: Image2D, mask: Image2DMask, state: Dict[str, Any]):
     assert StateKey.BRIGHT_MAX.value in state, STATE_NOT_INITIALIZED
@@ -301,7 +295,7 @@ def _accumulate_brightfield(image: Image2D, mask: Image2DMask, state: Dict[str, 
     state[StateKey.BRIGHT_MAX.value] = bright_max
     state[StateKey.BRIGHT_MIN.value] = bright_min  
 
-def _finalize_brightfield(state: Dict[str, Any]) -> Tuple[Image2D, Image2DMask]:
+def _finalize_brightfield(state: Dict[str, Any]) -> Image2D:
     image_count = state[StateKey.IMAGE_COUNT.value]
     bright_max = state[StateKey.BRIGHT_MAX.value]
     bright_min = state[StateKey.BRIGHT_MIN.value]
@@ -315,13 +309,13 @@ def _finalize_brightfield(state: Dict[str, Any]) -> Tuple[Image2D, Image2DMask]:
     cached_image[mask] = bright_max[mask] - bright_min[mask]
     cached_image[~mask] = 0
     
-    return _wrap_result(cached_image, mask)
+    return cached_image
 
 def _accumulate_mask(image: Image2D, mask: Image2DMask, state: Dict[str, Any]):
     assert StateKey.IMAGE.value in state, STATE_NOT_INITIALIZED
     state[StateKey.IMAGE.value] = state[StateKey.IMAGE.value] & mask
 
-def _finalize_mask(state: Dict[str, Any]) -> Tuple[Image2D, Image2DMask]:
+def _finalize_mask(state: Dict[str, Any]) -> Image2D:
     final_mask = state[StateKey.IMAGE.value]
-    return final_mask, np.ones(final_mask.shape, dtype=bool)
+    return final_mask
 

--- a/src/subpackages/library/cellprofiler_library/modules/_makeprojection.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_makeprojection.py
@@ -285,6 +285,8 @@ def calculate_final_projection(
 
 # --- Helper functions ---
 
+# NOTE: _mut prefix means the function mutates input numpy arrays, rather than returning new arrays
+
 def _mut_accumulate_sum(image: Image2D, mask: Image2DMask, agg_image: Union[Image2DMask, Image2D]):
     """This function is called by both sum and average projection methods"""
     agg_image[mask] += image[mask]

--- a/src/subpackages/library/cellprofiler_library/modules/_makeprojection.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_makeprojection.py
@@ -35,7 +35,7 @@ ProjectionAccumulator: TypeAlias = Callable[
 ]
 ProjectionFinalizer: TypeAlias = Callable[
     [],
-    Tuple[Image2D, Image2DMask, NDArray[np.int_]]
+    Tuple[Image2D, Image2DMask]
 ]
 class MakeProjectionAccumulator(BaseModel):
     model_config = ConfigDict(
@@ -237,7 +237,7 @@ def calculate_final_projection(
         agg_bright_max:   Annotated[Optional[Image2D], Field(description="Aggregation of max brightfield vals (for method brightfield)")],
         agg_bright_min:   Annotated[Optional[Image2D], Field(description="Aggregation of min brightfield vals (for method brightfield)")],
         agg_image:        Annotated[Optional[Union[Image2DMask, Image2D]], Field(description="Aggregation of image or mask (for methods mask, average, sum, maximum, minimum)")],
-    ) -> Tuple[Image2D, Image2DMask, NDArray[np.int_]]:
+    ) -> Tuple[Image2D, Image2DMask]:
     """
     Calculate the final projection image from the state.
 
@@ -281,7 +281,7 @@ def calculate_final_projection(
     else:
         raise ValueError(T_PROJECTION_METHOD_INVALID % method)
 
-    return final_projection, mask_2d, agg_image_count
+    return final_projection, mask_2d
 
 # --- Helper functions ---
 

--- a/src/subpackages/library/cellprofiler_library/modules/_makeprojection.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_makeprojection.py
@@ -1,321 +1,422 @@
-from pydantic import validate_call, ConfigDict, Field
+from functools import partial
+from collections.abc import Callable
+from typing import Any, Tuple, Optional, Annotated, Union, cast
+from typing_extensions import TypeAlias
+from numpy.typing import NDArray
+from pydantic import validate_call, ConfigDict, Field, BaseModel
 import numpy as np
-from typing import Dict, Any, Tuple, Optional, Union, Annotated
 from cellprofiler_library.types import Image2D, Image2DMask
 from ..opts.makeprojection import ProjectionType
-from ..opts.makeprojection import StateKey
 
 STATE_NOT_INITIALIZED = "Invalid state key. Please initialize the state dictionary with a call to set_projection before calling this function"
-POWER_FREQUENCY_NOT_PROVIDED = "Frequency must be provided for Power projection"
-PROJECTION_METHOD_INVALID = "Unknown projection method: %s"
 NORM_IS_ZERO = "Norm is zero. Please check your input images"
+REQ_IMG = "Image is required"
+AGG_IMG_MISSING = "Aggregate image missing"
+AGG_VSUM_MISSING = "Aggregate vsum missing"
+AGG_VSQUARED_MISSING = "Aggregate vsquared missing"
+AGG_POWER_MASK_MISSING = "Aggregate power mask missing"
+AGG_POWER_IMAGE_MISSING = "Aggregate power image missing"
+AGG_STACK_NUMBER_MISSING = "Aggregate stack number missing"
+AGG_BRIGHT_MAX_MISSING = "Aggregate bright max mssing"
+AGG_BRIGHT_MIN_MISSING = "Aggregate bright min mssing"
+NORM0_MISSING = "Aggregate norm0 missing"
+POWER_FREQUENCY_NOT_PROVIDED = "Frequency must be provided for Power projection"
+AGG_IMG_MISTYPE = "Aggregate image must be bool mask"
+
+T_PROJECTION_METHOD_INVALID = "Unknown projection method: %s"
+
+
+ProjectionAccumulator: TypeAlias = Callable[
+    [
+        Image2D, # image
+        Optional[Image2DMask], # mask
+    ],
+    "MakeProjectionAccumulator"
+]
+ProjectionFinalizer: TypeAlias = Callable[
+    [],
+    Tuple[Image2D, Image2DMask, NDArray[np.int_]]
+]
+class MakeProjectionAccumulator(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True, 
+        populate_by_name=True
+    )
+
+    accumulate: ProjectionAccumulator
+    finalize: ProjectionFinalizer
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
+def makeprojection(
+        # set_projection
+        method:     Annotated[ProjectionType, Field(description="The projection method")],
+        # set_projection, accumulate_projection
+        image:      Annotated[Image2D, Field(description="The pixel data of the image to accumulate")],
+        mask:       Annotated[Optional[Image2DMask], Field(description="The mask of the image (True = valid). If None, all pixels are valid")] = None,
+        frequency:  Annotated[float, Field(description="Frequency parameter for Power projection")] = 6.0,
+    ) -> MakeProjectionAccumulator:
+    has_mask = mask is not None
+    if not has_mask:
+        mask = np.ones(image.shape[:2], dtype=bool)
+    agg_image_count = mask.astype(int)
+
+    agg_vsum, agg_vsquared, agg_power_mask, agg_power_image, agg_stack_number, agg_bright_max, agg_bright_min, norm0, agg_image = (None,)*9
+    if method == ProjectionType.VARIANCE:
+        agg_vsum = image.copy()
+        agg_vsum[~mask] = 0
+        agg_vsquared = agg_vsum.astype(np.float64) ** 2.0
+
+    elif method == ProjectionType.POWER:
+        agg_vsum = image.copy()
+        agg_vsum[~mask] = 0
+        #
+        # e**0 = 1 so the first image is always in the real plane
+        #
+        agg_power_mask = agg_image_count.astype(np.complex128).copy()
+        agg_power_image = image.astype(np.complex128).copy()
+        agg_stack_number = np.array(1.)
+
+    elif method == ProjectionType.BRIGHTFIELD:
+        agg_bright_max = image.copy()
+        agg_bright_min = image.copy()
+        norm0 = np.mean(image)
+
+    elif method == ProjectionType.MASK:
+        agg_image = mask
+
+    elif method in (ProjectionType.AVERAGE, ProjectionType.SUM, ProjectionType.MAXIMUM, ProjectionType.MINIMUM):
+        agg_image = image.copy()
+        if has_mask:
+            nan_value = 1 if method == ProjectionType.MINIMUM else 0
+            agg_image[~mask] = nan_value
+
+    else:
+        raise ValueError(T_PROJECTION_METHOD_INVALID % method)
+
+    return MakeProjectionAccumulator(
+        accumulate = partial(
+            accumulate_projection,
+            method=method,
+            agg_image_count=agg_image_count,
+            agg_vsum=agg_vsum,
+            agg_vsquared=agg_vsquared,
+            agg_power_mask=agg_power_mask,
+            agg_power_image=agg_power_image,
+            frequency=frequency,
+            agg_stack_number=agg_stack_number,
+            agg_bright_max=agg_bright_max,
+            agg_bright_min=agg_bright_min,
+            norm0=norm0,
+            agg_image=agg_image,
+        ),
+        finalize = partial(
+            calculate_final_projection,
+            method=method,
+            agg_image_count=agg_image_count,
+            agg_vsum=agg_vsum,
+            agg_vsquared=agg_vsquared,
+            agg_power_image=agg_power_image,
+            agg_power_mask=agg_power_mask,
+            agg_bright_max=agg_bright_max,
+            agg_bright_min=agg_bright_min,
+            agg_image=agg_image,
+        )
+    )
+
 def accumulate_projection(
-    image:      Annotated[Image2D, Field(description="The pixel data of the image to accumulate")],
-    mask:       Annotated[Optional[Image2DMask], Field(description="The mask of the image (True = valid). If None, all pixels are valid")],
-    state:      Annotated[Dict[str, Any], Field(description="The current accumulation state. Empty dict for first image")],
-    method:     Annotated[ProjectionType, Field(description="The projection method")],
-    frequency:  Annotated[Optional[float], Field(description="Frequency parameter for Power projection")] = 6.0
-) -> Dict[str, Any]:
+        image:      Annotated[Image2D, Field(description="The pixel data of the image to accumulate")],
+        mask:       Annotated[Optional[Image2DMask], Field(description="The mask of the image (True = valid). If None, all pixels are valid")],
+        *,
+        method:           Annotated[ProjectionType, Field(description="The projection method")],
+        agg_image_count:  Annotated[NDArray[np.int_], Field(description="Aggregation of image count")],
+        agg_vsum:         Annotated[Optional[Image2D], Field(description="Aggregation of variance (for methods variance, power)")],
+        agg_vsquared:     Annotated[Optional[NDArray[np.float64]], Field(description="Aggregation of squared variance (for method variance)")],
+        agg_power_mask:   Annotated[Optional[NDArray[np.complex128]], Field(description="Aggregation of power mask (for method power)")],
+        agg_power_image:  Annotated[Optional[NDArray[np.complex128]], Field(description="Aggregation of power image (for method power)")],
+        frequency:        Annotated[float, Field(description="Frequency parameter for Power projection")],
+        agg_stack_number: Annotated[Optional[NDArray[np.float64]], Field(description="Aggregation of stack number (for method power; zero dimensional)")],
+        agg_bright_max:   Annotated[Optional[Image2D], Field(description="Aggregation of max brightfield vals (for method brightfield)")],
+        agg_bright_min:   Annotated[Optional[Image2D], Field(description="Aggregation of min brightfield vals (for method brightfield)")],
+        norm0:            Annotated[Optional[np.floating[Any]], Field(description="Normalization val (for method brightfield)")],
+        agg_image:        Annotated[Optional[Union[Image2DMask, Image2D]], Field(description="Aggregation of image or mask (for methods mask, average, sum, maximum, minimum)")],
+    ) -> MakeProjectionAccumulator:
     """
     Accumulate an image into the projection state.
-    
+
     Args:
         image: The pixel data of the image to accumulate.
         mask: The mask of the image (True = valid). If None, all pixels are valid.
         state: The current accumulation state. Empty dict for first image.
         method: The projection method.
         frequency: Frequency parameter for Power projection.
-    
+
     Returns:
         Updated state dictionary.
     """
-    assert StateKey.IMAGE_COUNT.value in state, STATE_NOT_INITIALIZED
     has_mask = mask is not None
     if has_mask:
-        state[StateKey.IMAGE_COUNT.value] += mask.astype(int)
+        agg_image_count += mask.astype(int)
     else:
-        state[StateKey.IMAGE_COUNT.value] += 1
+        agg_image_count += 1
     # Ensure mask exists
     if mask is None:
         mask = np.ones(image.shape[:2], dtype=bool)
-        
+
     # Initialize if empty
 
     if method == ProjectionType.AVERAGE or method == ProjectionType.SUM:
-        _accumulate_sum(image, mask, state)
+        assert agg_image is not None, AGG_IMG_MISSING
+        _mut_accumulate_sum(image, mask, agg_image)
     elif method == ProjectionType.MAXIMUM:
-        _accumulate_maximum(image, mask, state)
+        assert agg_image is not None, AGG_IMG_MISSING
+        _mut_accumulate_maximum(image, mask, agg_image)
     elif method == ProjectionType.MINIMUM:
-        _accumulate_minimum(image, mask, state)
+        assert agg_image is not None, AGG_IMG_MISSING
+        _mut_accumulate_minimum(image, mask, agg_image)
     elif method == ProjectionType.VARIANCE:
-        _accumulate_variance(image, mask, state)
+        assert agg_vsum is not None, AGG_VSUM_MISSING
+        assert agg_vsquared is not None, AGG_VSQUARED_MISSING
+        _mut_accumulate_variance(image, mask, agg_vsum, agg_vsquared)
     elif method == ProjectionType.POWER:
         assert frequency is not None, POWER_FREQUENCY_NOT_PROVIDED
-        _accumulate_power(image, mask, state, frequency)
+        assert agg_vsum is not None, AGG_VSUM_MISSING
+        assert agg_power_mask is not None, AGG_POWER_MASK_MISSING
+        assert agg_power_image is not None, AGG_POWER_IMAGE_MISSING
+        assert agg_stack_number is not None, AGG_STACK_NUMBER_MISSING
+        _mut_accumulate_power(image, mask, frequency, agg_vsum, agg_power_mask, agg_power_image, agg_stack_number)
     elif method == ProjectionType.BRIGHTFIELD:
-        _accumulate_brightfield(image, mask, state)
+        assert agg_bright_max is not None, AGG_BRIGHT_MAX_MISSING
+        assert agg_bright_min is not None, AGG_BRIGHT_MIN_MISSING
+        assert norm0 is not None, NORM0_MISSING
+        _mut_accumulate_brightfield(image, mask, norm0, agg_bright_max, agg_bright_min)
     elif method == ProjectionType.MASK:
-        _accumulate_mask(image, mask, state)
+        assert agg_image is not None, AGG_IMG_MISSING
+        assert agg_image.dtype == np.bool_, AGG_IMG_MISTYPE
+        _mut_accumulate_mask(mask, cast(Image2DMask, agg_image))
     else:
-        raise ValueError(f"Unknown projection method: {method}")
-        
-    return state
+        raise ValueError(T_PROJECTION_METHOD_INVALID % method)
 
-def set_projection(
-        image:  Annotated[Image2D, Field(description="The pixel data of the image to accumulate.")],
-        mask:   Annotated[Optional[Image2DMask], Field(description="The mask of the image (True = valid). If None, all pixels are valid")],
-        state:  Annotated[Dict[str, Any], Field(description="The current accumulation state. Empty dict for first image")],
-        method: Annotated[ProjectionType, Field(description="The projection method")],
-    ) -> Dict[str, Any]:
-    has_mask = mask is not None
-    if not has_mask:
-        mask = np.ones(image.shape[:2], dtype=bool)
-    state[StateKey.IMAGE_COUNT.value] = mask.astype(int)
-    
-    if method == ProjectionType.VARIANCE:
-        state[StateKey.VSUM.value] = image.copy()
-        state[StateKey.VSUM.value][~mask] = 0
-        state[StateKey.VSQUARED.value] = state[StateKey.VSUM.value].astype(np.float64) ** 2.0
+    return MakeProjectionAccumulator(
+        accumulate = partial(
+            accumulate_projection,
+            method=method,
+            agg_image_count=agg_image_count,
+            agg_vsum=agg_vsum,
+            agg_vsquared=agg_vsquared,
+            agg_power_mask=agg_power_mask,
+            agg_power_image=agg_power_image,
+            frequency=frequency,
+            agg_stack_number=agg_stack_number,
+            agg_bright_max=agg_bright_max,
+            agg_bright_min=agg_bright_min,
+            norm0=norm0,
+            agg_image=agg_image,
+        ),
+        finalize = partial(
+            calculate_final_projection,
+            method=method,
+            agg_image_count=agg_image_count,
+            agg_vsum=agg_vsum,
+            agg_vsquared=agg_vsquared,
+            agg_power_image=agg_power_image,
+            agg_power_mask=agg_power_mask,
+            agg_bright_max=agg_bright_max,
+            agg_bright_min=agg_bright_min,
+            agg_image=agg_image,
+        )
+    )
 
-    elif method == ProjectionType.POWER:
-        state[StateKey.VSUM.value] = image.copy()
-        state[StateKey.VSUM.value][~mask] = 0
-        #
-        # e**0 = 1 so the first image is always in the real plane
-        #
-        state[StateKey.POWER_MASK.value] = state[StateKey.IMAGE_COUNT.value].astype(np.complex128).copy()
-        state[StateKey.POWER_IMAGE.value] = image.astype(np.complex128).copy()
-        state[StateKey.STACK_NUMBER.value] = 1
-
-    elif method == ProjectionType.BRIGHTFIELD:
-        state[StateKey.BRIGHT_MAX.value] = image.copy()
-        state[StateKey.BRIGHT_MIN.value] = image.copy()
-        state[StateKey.NORM0.value] = np.mean(image)
-
-    elif method == ProjectionType.MASK:
-        state[StateKey.IMAGE.value] = mask
-
-    elif method in (ProjectionType.AVERAGE, ProjectionType.SUM, ProjectionType.MAXIMUM, ProjectionType.MINIMUM):
-        state[StateKey.IMAGE.value] = image.copy()
-        if has_mask:
-            nan_value = 1 if method == ProjectionType.MINIMUM else 0
-            state[StateKey.IMAGE.value][~mask] = nan_value
-
-    else:
-        raise ValueError(PROJECTION_METHOD_INVALID % method)
-    
-    return state
-
-    
-
-@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def calculate_final_projection(
-    state: Annotated[Dict[str, Any], Field(description="The accumulation state.")],
-    method: Annotated[ProjectionType, Field(description="The projection method.")]
-) -> Tuple[Image2D, Image2DMask]:
+        *,
+        method:           Annotated[ProjectionType, Field(description="The projection method.")],
+        agg_image_count:  Annotated[NDArray[np.int_], Field(description="Aggregation of image count")],
+        agg_vsum:         Annotated[Optional[Image2D], Field(description="Aggregation of variance (for methods variance, power)")],
+        agg_vsquared:     Annotated[Optional[NDArray[np.float64]], Field(description="Aggregation of squared variance (for method variance)")],
+        agg_power_image:  Annotated[Optional[NDArray[np.complex128]], Field(description="Aggregation of power image (for method power)")],
+        agg_power_mask:   Annotated[Optional[NDArray[np.complex128]], Field(description="Aggregation of power mask (for method power)")],
+        agg_bright_max:   Annotated[Optional[Image2D], Field(description="Aggregation of max brightfield vals (for method brightfield)")],
+        agg_bright_min:   Annotated[Optional[Image2D], Field(description="Aggregation of min brightfield vals (for method brightfield)")],
+        agg_image:        Annotated[Optional[Union[Image2DMask, Image2D]], Field(description="Aggregation of image or mask (for methods mask, average, sum, maximum, minimum)")],
+    ) -> Tuple[Image2D, Image2DMask, NDArray[np.int_]]:
     """
     Calculate the final projection image from the state.
-    
+
     Args:
         state: The accumulation state.
         method: The projection method.
-        
+
     Returns:
         Tuple of (pixel_data, mask).
     """
-    
-    image_count = state[StateKey.IMAGE_COUNT.value]
-    mask_2d = image_count > 0
+    mask_2d = agg_image_count > 0
     final_projection = None
     if method == ProjectionType.AVERAGE:
-        final_projection = _finalize_average(state)
+        assert agg_image is not None, AGG_IMG_MISSING
+        final_projection = _finalize_average(agg_image, agg_image_count)
     elif method == ProjectionType.SUM:
-        final_projection = _finalize_sum(state)
+        assert agg_image is not None, AGG_IMG_MISSING
+        final_projection = _finalize_sum(agg_image, agg_image_count)
     elif method == ProjectionType.MAXIMUM:
-        final_projection = _finalize_maximum(state)
+        assert agg_image is not None, AGG_IMG_MISSING
+        final_projection = _finalize_maximum(agg_image, agg_image_count)
     elif method == ProjectionType.MINIMUM:
-        final_projection = _finalize_minimum(state)
+        assert agg_image is not None, AGG_IMG_MISSING
+        final_projection = _finalize_minimum(agg_image, agg_image_count)
     elif method == ProjectionType.VARIANCE:
-        final_projection = _finalize_variance(state)
+        assert agg_vsum is not None, AGG_VSUM_MISSING
+        assert agg_vsquared is not None, AGG_VSQUARED_MISSING
+        final_projection = _finalize_variance(agg_vsum, agg_vsquared, agg_image_count)
     elif method == ProjectionType.POWER:
-        final_projection = _finalize_power(state)
+        assert agg_vsum is not None, AGG_VSUM_MISSING
+        assert agg_power_mask is not None, AGG_POWER_MASK_MISSING
+        assert agg_power_image is not None, AGG_POWER_IMAGE_MISSING
+        final_projection = _finalize_power(agg_image_count, agg_power_image, agg_power_mask, agg_vsum)
     elif method == ProjectionType.BRIGHTFIELD:
-        final_projection = _finalize_brightfield(state)
+        assert agg_bright_max is not None, AGG_BRIGHT_MAX_MISSING
+        assert agg_bright_min is not None, AGG_BRIGHT_MIN_MISSING
+        final_projection = _finalize_brightfield(agg_image_count, agg_bright_max, agg_bright_min)
     elif method == ProjectionType.MASK:
-        final_projection = _finalize_mask(state)
+        assert agg_image is not None, AGG_IMG_MISSING
+        final_projection = _finalize_mask(agg_image)
     else:
-        raise ValueError(PROJECTION_METHOD_INVALID % method)
+        raise ValueError(T_PROJECTION_METHOD_INVALID % method)
 
-    return final_projection, mask_2d
+    return final_projection, mask_2d, agg_image_count
 
 # --- Helper functions ---
 
-def _accumulate_sum(image: Image2D, mask: Image2DMask, state: Dict[str, Any]):
+def _mut_accumulate_sum(image: Image2D, mask: Image2DMask, agg_image: Union[Image2DMask, Image2D]):
     """This function is called by both sum and average projection methods"""
-    assert StateKey.IMAGE.value in state, STATE_NOT_INITIALIZED
-    state[StateKey.IMAGE.value][mask] += image[mask]
+    agg_image[mask] += image[mask]
 
+def _finalize_sum(agg_image: Union[Image2DMask, Image2D], agg_image_count: NDArray[np.int_]) -> Image2D:
+    mask = agg_image_count > 0
 
-def _finalize_sum(state: Dict[str, Any]) -> Image2D:
-    image = state[StateKey.IMAGE.value]
-    image_count = state[StateKey.IMAGE_COUNT.value]
-    
-    mask = image_count > 0
-    
     if np.any(~mask):
-        cached_image = image.copy()
+        cached_image = agg_image.copy()
         cached_image[~mask] = 0
     else:
-        cached_image = image
-        
+        cached_image = agg_image
+
     return cached_image
 
-def _finalize_average(state: Dict[str, Any]) -> Image2D:
-    image = state[StateKey.IMAGE.value]
-    image_count = state[StateKey.IMAGE_COUNT.value]
+def _finalize_average(agg_image: Union[Image2DMask, Image2D], agg_image_count: NDArray[np.int_]) -> Image2D:
     # Handle multi-channel image count broadcasting
-    if image.ndim == 3 and image_count.ndim == 2:
-        image_count = np.dstack([image_count] * image.shape[2])
-        
-    mask = image_count > 0
-    
+    if agg_image.ndim == 3 and agg_image_count.ndim == 2:
+        agg_image_count = np.dstack([agg_image_count] * agg_image.shape[2])
+
+    mask = agg_image_count > 0
+
     # Avoid divide by zero
-    cached_image = np.zeros_like(image)
-    valid = image_count > 0
-    cached_image[valid] = image[valid] / image_count[valid]
-    
+    cached_image = np.zeros_like(agg_image)
+    valid = agg_image_count > 0
+    cached_image[valid] = agg_image[valid] / agg_image_count[valid]
+
     if cached_image.ndim == 3 and mask.ndim == 2:
         cached_image[~mask, :] = 0
     else:
         cached_image[~mask] = 0
-        
+
     return cached_image
 
-def _accumulate_maximum(image: Image2D, mask: Image2DMask, state: Dict[str, Any]):
-    assert StateKey.IMAGE.value in state, STATE_NOT_INITIALIZED
-    current_image = state[StateKey.IMAGE.value]
-    state[StateKey.IMAGE.value][mask] = np.maximum(current_image[mask], image[mask])
+def _mut_accumulate_maximum(image: Image2D, mask: Image2DMask, agg_image: Union[Image2DMask, Image2D]):
+    agg_image[mask] = np.maximum(agg_image[mask], image[mask])
 
-def _finalize_maximum(state: Dict[str, Any]) -> Image2D:
+def _finalize_maximum(agg_image: Union[Image2DMask, Image2D], agg_image_count: NDArray[np.int_]) -> Image2D:
     # Same finalization logic as SumProvider except it uses the max accumulated image
-    return _finalize_sum(state)
+    return _finalize_sum(agg_image, agg_image_count)
 
-def _accumulate_minimum(image: Image2D, mask: Image2DMask, state: Dict[str, Any]):
-    assert StateKey.IMAGE.value in state, STATE_NOT_INITIALIZED
-    current_image = state[StateKey.IMAGE.value]
-    state[StateKey.IMAGE.value][mask] = np.minimum(current_image[mask], image[mask])
+def _mut_accumulate_minimum(image: Image2D, mask: Image2DMask, agg_image: Union[Image2DMask, Image2D]):
+    agg_image[mask] = np.minimum(agg_image[mask], image[mask])
 
-def _finalize_minimum(state: Dict[str, Any]) -> Image2D:
-    return _finalize_sum(state)
+def _finalize_minimum(agg_image: Union[Image2DMask, Image2D], agg_image_count: NDArray[np.int_]) -> Image2D:
+    return _finalize_sum(agg_image, agg_image_count)
 
-def _accumulate_variance(image: Image2D, mask: Image2DMask, state: Dict[str, Any]):
-    assert StateKey.VSUM.value in state, STATE_NOT_INITIALIZED
-    assert StateKey.VSQUARED.value in state, STATE_NOT_INITIALIZED
-    state[StateKey.VSUM.value][mask] += image[mask]
-    state[StateKey.VSQUARED.value][mask] += image[mask].astype(np.float64) ** 2
+def _mut_accumulate_variance(image: Image2D, mask: Image2DMask, agg_vsum: Image2D, agg_vsquared: NDArray[np.float64]):
+    agg_vsum[mask] += image[mask]
+    agg_vsquared[mask] += image[mask].astype(np.float64) ** 2
 
-def _finalize_variance(state: Dict[str, Any]) -> Image2D:
-    vsum = state[StateKey.VSUM.value]
-    vsquared = state[StateKey.VSQUARED.value]
-    image_count = state[StateKey.IMAGE_COUNT.value]
-    
-    if vsquared.ndim == 3 and image_count.ndim == 2:
-        image_count = np.dstack([image_count] * vsquared.shape[2])
-        
-    mask = image_count > 0
-    
-    cached_image = np.zeros(vsquared.shape, np.float32)
-    
+def _finalize_variance(agg_vsum: Image2D, agg_vsquared: NDArray[np.float64], agg_image_count: NDArray[np.int_]) -> Image2D:
+    if agg_vsquared.ndim == 3 and agg_image_count.ndim == 2:
+        agg_image_count = np.dstack([agg_image_count] * agg_vsquared.shape[2])
+
+    mask = agg_image_count > 0
+
+    cached_image = np.zeros(agg_vsquared.shape, np.float32)
+
     # Calculate variance: E[x^2] - (E[x])^2
-    
+
     valid = mask # logic alias
-    cached_image[valid] = vsquared[valid] / image_count[valid]
-    cached_image[valid] -= (vsum[valid] ** 2) / (image_count[valid] ** 2)
-    
+    cached_image[valid] = agg_vsquared[valid] / agg_image_count[valid]
+    cached_image[valid] -= (agg_vsum[valid] ** 2) / (agg_image_count[valid] ** 2)
+
     cached_image[~mask] = 0
-    
+
     return cached_image
 
-def _accumulate_power(image: Image2D, mask: Image2DMask, state: Dict[str, Any], frequency: float):     
-    assert StateKey.VSUM.value in state, STATE_NOT_INITIALIZED
-    assert StateKey.POWER_MASK.value in state, STATE_NOT_INITIALIZED
-    assert StateKey.POWER_IMAGE.value in state, STATE_NOT_INITIALIZED
-    assert StateKey.STACK_NUMBER.value in state, STATE_NOT_INITIALIZED
+def _mut_accumulate_power(
+        image: Image2D,
+        mask: Image2DMask,
+        frequency: float,
+        agg_vsum: Image2D,
+        agg_power_mask: NDArray[np.complex128],
+        agg_power_image: NDArray[np.complex128],
+        agg_stack_number: NDArray[np.float64],
+    ):
+    multiplier = np.exp(2j * np.pi * agg_stack_number / frequency)
+    agg_stack_number += 1
 
-    stack_number = state[StateKey.STACK_NUMBER.value]
-    multiplier = np.exp(2j * np.pi * float(stack_number) / frequency)
-    state[StateKey.STACK_NUMBER.value] += 1
-    
-    state[StateKey.VSUM.value][mask] += image[mask]
-    state[StateKey.POWER_IMAGE.value][mask] += multiplier * image[mask]
-    state[StateKey.POWER_MASK.value][mask] += multiplier
+    agg_vsum[mask] += image[mask]
+    agg_power_image[mask] += multiplier * image[mask]
+    agg_power_mask[mask] += multiplier
 
-def _finalize_power(state: Dict[str, Any]) -> Image2D:
-    image_count = state[StateKey.IMAGE_COUNT.value]
-    power_image = state[StateKey.POWER_IMAGE.value]
-    vsum = state[StateKey.VSUM.value]
-    power_mask = state[StateKey.POWER_MASK.value]
-    
-    if power_image.ndim == 3 and image_count.ndim == 2:
-        image_count = np.dstack([image_count] * power_image.shape[2])
-        
-    mask = image_count > 0
-    
-    cached_image = np.zeros(image_count.shape, np.complex128)
-    cached_image[mask] = power_image[mask]
-    cached_image[mask] -= (vsum[mask] * power_mask[mask] / image_count[mask])
-    
+def _finalize_power(
+        agg_image_count: NDArray[np.int_],
+        agg_power_image: NDArray[np.complex128],
+        agg_power_mask: NDArray[np.complex128],
+        agg_vsum: Image2D,
+    ) -> Image2D:
+    if agg_power_image.ndim == 3 and agg_image_count.ndim == 2:
+        agg_image_count = np.dstack([agg_image_count] * agg_power_image.shape[2])
+
+    mask = agg_image_count > 0
+
+    cached_image = np.zeros(agg_image_count.shape, np.complex128)
+    cached_image[mask] = agg_power_image[mask]
+    cached_image[mask] -= (agg_vsum[mask] * agg_power_mask[mask] / agg_image_count[mask])
+
     # |z|^2 = z * conj(z)
     cached_image = (cached_image * np.conj(cached_image)).real.astype(np.float32)
     cached_image[~mask] = 0
-    
+
     return cached_image
 
-def _accumulate_brightfield(image: Image2D, mask: Image2DMask, state: Dict[str, Any]):
-    assert StateKey.BRIGHT_MAX.value in state, STATE_NOT_INITIALIZED
-    assert StateKey.BRIGHT_MIN.value in state, STATE_NOT_INITIALIZED
-    assert StateKey.NORM0.value in state, STATE_NOT_INITIALIZED
-
-    norm0 = state[StateKey.NORM0.value]
-    bright_max = state[StateKey.BRIGHT_MAX.value]
-    bright_min = state[StateKey.BRIGHT_MIN.value]
-    
+def _mut_accumulate_brightfield(image: Image2D, mask: Image2DMask, norm0: np.floating[Any], agg_bright_max: Image2D, agg_bright_min: Image2D):
     norm = np.mean(image)
     assert norm != 0, NORM_IS_ZERO
     pixel_data = image * norm0 / norm
-    
-    max_mask = (bright_max < pixel_data) & mask
-    min_mask = (bright_min > pixel_data) & mask
-    
-    bright_min[min_mask] = pixel_data[min_mask]
-    bright_max[max_mask] = pixel_data[max_mask]
-    bright_min[max_mask] = bright_max[max_mask]
-    state[StateKey.BRIGHT_MAX.value] = bright_max
-    state[StateKey.BRIGHT_MIN.value] = bright_min  
 
-def _finalize_brightfield(state: Dict[str, Any]) -> Image2D:
-    image_count = state[StateKey.IMAGE_COUNT.value]
-    bright_max = state[StateKey.BRIGHT_MAX.value]
-    bright_min = state[StateKey.BRIGHT_MIN.value]
-    
-    if bright_max.ndim == 3 and image_count.ndim == 2:
-        image_count = np.dstack([image_count] * bright_max.shape[2])
-        
-    mask = image_count > 0
-    
-    cached_image = np.zeros(image_count.shape, np.float32)
-    cached_image[mask] = bright_max[mask] - bright_min[mask]
+    max_mask = (agg_bright_max < pixel_data) & mask
+    min_mask = (agg_bright_min > pixel_data) & mask
+
+    agg_bright_min[min_mask] = pixel_data[min_mask]
+    agg_bright_max[max_mask] = pixel_data[max_mask]
+    agg_bright_min[max_mask] = agg_bright_max[max_mask]
+
+def _finalize_brightfield(agg_image_count: NDArray[np.int_], agg_bright_max: Image2D, agg_bright_min: Image2D) -> Image2D:
+    if agg_bright_max.ndim == 3 and agg_image_count.ndim == 2:
+        agg_image_count = np.dstack([agg_image_count] * agg_bright_max.shape[2])
+
+    mask = agg_image_count > 0
+
+    cached_image = np.zeros(agg_image_count.shape, np.float32)
+    cached_image[mask] = agg_bright_max[mask] - agg_bright_min[mask]
     cached_image[~mask] = 0
-    
+
     return cached_image
 
-def _accumulate_mask(image: Image2D, mask: Image2DMask, state: Dict[str, Any]):
-    assert StateKey.IMAGE.value in state, STATE_NOT_INITIALIZED
-    state[StateKey.IMAGE.value] = state[StateKey.IMAGE.value] & mask
+def _mut_accumulate_mask(mask: Image2DMask, agg_image: Image2DMask):
+    agg_image &= mask
 
-def _finalize_mask(state: Dict[str, Any]) -> Image2D:
-    final_mask = state[StateKey.IMAGE.value]
-    return final_mask
-
+def _finalize_mask(agg_image: Union[Image2DMask, Image2D]) -> Image2D:
+    return agg_image

--- a/src/subpackages/library/cellprofiler_library/opts/makeprojection.py
+++ b/src/subpackages/library/cellprofiler_library/opts/makeprojection.py
@@ -1,0 +1,24 @@
+from enum import Enum
+
+class ProjectionType(str, Enum):
+    AVERAGE = "Average"
+    MAXIMUM = "Maximum"
+    MINIMUM = "Minimum"
+    SUM = "Sum"
+    VARIANCE = "Variance"
+    POWER = "Power"
+    BRIGHTFIELD = "Brightfield"
+    MASK = "Mask"
+
+class StateKey(str, Enum):
+    IMAGE = "image"
+    IMAGE_COUNT = "image_count"
+    VSUM = "vsum"
+    VSQUARED = "vsquared"
+    POWER_IMAGE = "power_image"
+    POWER_MASK = "power_mask"
+    STACK_NUMBER = "stack_number"
+    BRIGHT_MAX = "bright_max"
+    BRIGHT_MIN = "bright_min"
+    NORM0 = "norm0"
+    

--- a/src/subpackages/library/cellprofiler_library/opts/makeprojection.py
+++ b/src/subpackages/library/cellprofiler_library/opts/makeprojection.py
@@ -10,6 +10,18 @@ class ProjectionType(str, Enum):
     BRIGHTFIELD = "Brightfield"
     MASK = "Mask"
 
+P_ALL = [
+    ProjectionType.AVERAGE.value,
+    ProjectionType.MAXIMUM.value,
+    ProjectionType.MINIMUM.value,
+    ProjectionType.SUM.value,
+    ProjectionType.VARIANCE.value,
+    ProjectionType.POWER.value,
+    ProjectionType.BRIGHTFIELD.value,
+    ProjectionType.MASK.value,
+]
+
+
 class StateKey(str, Enum):
     IMAGE = "image"
     IMAGE_COUNT = "image_count"

--- a/src/subpackages/library/cellprofiler_library/opts/makeprojection.py
+++ b/src/subpackages/library/cellprofiler_library/opts/makeprojection.py
@@ -20,17 +20,3 @@ P_ALL = [
     ProjectionType.BRIGHTFIELD.value,
     ProjectionType.MASK.value,
 ]
-
-
-class StateKey(str, Enum):
-    IMAGE = "image"
-    IMAGE_COUNT = "image_count"
-    VSUM = "vsum"
-    VSQUARED = "vsquared"
-    POWER_IMAGE = "power_image"
-    POWER_MASK = "power_mask"
-    STACK_NUMBER = "stack_number"
-    BRIGHT_MAX = "bright_max"
-    BRIGHT_MIN = "bright_min"
-    NORM0 = "norm0"
-    

--- a/tests/frontend/modules/test_makeprojection.py
+++ b/tests/frontend/modules/test_makeprojection.py
@@ -106,7 +106,8 @@ def run_image_set(projection_type, images_and_masks, frequency=9, run_last=True)
     )
     module.run(w)
     image_provider = image_set.get_image_provider(PROJECTED_IMAGE_NAME)
-    assert numpy.max(image_provider.count) == 1
+    agg_image_count = image_provider.library_accumulator.finalize.keywords["agg_image_count"]
+    assert numpy.max(agg_image_count) == 1
 
     return image
 

--- a/tests/frontend/modules/test_makeprojection.py
+++ b/tests/frontend/modules/test_makeprojection.py
@@ -5,11 +5,13 @@ import cellprofiler_core.image
 import cellprofiler_core.measurement
 
 
-import cellprofiler.modules.makeprojection
 import cellprofiler_core.object
 import cellprofiler_core.pipeline
 import cellprofiler_core.workspace
 import tests.frontend.modules
+
+from cellprofiler.modules.makeprojection import MakeProjection
+from cellprofiler_library.opts.makeprojection import ProjectionType
 
 IMAGE_NAME = "image"
 PROJECTED_IMAGE_NAME = "projectedimage"
@@ -27,17 +29,17 @@ def test_load_v2():
 
     pipeline.load(six.moves.StringIO(data))
     methods = (
-        cellprofiler.modules.makeprojection.P_AVERAGE,
-        cellprofiler.modules.makeprojection.P_MAXIMUM,
-        cellprofiler.modules.makeprojection.P_MINIMUM,
-        cellprofiler.modules.makeprojection.P_SUM,
-        cellprofiler.modules.makeprojection.P_VARIANCE,
-        cellprofiler.modules.makeprojection.P_POWER,
-        cellprofiler.modules.makeprojection.P_BRIGHTFIELD,
+        ProjectionType.AVERAGE.value,
+        ProjectionType.MAXIMUM.value,
+        ProjectionType.MINIMUM.value,
+        ProjectionType.SUM.value,
+        ProjectionType.VARIANCE.value,
+        ProjectionType.POWER.value,
+        ProjectionType.BRIGHTFIELD.value,
     )
     assert len(pipeline.modules()) == len(methods)
     for method, module in zip(methods, pipeline.modules()):
-        assert isinstance(module, cellprofiler.modules.makeprojection.MakeProjection)
+        assert isinstance(module, MakeProjection)
         assert module.image_name == "ch02"
         assert module.projection_type == method
         assert module.projection_image_name == "ProjectionCh00Scale6"
@@ -61,7 +63,7 @@ def run_image_set(projection_type, images_and_masks, frequency=9, run_last=True)
     image_set_list.get_image_set(image_count).add(IMAGE_NAME, bogus_image)
 
     pipeline = cellprofiler_core.pipeline.Pipeline()
-    module = cellprofiler.modules.makeprojection.MakeProjection()
+    module = MakeProjection()
     module.set_module_num(1)
     module.image_name.value = IMAGE_NAME
     module.projection_image_name.value = PROJECTED_IMAGE_NAME
@@ -120,7 +122,7 @@ def test_average():
         expected += image
     expected = expected / len(images_and_masks)
     image = run_image_set(
-        cellprofiler.modules.makeprojection.P_AVERAGE, images_and_masks
+        ProjectionType.AVERAGE.value, images_and_masks
     )
     assert not image.has_mask
     assert numpy.all(numpy.abs(image.pixel_data - expected) < numpy.finfo(float).eps)
@@ -144,7 +146,7 @@ def test_average_mask():
         expected_mask = mask | expected_mask
     expected = expected / expected_count
     image = run_image_set(
-        cellprofiler.modules.makeprojection.P_AVERAGE, images_and_masks
+        ProjectionType.AVERAGE.value, images_and_masks
     )
     assert image.has_mask
     assert numpy.all(expected_mask == image.mask)
@@ -164,7 +166,7 @@ def test_average_color():
         expected += image
     expected = expected / len(images_and_masks)
     image = run_image_set(
-        cellprofiler.modules.makeprojection.P_AVERAGE, images_and_masks
+        ProjectionType.AVERAGE.value, images_and_masks
     )
     assert not image.has_mask
     assert numpy.all(numpy.abs(image.pixel_data - expected) < numpy.finfo(float).eps)
@@ -188,7 +190,7 @@ def test_average_masked_color():
         expected_mask = mask | expected_mask
     expected = expected / expected_count[:, :, numpy.newaxis]
     image = run_image_set(
-        cellprofiler.modules.makeprojection.P_AVERAGE, images_and_masks
+        ProjectionType.AVERAGE.value, images_and_masks
     )
     assert image.has_mask
     numpy.testing.assert_equal(image.mask, expected_mask)
@@ -207,7 +209,7 @@ def test_maximum():
     for image, mask in images_and_masks:
         expected = numpy.maximum(expected, image)
     image = run_image_set(
-        cellprofiler.modules.makeprojection.P_MAXIMUM, images_and_masks
+        ProjectionType.MAXIMUM.value, images_and_masks
     )
     assert not image.has_mask
     assert numpy.all(numpy.abs(image.pixel_data - expected) < numpy.finfo(float).eps)
@@ -228,7 +230,7 @@ def test_maximum_mask():
         expected[mask] = numpy.maximum(expected[mask], image[mask])
         expected_mask = mask | expected_mask
     image = run_image_set(
-        cellprofiler.modules.makeprojection.P_MAXIMUM, images_and_masks
+        ProjectionType.MAXIMUM.value, images_and_masks
     )
     assert image.has_mask
     assert numpy.all(expected_mask == image.mask)
@@ -248,7 +250,7 @@ def test_maximum_color():
     for image, mask in images_and_masks:
         expected = numpy.maximum(expected, image)
     image = run_image_set(
-        cellprofiler.modules.makeprojection.P_MAXIMUM, images_and_masks
+        ProjectionType.MAXIMUM.value, images_and_masks
     )
     assert not image.has_mask
     assert numpy.all(numpy.abs(image.pixel_data - expected) < numpy.finfo(float).eps)
@@ -261,7 +263,7 @@ def test_variance():
         for i in range(10)
     ]
     image = run_image_set(
-        cellprofiler.modules.makeprojection.P_VARIANCE, images_and_masks
+        ProjectionType.VARIANCE.value, images_and_masks
     )
     images = numpy.array([x[0] for x in images_and_masks])
     x = numpy.sum(images, 0)
@@ -276,7 +278,7 @@ def test_power():
     for i, (img, _) in enumerate(images_and_masks):
         img[5, 5] *= numpy.sin(2 * numpy.pi * float(i) / 9.0)
     image_out = run_image_set(
-        cellprofiler.modules.makeprojection.P_POWER, images_and_masks, frequency=9
+        ProjectionType.POWER.value, images_and_masks, frequency=9
     )
     i, j = numpy.mgrid[: image.shape[0], : image.shape[1]]
     numpy.testing.assert_almost_equal(image_out.pixel_data[(i != 5) & (j != 5)], 0)
@@ -292,7 +294,7 @@ def test_brightfield():
         else:
             img[:5, 5:] = 0
     image_out = run_image_set(
-        cellprofiler.modules.makeprojection.P_BRIGHTFIELD, images_and_masks
+        ProjectionType.BRIGHTFIELD.value, images_and_masks
     )
     i, j = numpy.mgrid[: image.shape[0], : image.shape[1]]
     numpy.testing.assert_almost_equal(image_out.pixel_data[(i > 5) | (j < 5)], 0)
@@ -309,7 +311,7 @@ def test_minimum():
     for image, mask in images_and_masks:
         expected = numpy.minimum(expected, image)
     image = run_image_set(
-        cellprofiler.modules.makeprojection.P_MINIMUM, images_and_masks
+        ProjectionType.MINIMUM.value, images_and_masks
     )
     assert not image.has_mask
     assert numpy.all(numpy.abs(image.pixel_data - expected) < numpy.finfo(float).eps)
@@ -330,7 +332,7 @@ def test_minimum_mask():
         expected[mask] = numpy.minimum(expected[mask], image[mask])
         expected_mask = mask | expected_mask
     image = run_image_set(
-        cellprofiler.modules.makeprojection.P_MINIMUM, images_and_masks
+        ProjectionType.MINIMUM.value, images_and_masks
     )
     assert image.has_mask
     assert numpy.any(image.mask == False)
@@ -352,7 +354,7 @@ def test_minimum_color():
     for image, mask in images_and_masks:
         expected = numpy.minimum(expected, image)
     image = run_image_set(
-        cellprofiler.modules.makeprojection.P_MINIMUM, images_and_masks
+        ProjectionType.MINIMUM.value, images_and_masks
     )
     assert not image.has_mask
     assert numpy.all(numpy.abs(image.pixel_data - expected) < numpy.finfo(float).eps)
@@ -361,7 +363,7 @@ def test_minimum_color():
 def test_mask_unmasked():
     numpy.random.seed(81)
     images_and_masks = [(numpy.random.uniform(size=(10, 10)), None) for i in range(3)]
-    image = run_image_set(cellprofiler.modules.makeprojection.P_MASK, images_and_masks)
+    image = run_image_set(ProjectionType.MASK.value, images_and_masks)
     assert tuple(image.pixel_data.shape) == (10, 10)
     assert numpy.all(image.pixel_data == True)
     assert not image.has_mask
@@ -376,7 +378,7 @@ def test_mask():
     expected = numpy.ones((10, 10), bool)
     for _, mask in images_and_masks:
         expected = expected & mask
-    image = run_image_set(cellprofiler.modules.makeprojection.P_MASK, images_and_masks)
+    image = run_image_set(ProjectionType.MASK.value, images_and_masks)
     assert numpy.all(image.pixel_data == expected)
 
 
@@ -390,7 +392,7 @@ def test_filtered():
     numpy.random.seed(81)
     images_and_masks = [(numpy.random.uniform(size=(10, 10)), None) for i in range(3)]
     image = run_image_set(
-        cellprofiler.modules.makeprojection.P_AVERAGE, images_and_masks, run_last=False
+        ProjectionType.AVERAGE.value, images_and_masks, run_last=False
     )
     numpy.testing.assert_array_almost_equal(
         image.pixel_data, (images_and_masks[0][0] + images_and_masks[1][0]) / 2


### PR DESCRIPTION
This PR has 2 changes
1. Splitting the ImageProvider into smaller, single-purpose classes
2. Refactoring the ImageProvider to make it stateless.

The original ImageProvider class was very large and had several conditionals at each class method which branched depending on the accumulation method selected. Since the FE only uses one accumulation method at a time, it makes sense to split up the monolith class into smaller classes that are easier to read and understand.

To make the code stateless, I've refactored the accumulator functions to accept a `state` variable that serves as a replacement of the instance variables that the ImageProvider instances had. 