### PR TITLE
[AI Code]: Refactor`measureimageskeleton` to Library

### DIFF
--- a/src/frontend/cellprofiler/modules/measureimageskeleton.py
+++ b/src/frontend/cellprofiler/modules/measureimageskeleton.py
@@ -37,7 +37,7 @@ import skimage.util
 from cellprofiler_core.module import Module
 from cellprofiler_core.setting.subscriber import ImageSubscriber
 from cellprofiler_library.modules._measureimageskeleton import measure_image_skeleton
-from cellprofiler_library.opts.measureimageskeleton import SkeletonMeasurements
+from cellprofiler_library.opts.measureimageskeleton import TemplateMeasurementFormat
 
 
 
@@ -74,18 +74,25 @@ You can create a morphological skeleton with the
 
         pixels = input_image.pixel_data
 
-        branch_nodes, endpoint_nodes, measurements = measure_image_skeleton(pixels, im_name=self.skeleton_name.value)
+        result = measure_image_skeleton(
+            pixels, 
+            im_name=self.skeleton_name.value,
+            return_visualization_data=self.show_window
+        )
 
-        for object_name, features in measurements.items():
-            if object_name == "Image":
-                for feature_name, value in features.items():
-                    workspace.measurements.add_image_measurement(feature_name, value)
+        if self.show_window:
+            lib_measurements, branch_nodes, endpoint_nodes = result
+        else:
+            lib_measurements = result
 
-        name_branches = SkeletonMeasurements.BRANCHES.value.format(input_image_name)
-        name_endpoints = SkeletonMeasurements.ENDPOINTS.value.format(input_image_name)
+        for feature_name, value in lib_measurements.image.items():
+            workspace.measurements.add_image_measurement(feature_name, value)
 
-        num_branches = measurements["Image"][name_branches]
-        num_endpoints = measurements["Image"][name_endpoints]
+        name_branches = TemplateMeasurementFormat.BRANCHES % input_image_name
+        name_endpoints = TemplateMeasurementFormat.ENDPOINTS % input_image_name
+
+        num_branches = lib_measurements.image[name_branches]
+        num_endpoints = lib_measurements.image[name_endpoints]
         
         statistics = [[num_branches, num_endpoints]]
 

