### PR TITLE
Update macOS version in GitHub Actions workflow to macos-15-intel

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.9'
     - name: Install dependencies

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,7 @@ jobs:
         # need to get git tags for setuptools-scm
         fetch-depth: 0
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.9'
     - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           # need to get git tags for setuptools-scm
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           architecture: x64
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           # need to get git tags for setuptools-scm
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           # NOTE: if/when we move to a runner using apple M[1-3] (arm64)
           # architecture we'll need to adjust:
@@ -93,7 +93,7 @@ jobs:
           # need to get git tags for setuptools-scm
           fetch-depth: 0
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           architecture: x64
           python-version: ${{ matrix.python-version }}
@@ -152,7 +152,7 @@ jobs:
           # need to get git tags for setuptools-scm
           fetch-depth: 0
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           architecture: x64
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
Bump `macos-13` to `macos-15-intel`.
Closes #5048