--- a/src/frontend/cellprofiler/modules/measureimageskeleton.py
+++ b/src/frontend/cellprofiler/modules/measureimageskeleton.py
@@ -30,15 +30,9 @@ Measurements made by this module
 - *Endpoints*: Total number of pixels with only one neighbor.
 """
 
-import numpy
-import scipy.ndimage
-import skimage.segmentation
-import skimage.util
 from cellprofiler_core.module import Module
 from cellprofiler_core.setting.subscriber import ImageSubscriber
 from cellprofiler_library.modules._measureimageskeleton import measure_image_skeleton
-from cellprofiler_library.opts.measureimageskeleton import TemplateMeasurementFormat
-
 
 
 class MeasureImageSkeleton(Module):
@@ -62,8 +56,6 @@ You can create a morphological skeleton with the
         return [self.skeleton_name]
 
     def run(self, workspace):
-        names = ["Branches", "Endpoints"]
-
         input_image_name = self.skeleton_name.value
 
         image_set = workspace.image_set
@@ -81,39 +73,23 @@ You can create a morphological skeleton with the
         )
 
         if self.show_window:
-            lib_measurements, branch_nodes, endpoint_nodes = result
+            lib_measurements, lib_display = result
         else:
             lib_measurements = result
 
         for feature_name, value in lib_measurements.image.items():
             workspace.measurements.add_image_measurement(feature_name, value)
 
-        name_branches = TemplateMeasurementFormat.BRANCHES % input_image_name
-        name_endpoints = TemplateMeasurementFormat.ENDPOINTS % input_image_name
-
-        num_branches = lib_measurements.image[name_branches]
-        num_endpoints = lib_measurements.image[name_endpoints]
-        
-        statistics = [[num_branches, num_endpoints]]
-
         if self.show_window:
             workspace.display_data.skeleton = pixels
 
-            a = numpy.copy(branch_nodes).astype(numpy.uint16)
-            b = numpy.copy(endpoint_nodes).astype(numpy.uint16)
-
-            a[a == 1] = 1
-            b[b == 1] = 2
-
-            nodes = skimage.segmentation.join_segmentations(a, b)
-
-            workspace.display_data.nodes = nodes
+            workspace.display_data.nodes = lib_display.nodes
 
             workspace.display_data.dimensions = dimensions
 
-            workspace.display_data.names = names
+            workspace.display_data.names = ["Branches", "Endpoints"]
 
-            workspace.display_data.statistics = statistics
+            workspace.display_data.statistics = lib_display.statistics
 
     def display(self, workspace, figure=None):
         layout = (2, 2)
@@ -158,8 +134,6 @@ You can create a morphological skeleton with the
         return "Skeleton_{}_{}".format(name, image)
 
     def get_measurements(self, pipeline, object_name, category):
-        name = self.skeleton_name.value
-
         if object_name == "Image" and category == "Skeleton":
             return [
                 "Branches",
@@ -190,7 +164,6 @@ You can create a morphological skeleton with the
         feature = self.get_feature_name(name)
 
         return feature
-
 
     def volumetric(self):
         return True

--- a/src/subpackages/library/cellprofiler_library/functions/measurement.py
+++ b/src/subpackages/library/cellprofiler_library/functions/measurement.py
@@ -2198,3 +2198,58 @@ def compute_earth_movers_distance_objects(
         extra_mass_penalty=extra_mass_penalty,
     )
     return emd
+
+
+###############################################################################
+# Measure Image Skeleton
+###############################################################################
+
+
+def neighbors(image: ImageBinary):
+    """
+
+    Counts the neighbor pixels for each pixel of an image:
+
+            x = [
+                [0, 1, 0],
+                [1, 1, 1],
+                [0, 1, 0]
+            ]
+
+            _neighbors(x)
+
+            [
+                [0, 3, 0],
+                [3, 4, 3],
+                [0, 3, 0]
+            ]
+
+    :type image: numpy.ndarray
+
+    :param image: A two-or-three dimensional image
+
+    :return: neighbor pixels for each pixel of an image
+
+    """
+    padding = numpy.pad(image, 1, "constant")
+    mask = padding > 0
+
+    padding = padding.astype(float)
+
+    if image.ndim == 2:
+        response = 3 ** 2 * scipy.ndimage.uniform_filter(padding) - 1
+        labels = (response * mask)[1:-1, 1:-1]
+
+        return labels.astype(numpy.uint16)
+    elif image.ndim == 3:
+        response = 3 ** 3 * scipy.ndimage.uniform_filter(padding) - 1
+        labels = (response * mask)[1:-1, 1:-1, 1:-1]
+
+        return labels.astype(numpy.uint16)
+    else:
+        raise ValueError("Only 2D and 3D images are supported")
+
+def branches(image: ImageBinary):
+    return neighbors(image) > 2
+def endpoints(image: ImageBinary):
+    return neighbors(image) == 1

--- a/src/subpackages/library/cellprofiler_library/modules/_measureimageskeleton.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_measureimageskeleton.py
@@ -1,0 +1,23 @@
+import numpy
+from typing import Annotated
+from pydantic import Field, validate_call, ConfigDict
+from cellprofiler_library.types import ImageGrayscale
+from cellprofiler_library.opts.measureimageskeleton import SkeletonMeasurements
+from cellprofiler_library.functions.measurement import branches, endpoints
+
+@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
+def measure_image_skeleton(
+        im_pixel_data: Annotated[ImageGrayscale, Field(description="Input image")],
+        im_name: Annotated[str, Field(description="Input image name")]="Image1",
+    ):
+    pixels = im_pixel_data > 0
+    branch_nodes = branches(pixels)
+    endpoint_nodes = endpoints(pixels)
+    num_branches = numpy.count_nonzero(branch_nodes)
+    num_endpoints = numpy.count_nonzero(endpoint_nodes)
+    measurements = {
+        SkeletonMeasurements.BRANCHES.value.format(im_name): num_branches,
+        SkeletonMeasurements.ENDPOINTS.value.format(im_name): num_endpoints,
+    }
+    return branch_nodes, endpoint_nodes, measurements
+

--- a/src/subpackages/library/cellprofiler_library/modules/_measureimageskeleton.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_measureimageskeleton.py
@@ -1,25 +1,34 @@
 import numpy
-from typing import Annotated
+from typing import Annotated, Tuple, Union
 from pydantic import Field, validate_call, ConfigDict
 from cellprofiler_library.types import ImageGrayscale
-from cellprofiler_library.opts.measureimageskeleton import SkeletonMeasurements
+from cellprofiler_library.opts.measureimageskeleton import TemplateMeasurementFormat
 from cellprofiler_library.functions.measurement import branches, endpoints
+from cellprofiler_library.measurement_model import LibraryMeasurements
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def measure_image_skeleton(
         im_pixel_data: Annotated[ImageGrayscale, Field(description="Input image")],
         im_name: Annotated[str, Field(description="Input image name")]="Image1",
-    ):
+        return_visualization_data: Annotated[bool, Field(description="Return data for display")] = False,
+    ) -> Union[LibraryMeasurements, Tuple[LibraryMeasurements, numpy.ndarray, numpy.ndarray]]:
     pixels = im_pixel_data > 0
     branch_nodes = branches(pixels)
     endpoint_nodes = endpoints(pixels)
     num_branches = numpy.count_nonzero(branch_nodes)
     num_endpoints = numpy.count_nonzero(endpoint_nodes)
-    measurements = {
-        "Image": {
-            SkeletonMeasurements.BRANCHES.value.format(im_name): num_branches,
-            SkeletonMeasurements.ENDPOINTS.value.format(im_name): num_endpoints,
-        }
-    }
-    return branch_nodes, endpoint_nodes, measurements
-
+    
+    measurements = LibraryMeasurements()
+    measurements.add_image_measurement(
+        TemplateMeasurementFormat.BRANCHES % im_name,
+        num_branches
+    )
+    measurements.add_image_measurement(
+        TemplateMeasurementFormat.ENDPOINTS % im_name,
+        num_endpoints
+    )
+    
+    if return_visualization_data:
+        return measurements, branch_nodes, endpoint_nodes
+    
+    return measurements

--- a/src/subpackages/library/cellprofiler_library/modules/_measureimageskeleton.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_measureimageskeleton.py
@@ -16,8 +16,10 @@ def measure_image_skeleton(
     num_branches = numpy.count_nonzero(branch_nodes)
     num_endpoints = numpy.count_nonzero(endpoint_nodes)
     measurements = {
-        SkeletonMeasurements.BRANCHES.value.format(im_name): num_branches,
-        SkeletonMeasurements.ENDPOINTS.value.format(im_name): num_endpoints,
+        "Image": {
+            SkeletonMeasurements.BRANCHES.value.format(im_name): num_branches,
+            SkeletonMeasurements.ENDPOINTS.value.format(im_name): num_endpoints,
+        }
     }
     return branch_nodes, endpoint_nodes, measurements
 

--- a/src/subpackages/library/cellprofiler_library/modules/_measureimageskeleton.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_measureimageskeleton.py
@@ -1,17 +1,31 @@
 import numpy
-from typing import Annotated, Tuple, Union
-from pydantic import Field, validate_call, ConfigDict
+from numpy.typing import NDArray
+import skimage.segmentation
+from typing import Annotated, Tuple, Union, List, Any
+from pydantic import Field, validate_call, ConfigDict, BaseModel
 from cellprofiler_library.types import ImageGrayscale
 from cellprofiler_library.opts.measureimageskeleton import TemplateMeasurementFormat
 from cellprofiler_library.functions.measurement import branches, endpoints
 from cellprofiler_library.measurement_model import LibraryMeasurements
+
+
+ImageSkeletonStatistics = List[Tuple[int, int]]
+
+class ImageSkeletonDisplayData(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True, 
+        populate_by_name=True
+    )
+
+    statistics: ImageSkeletonStatistics
+    nodes: NDArray[Any]
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def measure_image_skeleton(
         im_pixel_data: Annotated[ImageGrayscale, Field(description="Input image")],
         im_name: Annotated[str, Field(description="Input image name")]="Image1",
         return_visualization_data: Annotated[bool, Field(description="Return data for display")] = False,
-    ) -> Union[LibraryMeasurements, Tuple[LibraryMeasurements, numpy.ndarray, numpy.ndarray]]:
+    ) -> Union[LibraryMeasurements, Tuple[LibraryMeasurements, ImageSkeletonDisplayData]]:
     pixels = im_pixel_data > 0
     branch_nodes = branches(pixels)
     endpoint_nodes = endpoints(pixels)
@@ -19,6 +33,7 @@ def measure_image_skeleton(
     num_endpoints = numpy.count_nonzero(endpoint_nodes)
     
     measurements = LibraryMeasurements()
+
     measurements.add_image_measurement(
         TemplateMeasurementFormat.BRANCHES % im_name,
         num_branches
@@ -29,6 +44,17 @@ def measure_image_skeleton(
     )
     
     if return_visualization_data:
-        return measurements, branch_nodes, endpoint_nodes
+        a = numpy.copy(branch_nodes).astype(numpy.uint16)
+        b = numpy.copy(endpoint_nodes).astype(numpy.uint16)
+
+        a[a == 1] = 1
+        b[b == 1] = 2
+
+        nodes: NDArray[Any] = skimage.segmentation.join_segmentations(a, b)
+
+        return measurements, ImageSkeletonDisplayData(
+            statistics=[(num_branches, num_endpoints)],
+            nodes=nodes
+        )
     
     return measurements

--- a/src/subpackages/library/cellprofiler_library/opts/measureimageskeleton.py
+++ b/src/subpackages/library/cellprofiler_library/opts/measureimageskeleton.py
@@ -1,5 +1,3 @@
-from enum import Enum
-
-class SkeletonMeasurements(str, Enum):
-    BRANCHES = "Skeleton_Branches_{}"
-    ENDPOINTS = "Skeleton_Endpoints_{}"
+class TemplateMeasurementFormat(str):
+    BRANCHES = "Skeleton_Branches_%s"
+    ENDPOINTS = "Skeleton_Endpoints_%s"

--- a/src/subpackages/library/cellprofiler_library/opts/measureimageskeleton.py
+++ b/src/subpackages/library/cellprofiler_library/opts/measureimageskeleton.py
@@ -1,0 +1,5 @@
+from enum import Enum
+
+class SkeletonMeasurements(str, Enum):
+    BRANCHES = "Skeleton_Branches_{}"
+    ENDPOINTS = "Skeleton_Endpoints_{}"


### PR DESCRIPTION
# Refactor MeasureImageSkeleton to use LibraryMeasurements

## Description
This PR refactors the `MeasureImageSkeleton` module to adhere to the strict 3-layer architecture (Functions -> Library Orchestrator -> Frontend). It separates pure algorithmic logic from the CellProfiler Core and UI dependencies.
It also refactors the `MeasureImageSkeleton` module to use the `LibraryMeasurements` Pydantic model. This ensures type safety, standardized API usage, and clean separation of concerns between the library and frontend.

## Changes
### 1. Library Layer (`cellprofiler_library`)
*   **Module**: Updated `measure_image_skeleton` in `subpackages/library/cellprofiler_library/modules/_measureimageskeleton.py`.
    *   Now returns `LibraryMeasurements` object.
    *   Added `return_visualization_data` argument to conditionally return data needed for the UI.
    *   Strictly typed inputs using `cellprofiler_library.types`.

### 2. Frontend Layer (`cellprofiler.modules`)
*   **Cleanup**: Removed redundant local implementations of `_neighbors`, `branches`, and `endpoints`.
*   **Orchestration**: Refactored the `run` method to:
    *   Delegate calculation to the library orchestrator.
    *   unpacks the `LibraryMeasurements` object into the workspace.
    *   Handles the conditional return of visualization data (branch and endpoint nodes) for display purposes.

## Verification
*   Ran existing regression tests: `tests/frontend/modules/test_measureimageskeleton.py` (All passed).
*   Verified that measurement names and values remain identical to the previous implementation.