### PR TITLE
[AI Code]: Refactor`measureobjectskeleton` to Library

### DIFF
--- a/src/frontend/cellprofiler/modules/measureobjectskeleton.py
+++ b/src/frontend/cellprofiler/modules/measureobjectskeleton.py
@@ -84,28 +84,7 @@ from cellprofiler_core.setting.text import Text
 from cellprofiler_core.utilities.core.object import size_similarly
 from centrosome.cpmorphology import fixup_scipy_ndimage_result as fix
 from scipy.ndimage import grey_dilation, grey_erosion
-
-"""The measurement category"""
-C_OBJSKELETON = "ObjectSkeleton"
-
-"""The trunk count feature"""
-F_NUMBER_TRUNKS = "NumberTrunks"
-
-"""The branch feature"""
-F_NUMBER_NON_TRUNK_BRANCHES = "NumberNonTrunkBranches"
-
-"""The endpoint feature"""
-F_NUMBER_BRANCH_ENDS = "NumberBranchEnds"
-
-"""The neurite length feature"""
-F_TOTAL_OBJSKELETON_LENGTH = "TotalObjectSkeletonLength"
-
-F_ALL = [
-    F_NUMBER_TRUNKS,
-    F_NUMBER_NON_TRUNK_BRANCHES,
-    F_NUMBER_BRANCH_ENDS,
-    F_TOTAL_OBJSKELETON_LENGTH,
-]
+from cellprofiler_library.opts.measureobjectskeleton import SkeletonMeasurements, C_OBJSKELETON, F_ALL
 
 
 class MeasureObjectSkeleton(Module):
@@ -526,13 +505,13 @@ The file has the following columns:
         #
         m = workspace.measurements
         assert isinstance(m, Measurements)
-        feature = "_".join((C_OBJSKELETON, F_NUMBER_TRUNKS, skeleton_name))
+        feature = "_".join((C_OBJSKELETON, SkeletonMeasurements.NUMBER_TRUNKS, skeleton_name))
         m.add_measurement(seed_objects_name, feature, trunk_counts)
-        feature = "_".join((C_OBJSKELETON, F_NUMBER_NON_TRUNK_BRANCHES, skeleton_name))
+        feature = "_".join((C_OBJSKELETON, SkeletonMeasurements.NUMBER_NON_TRUNK_BRANCHES, skeleton_name))
         m.add_measurement(seed_objects_name, feature, branch_counts)
-        feature = "_".join((C_OBJSKELETON, F_NUMBER_BRANCH_ENDS, skeleton_name))
+        feature = "_".join((C_OBJSKELETON, SkeletonMeasurements.NUMBER_BRANCH_ENDS, skeleton_name))
         m.add_measurement(seed_objects_name, feature, end_counts)
-        feature = "_".join((C_OBJSKELETON, F_TOTAL_OBJSKELETON_LENGTH, skeleton_name))
+        feature = "_".join((C_OBJSKELETON, SkeletonMeasurements.TOTAL_OBJSKELETON_LENGTH, skeleton_name))
         m[seed_objects_name, feature] = total_distance
         #
         # Collect the graph information
@@ -654,7 +633,7 @@ The file has the following columns:
                 self.seed_objects_name.value,
                 "_".join((C_OBJSKELETON, feature, self.image_name.value)),
                 COLTYPE_FLOAT
-                if feature == F_TOTAL_OBJSKELETON_LENGTH
+                if feature == SkeletonMeasurements.TOTAL_OBJSKELETON_LENGTH
                 else COLTYPE_INTEGER,
             )
             for feature in F_ALL

--- a/src/frontend/cellprofiler/modules/measureobjectskeleton.py
+++ b/src/frontend/cellprofiler/modules/measureobjectskeleton.py
@@ -350,7 +350,7 @@ The file has the following columns:
             intensity_image = workspace.image_set.get_image(self.intensity_image_name.value, must_be_grayscale=True)
 
         (
-            measurements,
+            lib_measurements,
             edge_graph,
             vertex_graph,
             branchpoint_image
@@ -372,11 +372,11 @@ The file has the following columns:
         m = workspace.measurements
         assert isinstance(m, Measurements)
         
-        for object_name, features in measurements["Object"].items():
+        for object_name, features in lib_measurements.objects.items():
             for feature_name, values in features.items():
                 m.add_measurement(object_name, feature_name, values)
         
-        for feature_name, value in measurements["Image"].items():
+        for feature_name, value in lib_measurements.image.items():
              m.add_image_measurement(feature_name, value)
         #
         # Collect the graph information

--- a/src/frontend/cellprofiler/modules/measureobjectskeleton.py
+++ b/src/frontend/cellprofiler/modules/measureobjectskeleton.py
@@ -350,14 +350,13 @@ The file has the following columns:
             intensity_image = workspace.image_set.get_image(self.intensity_image_name.value, must_be_grayscale=True)
 
         (
-            trunk_counts,
-            branch_counts,
-            end_counts,
-            total_distance,
+            measurements,
             edge_graph,
             vertex_graph,
             branchpoint_image
         ) = measure_object_skeleton(
+            seed_objects_name,
+            skeleton_name,
             skeleton, 
             labels, 
             labels_count, 
@@ -372,14 +371,13 @@ The file has the following columns:
         #
         m = workspace.measurements
         assert isinstance(m, Measurements)
-        feature = "_".join((C_OBJSKELETON, SkeletonMeasurements.NUMBER_TRUNKS, skeleton_name))
-        m.add_measurement(seed_objects_name, feature, trunk_counts)
-        feature = "_".join((C_OBJSKELETON, SkeletonMeasurements.NUMBER_NON_TRUNK_BRANCHES, skeleton_name))
-        m.add_measurement(seed_objects_name, feature, branch_counts)
-        feature = "_".join((C_OBJSKELETON, SkeletonMeasurements.NUMBER_BRANCH_ENDS, skeleton_name))
-        m.add_measurement(seed_objects_name, feature, end_counts)
-        feature = "_".join((C_OBJSKELETON, SkeletonMeasurements.TOTAL_OBJSKELETON_LENGTH, skeleton_name))
-        m[seed_objects_name, feature] = total_distance
+        
+        for object_name, features in measurements["Object"].items():
+            for feature_name, values in features.items():
+                m.add_measurement(object_name, feature_name, values)
+        
+        for feature_name, value in measurements["Image"].items():
+             m.add_image_measurement(feature_name, value)
         #
         # Collect the graph information
         #

--- a/src/frontend/cellprofiler/modules/measureobjectskeleton.py
+++ b/src/frontend/cellprofiler/modules/measureobjectskeleton.py
@@ -331,7 +331,6 @@ The file has the following columns:
         seed_objects = workspace.object_set.get_objects(seed_objects_name)
         labels = seed_objects.segmented
         labels_count = numpy.max(labels)
-        label_range = numpy.arange(labels_count, dtype=numpy.int32) + 1
 
         skeleton_image = workspace.image_set.get_image(
             skeleton_name, must_be_binary=True
@@ -362,12 +361,11 @@ The file has the following columns:
             skeleton, 
             labels, 
             labels_count, 
-            label_range, 
             fill_small_holes, 
             max_hole_size, 
             self.wants_objskeleton_graph.value, 
             intensity_image.pixel_data if intensity_image else None,
-            self.wants_branchpoint_image.value
+            True # This is hardcoded to True as branchpoint_image output is needed for frontend show_window
             )
         #
         # Save measurements

--- a/src/frontend/cellprofiler/modules/measureobjectskeleton.py
+++ b/src/frontend/cellprofiler/modules/measureobjectskeleton.py
@@ -60,11 +60,7 @@ Measurements made by this module
 """
 
 import os
-
-import centrosome.cpmorphology
-import centrosome.propagate as propagate
 import numpy
-import scipy.ndimage
 from cellprofiler_core.constants.measurement import COLTYPE_FLOAT
 from cellprofiler_core.constants.measurement import COLTYPE_INTEGER
 from cellprofiler_core.image import Image
@@ -82,11 +78,8 @@ from cellprofiler_core.setting.text import ImageName, Directory
 from cellprofiler_core.setting.text import Integer
 from cellprofiler_core.setting.text import Text
 from cellprofiler_core.utilities.core.object import size_similarly
-from centrosome.cpmorphology import fixup_scipy_ndimage_result as fix
-from scipy.ndimage import grey_dilation, grey_erosion
-from cellprofiler_library.opts.measureobjectskeleton import SkeletonMeasurements, C_OBJSKELETON, F_ALL
-from typing import Tuple
-from cellprofiler_library.types import ImageBinary, ObjectSegmentation, NDArray
+from cellprofiler_library.opts.measureobjectskeleton import SkeletonMeasurements, C_OBJSKELETON, F_ALL, edge_file_columns, vertex_file_columns
+from cellprofiler_library.modules._measureobjectskeleton import measure_object_skeleton
 
 class MeasureObjectSkeleton(Module):
     module_name = "MeasureObjectSkeleton"
@@ -292,26 +285,6 @@ The file has the following columns:
         vertex_path = os.path.abspath(os.path.join(path, vertex_file))
         return edge_path, vertex_path
 
-    VF_IMAGE_NUMBER = "image_number"
-    VF_VERTEX_NUMBER = "vertex_number"
-    VF_I = "i"
-    VF_J = "j"
-    VF_LABELS = "labels"
-    VF_KIND = "kind"
-    vertex_file_columns = (
-        VF_IMAGE_NUMBER,
-        VF_VERTEX_NUMBER,
-        VF_I,
-        VF_J,
-        VF_LABELS,
-        VF_KIND,
-    )
-    EF_IMAGE_NUMBER = "image_number"
-    EF_V1 = "v1"
-    EF_V2 = "v2"
-    EF_LENGTH = "length"
-    EF_TOTAL_INTENSITY = "total_intensity"
-    edge_file_columns = (EF_IMAGE_NUMBER, EF_V1, EF_V2, EF_LENGTH, EF_TOTAL_INTENSITY)
 
     def prepare_run(self, workspace):
         """Initialize graph files"""
@@ -327,8 +300,8 @@ The file has the following columns:
             vertex_files.add(vertex_path)
 
         for file_path, header in (
-            (edge_path, self.edge_file_columns),
-            (vertex_path, self.vertex_file_columns),
+            (edge_path, edge_file_columns),
+            (vertex_path, vertex_file_columns),
         ):
             if os.path.exists(file_path):
                 import wx
@@ -349,191 +322,7 @@ The file has the following columns:
                 fd.write(header + "\n")
         return True
     
-    def get_ring_with_trunks(self, skeleton, labels):
-        #
-        # The following code makes a ring around the seed objects with
-        # the skeleton trunks sticking out of it.
-        #
-        # Create a new skeleton with holes at the seed objects
-        # First combine the seed objects with the skeleton so
-        # that the skeleton trunks come out of the seed objects.
-        #
-        # Erode the labels once so that all of the trunk branchpoints
-        # will be within the labels
-        #
-        #
-        # Dilate the objects, then subtract them to make a ring
-        #
-        my_disk = centrosome.cpmorphology.strel_disk(1.5).astype(int)
-        dilated_labels = grey_dilation(labels, footprint=my_disk)
-        seed_mask = dilated_labels > 0
-        combined_skel = skeleton | seed_mask
-
-        closed_labels = grey_erosion(dilated_labels, footprint=my_disk)
-        seed_center = closed_labels > 0
-        combined_skel = combined_skel & (~seed_center)
-        return dilated_labels, combined_skel, seed_center
     
-
-    def measure_object_skeleton(
-            self, 
-            skeleton, 
-            cropped_labels, 
-            labels_count, 
-            label_range, 
-            fill_small_holes, 
-            max_hole_size,
-            wants_objskeleton_graph,
-            ) -> Tuple[
-                ObjectSegmentation,
-                ImageBinary,
-                ObjectSegmentation,
-                ImageBinary,
-                ImageBinary, # branch points
-                NDArray[numpy.int32], # branching counts
-                ImageBinary,
-                ObjectSegmentation,
-                ObjectSegmentation, # outside labels
-                NDArray[numpy.float_], # trunk counts
-                NDArray[numpy.float_], # branch counts
-                NDArray[numpy.float_], # end counts
-                NDArray[numpy.float_] # total distance
-
-
-            ]:
-        #
-        # The following code makes a ring around the seed objects with
-        # the skeleton trunks sticking out of it.
-        #
-        dilated_labels, combined_skel, seed_center = self.get_ring_with_trunks(skeleton, cropped_labels)
-        
-        #
-        # Fill in single holes (but not a one-pixel hole made by
-        # a one-pixel image)
-        #
-        if fill_small_holes:
-            def size_fn(area, is_object):
-                return (~is_object) and (area <= max_hole_size)
-
-            combined_skel = centrosome.cpmorphology.fill_labeled_holes(
-                combined_skel, ~seed_center, size_fn
-            )
-        #
-        # Reskeletonize to make true branchpoints at the ring boundaries
-        #
-        combined_skel = centrosome.cpmorphology.skeletonize(combined_skel)
-        #
-        # The skeleton outside of the labels
-        #
-        outside_skel = combined_skel & (dilated_labels == 0)
-        #
-        # Associate all skeleton points with seed objects
-        #
-        dlabels, distance_map = propagate.propagate(
-            numpy.zeros(cropped_labels.shape), dilated_labels, combined_skel, 1
-        )
-        #
-        # Get rid of any branchpoints not connected to seeds
-        #
-        combined_skel[dlabels == 0] = False
-        #
-        # Find the branchpoints
-        #
-        branch_points = centrosome.cpmorphology.branchpoints(combined_skel)
-
-        #
-        # Odd case: when four branches meet like this, branchpoints are not
-        # assigned because they are arbitrary. So assign them.
-        #
-        # .  .
-        #  B.
-        #  .B
-        # .  .
-        #
-        odd_case = (
-            combined_skel[:-1, :-1]
-            & combined_skel[1:, :-1]
-            & combined_skel[:-1, 1:]
-            & combined_skel[1, 1]
-        )
-        branch_points[:-1, :-1][odd_case] = True
-        branch_points[1:, 1:][odd_case] = True
-        #
-        # Find the branching counts for the trunks (# of extra branches
-        # emanating from a point other than the line it might be on).
-        #
-        branching_counts = centrosome.cpmorphology.branchings(combined_skel)
-        branching_counts = numpy.array([0, 0, 0, 1, 2])[branching_counts]
-        #
-        # Only take branches within 1 of the outside skeleton
-        #
-        dilated_skel = scipy.ndimage.binary_dilation(
-            outside_skel, centrosome.cpmorphology.eight_connect
-        )
-        branching_counts[~dilated_skel] = 0
-        #
-        # Find the endpoints
-        #
-        end_points = centrosome.cpmorphology.endpoints(combined_skel)
-        #
-        # We use two ranges for classification here:
-        # * anything within one pixel of the dilated image is a trunk
-        # * anything outside of that range is a branch
-        #
-        nearby_labels = dlabels.copy()
-        nearby_labels[distance_map > 1.5] = 0
-
-        outside_labels = dlabels.copy()
-        outside_labels[nearby_labels > 0] = 0
-        #
-        # The trunks are the branchpoints that lie within one pixel of
-        # the dilated image.
-        #
-        if labels_count > 0:
-            trunk_counts = fix(
-                scipy.ndimage.sum(branching_counts, nearby_labels, label_range)
-            ).astype(int)
-        else:
-            trunk_counts = numpy.zeros((0,), int)
-        #
-        # The branches are the branchpoints that lie outside the seed objects
-        #
-        if labels_count > 0:
-            branch_counts = fix(
-                scipy.ndimage.sum(branch_points, outside_labels, label_range)
-            )
-        else:
-            branch_counts = numpy.zeros((0,), int)
-        #
-        # Save the endpoints
-        #
-        if labels_count > 0:
-            end_counts = fix(scipy.ndimage.sum(end_points, outside_labels, label_range))
-        else:
-            end_counts = numpy.zeros((0,), int)
-        #
-        # Calculate the distances
-        #
-        total_distance = centrosome.cpmorphology.skeleton_length(
-            dlabels * outside_skel, label_range
-        )
-        
-        return (
-            dilated_labels, # last update on on line 383
-            outside_skel, # 403
-            dlabels, # 407
-            combined_skel, # 413
-            branch_points, # 435
-            branching_counts, # 448
-            end_points, # 452
-            nearby_labels, #459
-            outside_labels, # 462
-            trunk_counts, # 472
-            branch_counts, # 481
-            end_counts, # 488
-            total_distance # 492
-        )
-
 
     def run(self, workspace):
         """Run the module on the image set"""
@@ -557,21 +346,29 @@ The file has the following columns:
             labels[~m1] = 0
         max_hole_size = self.maximum_hole_size.value
         fill_small_holes = self.wants_to_fill_holes.value
+        intensity_image = None
+        if self.wants_objskeleton_graph:
+            intensity_image = workspace.image_set.get_image(self.intensity_image_name.value, must_be_grayscale=True)
+
         (
-            dilated_labels,
-            outside_skel,
-            dlabels,
-            combined_skel,
-            branch_points,
-            branching_counts,
-            end_points,
-            nearby_labels,
-            outside_labels,
             trunk_counts,
             branch_counts,
             end_counts,
-            total_distance
-        ) = self.measure_object_skeleton(skeleton, labels, labels_count, label_range, fill_small_holes, max_hole_size, self.wants_objskeleton_graph)
+            total_distance,
+            edge_graph,
+            vertex_graph,
+            branchpoint_image
+        ) = measure_object_skeleton(
+            skeleton, 
+            labels, 
+            labels_count, 
+            label_range, 
+            fill_small_holes, 
+            max_hole_size, 
+            self.wants_objskeleton_graph.value, 
+            intensity_image.pixel_data if intensity_image else None,
+            self.wants_branchpoint_image.value
+            )
         #
         # Save measurements
         #
@@ -589,19 +386,6 @@ The file has the following columns:
         # Collect the graph information
         #
         if self.wants_objskeleton_graph:
-            trunk_mask = (branching_counts > 0) & (nearby_labels != 0)
-            intensity_image = workspace.image_set.get_image(
-                self.intensity_image_name.value
-            )
-            edge_graph, vertex_graph = self.make_objskeleton_graph(
-                combined_skel,
-                dlabels,
-                trunk_mask,
-                branch_points & ~trunk_mask,
-                end_points,
-                intensity_image.pixel_data,
-            )
-
             image_number = workspace.measurements.image_set_number
 
             edge_path, vertex_path = self.get_graph_file_paths(m, m.image_number)
@@ -623,17 +407,6 @@ The file has the following columns:
         # Make the display image
         #
         if self.show_window or self.wants_branchpoint_image:
-            branchpoint_image = numpy.zeros((skeleton.shape[0], skeleton.shape[1], 3))
-            trunk_mask = (branching_counts > 0) & (nearby_labels != 0)
-            branch_mask = branch_points & (outside_labels != 0)
-            end_mask = end_points & (outside_labels != 0)
-            branchpoint_image[outside_skel, :] = 1
-            branchpoint_image[trunk_mask | branch_mask | end_mask, :] = 0
-            branchpoint_image[trunk_mask, 0] = 1
-            branchpoint_image[branch_mask, 1] = 1
-            branchpoint_image[end_mask, 2] = 1
-            branchpoint_image[dilated_labels != 0, :] *= 0.875
-            branchpoint_image[dilated_labels != 0, :] += 0.1
             if self.show_window:
                 workspace.display_data.branchpoint_image = branchpoint_image
             if self.wants_branchpoint_image:
@@ -644,7 +417,7 @@ The file has the following columns:
         self, image_number, edge_path, edge_graph, vertex_path, vertex_graph
     ):
         columns = tuple(
-            [vertex_graph[f].tolist() for f in self.vertex_file_columns[2:]]
+            [vertex_graph[f].tolist() for f in vertex_file_columns[2:]]
         )
         with open(vertex_path, "at") as fd:
             for vertex_number, fields in enumerate(zip(*columns)):
@@ -653,7 +426,7 @@ The file has the following columns:
                     + ("%d,%d,%d,%s\n" % fields)
                 )
 
-        columns = tuple([edge_graph[f].tolist() for f in self.edge_file_columns[1:]])
+        columns = tuple([edge_graph[f].tolist() for f in edge_file_columns[1:]])
         with open(edge_path, "at") as fd:
             line_format = "%d,%%d,%%d,%%d,%%.4f\n" % image_number
             for fields in zip(*columns):
@@ -773,202 +546,3 @@ The file has the following columns:
             ]
             variable_revision_number = 3
         return setting_values, variable_revision_number
-
-    def make_objskeleton_graph(
-        self, skeleton, skeleton_labels, trunks, branchpoints, endpoints, image
-    ):
-        """Make a table that captures the graph relationship of the skeleton
-
-        skeleton - binary skeleton image + outline of seed objects
-        skeleton_labels - labels matrix of skeleton
-        trunks - binary image with trunk points as 1
-        branchpoints - binary image with branchpoints as 1
-        endpoints - binary image with endpoints as 1
-        image - image for intensity measurement
-
-        returns two tables.
-        Table 1: edge table
-        The edge table is a numpy record array with the following named
-        columns in the following order:
-        v1: index into vertex table of first vertex of edge
-        v2: index into vertex table of second vertex of edge
-        length: # of intermediate pixels + 2 (for two vertices)
-        total_intensity: sum of intensities along the edge
-
-        Table 2: vertex table
-        The vertex table is a numpy record array:
-        i: I coordinate of the vertex
-        j: J coordinate of the vertex
-        label: the vertex's label
-        kind: kind of vertex = "T" for trunk, "B" for branchpoint or "E" for endpoint.
-        """
-        i, j = numpy.mgrid[0 : skeleton.shape[0], 0 : skeleton.shape[1]]
-        #
-        # Give each point of interest a unique number
-        #
-        points_of_interest = trunks | branchpoints | endpoints
-        number_of_points = numpy.sum(points_of_interest)
-        #
-        # Make up the vertex table
-        #
-        tbe = numpy.zeros(points_of_interest.shape, "|S1")
-        tbe[trunks] = "T"
-        tbe[branchpoints] = "B"
-        tbe[endpoints] = "E"
-        i_idx = i[points_of_interest]
-        j_idx = j[points_of_interest]
-        poe_labels = skeleton_labels[points_of_interest]
-        tbe = tbe[points_of_interest]
-        vertex_table = {
-            self.VF_I: i_idx,
-            self.VF_J: j_idx,
-            self.VF_LABELS: poe_labels,
-            self.VF_KIND: tbe,
-        }
-        #
-        # First, break the skeleton by removing the branchpoints, endpoints
-        # and trunks
-        #
-        broken_skeleton = skeleton & (~points_of_interest)
-        #
-        # Label the broken skeleton: this labels each edge differently
-        #
-        edge_labels, nlabels = centrosome.cpmorphology.label_skeleton(skeleton)
-        #
-        # Reindex after removing the points of interest
-        #
-        edge_labels[points_of_interest] = 0
-        if nlabels > 0:
-            indexer = numpy.arange(nlabels + 1)
-            unique_labels = numpy.sort(numpy.unique(edge_labels))
-            nlabels = len(unique_labels) - 1
-            indexer[unique_labels] = numpy.arange(len(unique_labels))
-            edge_labels = indexer[edge_labels]
-            #
-            # find magnitudes and lengths for all edges
-            #
-            magnitudes = fix(
-                scipy.ndimage.sum(
-                    image, edge_labels, numpy.arange(1, nlabels + 1, dtype=numpy.int32)
-                )
-            )
-            lengths = fix(
-                scipy.ndimage.sum(
-                    numpy.ones(edge_labels.shape),
-                    edge_labels,
-                    numpy.arange(1, nlabels + 1, dtype=numpy.int32),
-                )
-            ).astype(int)
-        else:
-            magnitudes = numpy.zeros(0)
-            lengths = numpy.zeros(0, int)
-        #
-        # combine the edge labels and indexes of points of interest with padding
-        #
-        edge_mask = edge_labels != 0
-        all_labels = numpy.zeros(numpy.array(edge_labels.shape) + 2, int)
-        all_labels[1:-1, 1:-1][edge_mask] = edge_labels[edge_mask] + number_of_points
-        all_labels[i_idx + 1, j_idx + 1] = numpy.arange(1, number_of_points + 1)
-        #
-        # Collect all 8 neighbors for each point of interest
-        #
-        p1 = numpy.zeros(0, int)
-        p2 = numpy.zeros(0, int)
-        for i_off, j_off in (
-            (0, 0),
-            (0, 1),
-            (0, 2),
-            (1, 0),
-            (1, 2),
-            (2, 0),
-            (2, 1),
-            (2, 2),
-        ):
-            p1 = numpy.hstack((p1, numpy.arange(1, number_of_points + 1)))
-            p2 = numpy.hstack((p2, all_labels[i_idx + i_off, j_idx + j_off]))
-        #
-        # Get rid of zeros which are background
-        #
-        p1 = p1[p2 != 0]
-        p2 = p2[p2 != 0]
-        #
-        # Find point_of_interest -> point_of_interest connections.
-        #
-        p1_poi = p1[(p2 <= number_of_points) & (p1 < p2)]
-        p2_poi = p2[(p2 <= number_of_points) & (p1 < p2)]
-        #
-        # Make sure matches are labeled the same
-        #
-        same_labels = (
-            skeleton_labels[i_idx[p1_poi - 1], j_idx[p1_poi - 1]]
-            == skeleton_labels[i_idx[p2_poi - 1], j_idx[p2_poi - 1]]
-        )
-        p1_poi = p1_poi[same_labels]
-        p2_poi = p2_poi[same_labels]
-        #
-        # Find point_of_interest -> edge
-        #
-        p1_edge = p1[p2 > number_of_points]
-        edge = p2[p2 > number_of_points]
-        #
-        # Now, each value that p2_edge takes forms a group and all
-        # p1_edge whose p2_edge are connected together by the edge.
-        # Possibly they touch each other without the edge, but we will
-        # take the minimum distance connecting each pair to throw out
-        # the edge.
-        #
-        edge, p1_edge, p2_edge = centrosome.cpmorphology.pairwise_permutations(
-            edge, p1_edge
-        )
-        indexer = edge - number_of_points - 1
-        lengths = lengths[indexer]
-        magnitudes = magnitudes[indexer]
-        #
-        # OK, now we make the edge table. First poi<->poi. Length = 2,
-        # magnitude = magnitude at each point
-        #
-        poi_length = numpy.ones(len(p1_poi)) * 2
-        poi_magnitude = (
-            image[i_idx[p1_poi - 1], j_idx[p1_poi - 1]]
-            + image[i_idx[p2_poi - 1], j_idx[p2_poi - 1]]
-        )
-        #
-        # Now the edges...
-        #
-        poi_edge_length = lengths + 2
-        poi_edge_magnitude = (
-            image[i_idx[p1_edge - 1], j_idx[p1_edge - 1]]
-            + image[i_idx[p2_edge - 1], j_idx[p2_edge - 1]]
-            + magnitudes
-        )
-        #
-        # Put together the columns
-        #
-        v1 = numpy.hstack((p1_poi, p1_edge))
-        v2 = numpy.hstack((p2_poi, p2_edge))
-        lengths = numpy.hstack((poi_length, poi_edge_length))
-        magnitudes = numpy.hstack((poi_magnitude, poi_edge_magnitude))
-        #
-        # Sort by p1, p2 and length in order to pick the shortest length
-        #
-        indexer = numpy.lexsort((lengths, v1, v2))
-        v1 = v1[indexer]
-        v2 = v2[indexer]
-        lengths = lengths[indexer]
-        magnitudes = magnitudes[indexer]
-        if len(v1) > 0:
-            to_keep = numpy.hstack(([True], (v1[1:] != v1[:-1]) | (v2[1:] != v2[:-1])))
-            v1 = v1[to_keep]
-            v2 = v2[to_keep]
-            lengths = lengths[to_keep]
-            magnitudes = magnitudes[to_keep]
-        #
-        # Put it all together into a table
-        #
-        edge_table = {
-            self.EF_V1: v1,
-            self.EF_V2: v2,
-            self.EF_LENGTH: lengths,
-            self.EF_TOTAL_INTENSITY: magnitudes,
-        }
-        return edge_table, vertex_table

--- a/src/frontend/cellprofiler/modules/measureobjectskeleton.py
+++ b/src/frontend/cellprofiler/modules/measureobjectskeleton.py
@@ -349,23 +349,24 @@ The file has the following columns:
         if self.wants_objskeleton_graph:
             intensity_image = workspace.image_set.get_image(self.intensity_image_name.value, must_be_grayscale=True)
 
-        (
-            lib_measurements,
-            edge_graph,
-            vertex_graph,
-            branchpoint_image
-        ) = measure_object_skeleton(
+        lib_res = measure_object_skeleton(
             seed_objects_name,
             skeleton_name,
-            skeleton, 
-            labels, 
-            labels_count, 
-            fill_small_holes, 
-            max_hole_size, 
-            self.wants_objskeleton_graph.value, 
+            skeleton,
+            labels,
+            labels_count,
+            fill_small_holes,
+            max_hole_size,
+            self.wants_objskeleton_graph.value,
             intensity_image.pixel_data if intensity_image else None,
-            True # This is hardcoded to True as branchpoint_image output is needed for frontend show_window
-            )
+            self.wants_branchpoint_image.value
+        )
+        # rare case of not conditioning on self.show_window for display results here
+        # since we might need them even if/when show_window is False
+        if self.wants_branchpoint_image or self.wants_objskeleton_graph:
+            lib_measurements, lib_display = lib_res
+        else:
+            lib_measurements = lib_res
         #
         # Save measurements
         #
@@ -382,32 +383,29 @@ The file has the following columns:
         # Collect the graph information
         #
         if self.wants_objskeleton_graph:
-            image_number = workspace.measurements.image_set_number
-
             edge_path, vertex_path = self.get_graph_file_paths(m, m.image_number)
             workspace.interaction_request(
                 self,
                 m.image_number,
                 edge_path,
-                edge_graph,
+                lib_display.edge_graph,
                 vertex_path,
-                vertex_graph,
+                lib_display.vertex_graph,
                 headless_ok=True,
             )
 
             if self.show_window:
-                workspace.display_data.edge_graph = edge_graph
-                workspace.display_data.vertex_graph = vertex_graph
+                workspace.display_data.edge_graph = lib_display.edge_graph
+                workspace.display_data.vertex_graph = lib_display.vertex_graph
                 workspace.display_data.intensity_image = intensity_image.pixel_data
         #
         # Make the display image
         #
-        if self.show_window or self.wants_branchpoint_image:
-            if self.show_window:
-                workspace.display_data.branchpoint_image = branchpoint_image
-            if self.wants_branchpoint_image:
-                bi = Image(branchpoint_image, parent_image=skeleton_image)
-                workspace.image_set.add(self.branchpoint_image_name.value, bi)
+        if self.show_window:
+            workspace.display_data.branchpoint_image = lib_display.branchpoint_image
+        if self.wants_branchpoint_image:
+            bi = Image(lib_display.branchpoint_image, parent_image=skeleton_image)
+            workspace.image_set.add(self.branchpoint_image_name.value, bi)
 
     def handle_interaction(
         self, image_number, edge_path, edge_graph, vertex_path, vertex_graph

--- a/src/subpackages/library/cellprofiler_library/functions/measurement.py
+++ b/src/subpackages/library/cellprofiler_library/functions/measurement.py
@@ -15,6 +15,7 @@ from centrosome.cpmorphology import fixup_scipy_ndimage_result as fix
 from sklearn.cluster import KMeans
 from typing import Tuple, Optional, Dict, Callable, List, Union, Any
 from scipy.linalg import lstsq
+from scipy.ndimage import grey_dilation, grey_erosion
 from numpy.typing import NDArray
 
 from cellprofiler_library.opts import measureimageoverlap as mio
@@ -24,10 +25,11 @@ from cellprofiler_library.functions.segmentation import cast_labels_to_label_set
 from cellprofiler_library.functions.segmentation import convert_label_set_to_ijv
 from cellprofiler_library.functions.image_processing import masked_erode, restore_scale, get_morphology_footprint
 
-from cellprofiler_library.types import Pixel, ObjectLabel, ImageGrayscale, ImageGrayscaleMask, ImageAny, ImageBinary, ImageBinaryMask, ObjectSegmentation, ObjectLabelsDense, ObjectLabelSet, ObjectSegmentationIJV
+from cellprofiler_library.types import Pixel, ObjectLabel, ImageGrayscale, ImageGrayscaleMask, ImageAny, ImageBinary, ImageBinaryMask, ObjectSegmentation, ObjectLabelsDense, ObjectLabelSet, ObjectSegmentationIJV, Image2DBinary, Image2DColor, Image2DGrayscale
 from cellprofiler_library.opts.objectsizeshapefeatures import ObjectSizeShapeFeatures
 from cellprofiler_library.opts.measurecolocalization import CostesMethod
 from cellprofiler_library.opts.measureobjectoverlap import DecimationMethod as ObjectDecimationMethod
+from cellprofiler_library.opts.measureobjectskeleton import VF_I, VF_J, VF_LABELS, VF_KIND, EF_V1, EF_V2, EF_LENGTH, EF_TOTAL_INTENSITY
 
 ###############################################################################
 # MeasureImageOverlap
@@ -2253,3 +2255,422 @@ def branches(image: ImageBinary):
     return neighbors(image) > 2
 def endpoints(image: ImageBinary):
     return neighbors(image) == 1
+
+###############################################################################
+# MeasureObjectSkeleton
+###############################################################################
+
+def get_ring_with_trunks(
+        skeleton: Image2DBinary, 
+        labels: ObjectSegmentation
+        ) -> Tuple[
+            ObjectSegmentation,
+            Image2DBinary,
+            Image2DBinary
+        ]:
+    #
+    # The following code makes a ring around the seed objects with
+    # the skeleton trunks sticking out of it.
+    #
+    # Create a new skeleton with holes at the seed objects
+    # First combine the seed objects with the skeleton so
+    # that the skeleton trunks come out of the seed objects.
+    #
+    # Erode the labels once so that all of the trunk branchpoints
+    # will be within the labels
+    #
+    #
+    # Dilate the objects, then subtract them to make a ring
+    #
+    my_disk = centrosome.cpmorphology.strel_disk(1.5).astype(int)
+    dilated_labels = grey_dilation(labels, footprint=my_disk)
+    seed_mask = dilated_labels > 0
+    combined_skel = skeleton | seed_mask
+
+    closed_labels = grey_erosion(dilated_labels, footprint=my_disk)
+    seed_center = closed_labels > 0
+    combined_skel = combined_skel & (~seed_center)
+    return dilated_labels, combined_skel, seed_center
+
+
+def calculate_object_skeleton(
+        skeleton: Image2DBinary, 
+        cropped_labels: ObjectSegmentation, 
+        labels_count: numpy.integer[Any],
+        fill_small_holes: bool, 
+        max_hole_size: Optional[int],
+        wants_objskeleton_graph: bool,
+        intensity_image_pixel_data: Optional[Image2DGrayscale],
+        wants_branchpoint_image: bool
+        ) -> Tuple[
+            NDArray[numpy.float_], # trunk counts
+            NDArray[numpy.float_], # branch counts
+            NDArray[numpy.float_], # end counts
+            NDArray[numpy.float_], # total distance
+            Optional[Dict[str, NDArray[Union[numpy.float_, numpy.int_]]]],
+            Optional[Dict[str, NDArray[Union[numpy.float_, numpy.int_]]]],
+            Optional[Image2DColor],
+        ]:
+    #
+    # The following code makes a ring around the seed objects with
+    # the skeleton trunks sticking out of it.
+    #
+    dilated_labels, combined_skel, seed_center = get_ring_with_trunks(skeleton, cropped_labels)
+    
+    #
+    # Fill in single holes (but not a one-pixel hole made by
+    # a one-pixel image)
+    #
+    if fill_small_holes:
+        assert max_hole_size is not None, "max_hole_size must be provided for filling small holes"
+        def size_fn(area, is_object):
+            return (~is_object) and (area <= max_hole_size)
+
+        combined_skel = centrosome.cpmorphology.fill_labeled_holes(
+            combined_skel, ~seed_center, size_fn
+        )
+    #
+    # Reskeletonize to make true branchpoints at the ring boundaries
+    #
+    combined_skel = centrosome.cpmorphology.skeletonize(combined_skel)
+    #
+    # The skeleton outside of the labels
+    #
+    outside_skel = combined_skel & (dilated_labels == 0)
+    #
+    # Associate all skeleton points with seed objects
+    #
+    dlabels, distance_map = centrosome.propagate.propagate(
+        numpy.zeros(cropped_labels.shape), dilated_labels, combined_skel, 1
+    )
+    #
+    # Get rid of any branchpoints not connected to seeds
+    #
+    combined_skel[dlabels == 0] = False
+    #
+    # Find the branchpoints
+    #
+    branch_points = centrosome.cpmorphology.branchpoints(combined_skel)
+
+    #
+    # Odd case: when four branches meet like this, branchpoints are not
+    # assigned because they are arbitrary. So assign them.
+    #
+    # .  .
+    #  B.
+    #  .B
+    # .  .
+    #
+    odd_case = (
+        combined_skel[:-1, :-1]
+        & combined_skel[1:, :-1]
+        & combined_skel[:-1, 1:]
+        & combined_skel[1, 1]
+    )
+    branch_points[:-1, :-1][odd_case] = True
+    branch_points[1:, 1:][odd_case] = True
+    #
+    # Find the branching counts for the trunks (# of extra branches
+    # emanating from a point other than the line it might be on).
+    #
+    branching_counts = centrosome.cpmorphology.branchings(combined_skel)
+    branching_counts = numpy.array([0, 0, 0, 1, 2])[branching_counts]
+    #
+    # Only take branches within 1 of the outside skeleton
+    #
+    dilated_skel = scipy.ndimage.binary_dilation(
+        outside_skel, centrosome.cpmorphology.eight_connect
+    )
+    branching_counts[~dilated_skel] = 0
+    #
+    # Find the endpoints
+    #
+    end_points = centrosome.cpmorphology.endpoints(combined_skel)
+    #
+    # We use two ranges for classification here:
+    # * anything within one pixel of the dilated image is a trunk
+    # * anything outside of that range is a branch
+    #
+    nearby_labels = dlabels.copy()
+    nearby_labels[distance_map > 1.5] = 0
+
+    outside_labels = dlabels.copy()
+    outside_labels[nearby_labels > 0] = 0
+    #
+    # The trunks are the branchpoints that lie within one pixel of
+    # the dilated image.
+    #
+    label_range = numpy.arange(labels_count, dtype=numpy.int32) + 1
+    if labels_count > 0:
+        trunk_counts = fix(
+            scipy.ndimage.sum(branching_counts, nearby_labels, label_range)
+        ).astype(int)
+    else:
+        trunk_counts = numpy.zeros((0,), int)
+    #
+    # The branches are the branchpoints that lie outside the seed objects
+    #
+    if labels_count > 0:
+        branch_counts = fix(
+            scipy.ndimage.sum(branch_points, outside_labels, label_range)
+        )
+    else:
+        branch_counts = numpy.zeros((0,), int)
+    #
+    # Save the endpoints
+    #
+    if labels_count > 0:
+        end_counts = fix(scipy.ndimage.sum(end_points, outside_labels, label_range))
+    else:
+        end_counts = numpy.zeros((0,), int)
+    #
+    # Calculate the distances
+    #
+    total_distance = centrosome.cpmorphology.skeleton_length(
+        dlabels * outside_skel, label_range
+    ).astype(numpy.float64)
+    edge_graph = None
+    vertex_graph = None
+    
+    branchpoint_image = None
+    if wants_objskeleton_graph or wants_branchpoint_image:
+        trunk_mask = (branching_counts > 0) & (nearby_labels != 0)
+        
+        if wants_objskeleton_graph:
+            assert intensity_image_pixel_data is not None
+            edge_graph, vertex_graph = make_objskeleton_graph(
+                combined_skel,
+                dlabels,
+                trunk_mask,
+                branch_points & ~trunk_mask,
+                end_points,
+                intensity_image_pixel_data,
+            )
+        if wants_branchpoint_image:
+            branchpoint_image = numpy.zeros((skeleton.shape[0], skeleton.shape[1], 3))
+            branch_mask = branch_points & (outside_labels != 0)
+            end_mask = end_points & (outside_labels != 0)
+            branchpoint_image[outside_skel, :] = 1
+            branchpoint_image[trunk_mask | branch_mask | end_mask, :] = 0
+            branchpoint_image[trunk_mask, 0] = 1
+            branchpoint_image[branch_mask, 1] = 1
+            branchpoint_image[end_mask, 2] = 1
+            branchpoint_image[dilated_labels != 0, :] *= 0.875
+            branchpoint_image[dilated_labels != 0, :] += 0.1
+
+    return (
+        trunk_counts, 
+        branch_counts,
+        end_counts,
+        total_distance,
+        edge_graph, 
+        vertex_graph,
+        branchpoint_image
+    )
+
+def make_objskeleton_graph(
+    skeleton: Image2DBinary, 
+    skeleton_labels: ObjectSegmentation, 
+    trunks: Image2DBinary, 
+    branchpoints: Image2DBinary, 
+    endpoints: Image2DBinary, 
+    image: Image2DGrayscale
+    ) -> Tuple[
+        Dict[str, NDArray[Union[numpy.float_, numpy.int_]]],
+        Dict[str, NDArray[Union[numpy.float_, numpy.int_]]]
+    ]:
+    """Make a table that captures the graph relationship of the skeleton
+
+    skeleton - binary skeleton image + outline of seed objects
+    skeleton_labels - labels matrix of skeleton
+    trunks - binary image with trunk points as 1
+    branchpoints - binary image with branchpoints as 1
+    endpoints - binary image with endpoints as 1
+    image - image for intensity measurement
+
+    returns two tables.
+    Table 1: edge table
+    The edge table is a numpy record array with the following named
+    columns in the following order:
+    v1: index into vertex table of first vertex of edge
+    v2: index into vertex table of second vertex of edge
+    length: # of intermediate pixels + 2 (for two vertices)
+    total_intensity: sum of intensities along the edge
+
+    Table 2: vertex table
+    The vertex table is a numpy record array:
+    i: I coordinate of the vertex
+    j: J coordinate of the vertex
+    label: the vertex's label
+    kind: kind of vertex = "T" for trunk, "B" for branchpoint or "E" for endpoint.
+    """
+    i, j = numpy.mgrid[0 : skeleton.shape[0], 0 : skeleton.shape[1]]
+    #
+    # Give each point of interest a unique number
+    #
+    points_of_interest = trunks | branchpoints | endpoints
+    number_of_points = numpy.sum(points_of_interest)
+    #
+    # Make up the vertex table
+    #
+    tbe = numpy.zeros(points_of_interest.shape, "|S1")
+    tbe[trunks] = "T"
+    tbe[branchpoints] = "B"
+    tbe[endpoints] = "E"
+    i_idx = i[points_of_interest]
+    j_idx = j[points_of_interest]
+    poe_labels = skeleton_labels[points_of_interest]
+    tbe = tbe[points_of_interest]
+    vertex_table = {
+        VF_I: i_idx,
+        VF_J: j_idx,
+        VF_LABELS: poe_labels,
+        VF_KIND: tbe,
+    }
+    #
+    # First, break the skeleton by removing the branchpoints, endpoints
+    # and trunks
+    #
+    broken_skeleton = skeleton & (~points_of_interest)
+    #
+    # Label the broken skeleton: this labels each edge differently
+    #
+    edge_labels, nlabels = centrosome.cpmorphology.label_skeleton(skeleton)
+    #
+    # Reindex after removing the points of interest
+    #
+    edge_labels[points_of_interest] = 0
+    if nlabels > 0:
+        indexer = numpy.arange(nlabels + 1)
+        unique_labels = numpy.sort(numpy.unique(edge_labels))
+        nlabels = len(unique_labels) - 1
+        indexer[unique_labels] = numpy.arange(len(unique_labels))
+        edge_labels = indexer[edge_labels]
+        #
+        # find magnitudes and lengths for all edges
+        #
+        magnitudes = fix(
+            scipy.ndimage.sum(
+                image, edge_labels, numpy.arange(1, nlabels + 1, dtype=numpy.int32)
+            )
+        )
+        lengths = fix(
+            scipy.ndimage.sum(
+                numpy.ones(edge_labels.shape),
+                edge_labels,
+                numpy.arange(1, nlabels + 1, dtype=numpy.int32),
+            )
+        ).astype(int)
+    else:
+        magnitudes = numpy.zeros(0)
+        lengths = numpy.zeros(0, int)
+    #
+    # combine the edge labels and indexes of points of interest with padding
+    #
+    edge_mask = edge_labels != 0
+    all_labels = numpy.zeros(numpy.array(edge_labels.shape) + 2, int)
+    all_labels[1:-1, 1:-1][edge_mask] = edge_labels[edge_mask] + number_of_points
+    all_labels[i_idx + 1, j_idx + 1] = numpy.arange(1, number_of_points + 1)
+    #
+    # Collect all 8 neighbors for each point of interest
+    #
+    p1 = numpy.zeros(0, int)
+    p2 = numpy.zeros(0, int)
+    for i_off, j_off in (
+        (0, 0),
+        (0, 1),
+        (0, 2),
+        (1, 0),
+        (1, 2),
+        (2, 0),
+        (2, 1),
+        (2, 2),
+    ):
+        p1 = numpy.hstack((p1, numpy.arange(1, number_of_points + 1)))
+        p2 = numpy.hstack((p2, all_labels[i_idx + i_off, j_idx + j_off]))
+    #
+    # Get rid of zeros which are background
+    #
+    p1 = p1[p2 != 0]
+    p2 = p2[p2 != 0]
+    #
+    # Find point_of_interest -> point_of_interest connections.
+    #
+    p1_poi = p1[(p2 <= number_of_points) & (p1 < p2)]
+    p2_poi = p2[(p2 <= number_of_points) & (p1 < p2)]
+    #
+    # Make sure matches are labeled the same
+    #
+    same_labels = (
+        skeleton_labels[i_idx[p1_poi - 1], j_idx[p1_poi - 1]]
+        == skeleton_labels[i_idx[p2_poi - 1], j_idx[p2_poi - 1]]
+    )
+    p1_poi = p1_poi[same_labels]
+    p2_poi = p2_poi[same_labels]
+    #
+    # Find point_of_interest -> edge
+    #
+    p1_edge = p1[p2 > number_of_points]
+    edge = p2[p2 > number_of_points]
+    #
+    # Now, each value that p2_edge takes forms a group and all
+    # p1_edge whose p2_edge are connected together by the edge.
+    # Possibly they touch each other without the edge, but we will
+    # take the minimum distance connecting each pair to throw out
+    # the edge.
+    #
+    edge, p1_edge, p2_edge = centrosome.cpmorphology.pairwise_permutations(
+        edge, p1_edge
+    )
+    indexer = edge - number_of_points - 1
+    lengths = lengths[indexer]
+    magnitudes = magnitudes[indexer]
+    #
+    # OK, now we make the edge table. First poi<->poi. Length = 2,
+    # magnitude = magnitude at each point
+    #
+    poi_length = numpy.ones(len(p1_poi)) * 2
+    poi_magnitude = (
+        image[i_idx[p1_poi - 1], j_idx[p1_poi - 1]]
+        + image[i_idx[p2_poi - 1], j_idx[p2_poi - 1]]
+    )
+    #
+    # Now the edges...
+    #
+    poi_edge_length = lengths + 2
+    poi_edge_magnitude = (
+        image[i_idx[p1_edge - 1], j_idx[p1_edge - 1]]
+        + image[i_idx[p2_edge - 1], j_idx[p2_edge - 1]]
+        + magnitudes
+    )
+    #
+    # Put together the columns
+    #
+    v1 = numpy.hstack((p1_poi, p1_edge))
+    v2 = numpy.hstack((p2_poi, p2_edge))
+    lengths = numpy.hstack((poi_length, poi_edge_length))
+    magnitudes = numpy.hstack((poi_magnitude, poi_edge_magnitude))
+    #
+    # Sort by p1, p2 and length in order to pick the shortest length
+    #
+    indexer = numpy.lexsort((lengths, v1, v2))
+    v1 = v1[indexer]
+    v2 = v2[indexer]
+    lengths = lengths[indexer]
+    magnitudes = magnitudes[indexer]
+    if len(v1) > 0:
+        to_keep = numpy.hstack(([True], (v1[1:] != v1[:-1]) | (v2[1:] != v2[:-1])))
+        v1 = v1[to_keep]
+        v2 = v2[to_keep]
+        lengths = lengths[to_keep]
+        magnitudes = magnitudes[to_keep]
+    #
+    # Put it all together into a table
+    #
+    edge_table = {
+        EF_V1: v1,
+        EF_V2: v2,
+        EF_LENGTH: lengths,
+        EF_TOTAL_INTENSITY: magnitudes,
+    }
+    return edge_table, vertex_table

--- a/src/subpackages/library/cellprofiler_library/functions/measurement.py
+++ b/src/subpackages/library/cellprofiler_library/functions/measurement.py
@@ -1,22 +1,22 @@
-import numpy as np
+from functools import reduce
+from typing import Tuple, Optional, Dict, Callable, List, Union, Any
+
 import numpy
+from numpy.typing import NDArray
 import scipy
 import scipy.ndimage
 import scipy.sparse
 import skimage
 import centrosome
-import centrosome.cpmorphology
 import centrosome.filter
 import centrosome.propagate
 import centrosome.fastemd
 import centrosome.index
-from functools import reduce
+import centrosome.cpmorphology
 from centrosome.cpmorphology import fixup_scipy_ndimage_result as fix
 from sklearn.cluster import KMeans
-from typing import Tuple, Optional, Dict, Callable, List, Union, Any
 from scipy.linalg import lstsq
 from scipy.ndimage import grey_dilation, grey_erosion
-from numpy.typing import NDArray
 
 from cellprofiler_library.opts import measureimageoverlap as mio
 from cellprofiler_library.functions.segmentation import count_from_ijv
@@ -41,14 +41,14 @@ def measure_image_overlap_statistics(
     mask: Optional[ImageBinaryMask]=None,
 ) -> Dict[str, numpy.float_]:
     # Check that the inputs are binary
-    if not np.array_equal(ground_truth_image, ground_truth_image.astype(bool)):
+    if not numpy.array_equal(ground_truth_image, ground_truth_image.astype(bool)):
         raise ValueError("ground_truth_image is not a binary image")
     
-    if not np.array_equal(test_image, test_image.astype(bool)):
+    if not numpy.array_equal(test_image, test_image.astype(bool)):
         raise ValueError("test_image is not a binary image")
 
     if mask is None:
-        mask = np.ones_like(ground_truth_image, bool)
+        mask = numpy.ones_like(ground_truth_image, bool)
 
     orig_shape = ground_truth_image.shape
     
@@ -78,13 +78,13 @@ def measure_image_overlap_statistics(
 
     true_negatives[~mask] = False
 
-    false_positive_count = np.sum(false_positives)
+    false_positive_count = numpy.sum(false_positives)
 
-    true_positive_count = np.sum(true_positives)
+    true_positive_count = numpy.sum(true_positives)
 
-    false_negative_count = np.sum(false_negatives)
+    false_negative_count = numpy.sum(false_negatives)
 
-    true_negative_count = np.sum(true_negatives)
+    true_negative_count = numpy.sum(true_negatives)
 
     labeled_pixel_count = true_positive_count + false_positive_count
 
@@ -125,11 +125,11 @@ def measure_image_overlap_statistics(
         true_positive_rate = float(true_positive_count) / float(true_count)
 
     ground_truth_labels, ground_truth_count = scipy.ndimage.label(
-        ground_truth_image & mask, np.ones((3, 3), bool)
+        ground_truth_image & mask, numpy.ones((3, 3), bool)
     )
 
     test_labels, test_count = scipy.ndimage.label(
-        test_image & mask, np.ones((3, 3), bool)
+        test_image & mask, numpy.ones((3, 3), bool)
     )
 
     rand_index, adjusted_rand_index = compute_rand_index(
@@ -200,8 +200,8 @@ def compute_rand_index(
 
     returns a tuple of the Rand Index and the adjusted Rand Index
     """
-    ground_truth_labels = ground_truth_labels[mask].astype(np.uint32)
-    test_labels = test_labels[mask].astype(np.uint32)
+    ground_truth_labels = ground_truth_labels[mask].astype(numpy.uint32)
+    test_labels = test_labels[mask].astype(numpy.uint32)
     if len(test_labels) > 0:
         #
         # Create a sparse matrix of the pixel labels in each of the sets
@@ -211,7 +211,7 @@ def compute_rand_index(
         # test set.
         #
         N_ij = scipy.sparse.coo_matrix(
-            (np.ones(len(test_labels)), (ground_truth_labels, test_labels))
+            (numpy.ones(len(test_labels)), (ground_truth_labels, test_labels))
         ).toarray()
 
         def choose2(x):
@@ -223,7 +223,7 @@ def compute_rand_index(
         # pixel pairs are in the same set in both groups. The number of
         # pixel pairs is n * (n - 1), so A = sum(matrix * (matrix - 1))
         #
-        A = np.sum(choose2(N_ij))
+        A = numpy.sum(choose2(N_ij))
         #
         # B is the sum of pixels that were classified differently by both
         # sets. But the easier calculation is to find A, C and D and get
@@ -236,10 +236,10 @@ def compute_rand_index(
         #
         # We do the similar calculation for D
         #
-        N_i = np.sum(N_ij, 1)
-        N_j = np.sum(N_ij, 0)
-        C = np.sum((N_i[:, np.newaxis] - N_ij) * N_ij) / 2
-        D = np.sum((N_j[np.newaxis, :] - N_ij) * N_ij) / 2
+        N_i = numpy.sum(N_ij, 1)
+        N_j = numpy.sum(N_ij, 0)
+        C = numpy.sum((N_i[:, numpy.newaxis] - N_ij) * N_ij) / 2
+        D = numpy.sum((N_j[numpy.newaxis, :] - N_ij) * N_ij) / 2
         total = choose2(len(test_labels))
         # an astute observer would say, why bother computing A and B
         # when all we need is A+B and C, D and the total can be used to do
@@ -249,14 +249,14 @@ def compute_rand_index(
         #
         # Compute adjusted Rand Index
         #
-        expected_index = np.sum(choose2(N_i)) * np.sum(choose2(N_j))
-        max_index = (np.sum(choose2(N_i)) + np.sum(choose2(N_j))) * total / 2
+        expected_index = numpy.sum(choose2(N_i)) * numpy.sum(choose2(N_j))
+        max_index = (numpy.sum(choose2(N_i)) + numpy.sum(choose2(N_j))) * total / 2
 
         adjusted_rand_index = (A * total - expected_index) / (
             max_index - expected_index
         )
     else:
-        rand_index = adjusted_rand_index = np.nan
+        rand_index = adjusted_rand_index = numpy.nan
     return rand_index, adjusted_rand_index
 
 
@@ -279,14 +279,14 @@ def compute_earth_movers_distance(
     """
 
     # Check that the inputs are binary
-    if not np.array_equal(ground_truth_image, ground_truth_image.astype(bool)):
+    if not numpy.array_equal(ground_truth_image, ground_truth_image.astype(bool)):
         raise ValueError("ground_truth_image is not a binary image")
     
-    if not np.array_equal(test_image, test_image.astype(bool)):
+    if not numpy.array_equal(test_image, test_image.astype(bool)):
         raise ValueError("test_image is not a binary image")
 
     if mask is None:
-        mask = np.ones_like(ground_truth_image, bool)
+        mask = numpy.ones_like(ground_truth_image, bool)
 
     # Covert 3D image to 2D long
     if ground_truth_image.ndim > 2:
@@ -299,8 +299,8 @@ def compute_earth_movers_distance(
         mask = mask.reshape(-1, mask.shape[-1])
 
     # ground truth labels
-    dest_labels = scipy.ndimage.label(ground_truth_image & mask, np.ones((3, 3), bool))[0]
-    src_labels = scipy.ndimage.label(test_image & mask, np.ones((3, 3), bool))[0]
+    dest_labels = scipy.ndimage.label(ground_truth_image & mask, numpy.ones((3, 3), bool))[0]
+    src_labels = scipy.ndimage.label(test_image & mask, numpy.ones((3, 3), bool))[0]
     dest_labelset = cast_labels_to_label_set(dest_labels)
     src_labelset = cast_labels_to_label_set(src_labels)
     emd = compute_earth_movers_distance_objects(
@@ -315,7 +315,7 @@ def compute_earth_movers_distance(
     
 
 def get_labels_mask(labelset, shape):
-    labels_mask = np.zeros(shape, bool)
+    labels_mask = numpy.zeros(shape, bool)
     for labels, indexes in labelset:
         labels_mask = labels_mask | labels > 0
     return labels_mask
@@ -325,13 +325,13 @@ def get_skeleton_points(
         labelset: ObjectLabelSet, 
         shape: Tuple[int, int], 
         max_points: int=250,
-    ) -> Tuple[NDArray[np.int32], NDArray[np.int32]]:
+    ) -> Tuple[NDArray[numpy.int32], NDArray[numpy.int32]]:
     """Get points by skeletonizing the objects and decimating"""
-    total_skel = np.zeros(shape, bool)
+    total_skel = numpy.zeros(shape, bool)
 
     for labels, indexes in labelset:
         colors = centrosome.cpmorphology.color_labels(labels)
-        for color in range(1, np.max(colors) + 1):
+        for color in range(1, numpy.max(colors) + 1):
             labels_mask = colors == color
             skel = centrosome.cpmorphology.skeletonize(
                 labels_mask,
@@ -340,37 +340,37 @@ def get_skeleton_points(
             )
             total_skel = total_skel | skel
 
-    n_pts = np.sum(total_skel)
+    n_pts = numpy.sum(total_skel)
 
     if n_pts == 0:
-        return np.zeros(0, np.int32), np.zeros(0, np.int32)
+        return numpy.zeros(0, numpy.int32), numpy.zeros(0, numpy.int32)
 
-    i, j = np.where(total_skel)
+    i, j = numpy.where(total_skel)
 
     if n_pts > max_points:
         #
         # Decimate the skeleton by finding the branchpoints in the
         # skeleton and propagating from those.
         #
-        markers = np.zeros(total_skel.shape, np.int32)
+        markers = numpy.zeros(total_skel.shape, numpy.int32)
         branchpoints = centrosome.cpmorphology.branchpoints(
             total_skel
         ) | centrosome.cpmorphology.endpoints(total_skel)
-        markers[branchpoints] = np.arange(np.sum(branchpoints)) + 1
+        markers[branchpoints] = numpy.arange(numpy.sum(branchpoints)) + 1
         #
         # We compute the propagation distance to that point, then impose
         # a slightly arbitrary order to get an unambiguous ordering
         # which should number the pixels in a skeleton branch monotonically
         #
         ts_labels, distances = centrosome.propagate.propagate(
-            np.zeros(markers.shape), markers, total_skel, 1
+            numpy.zeros(markers.shape), markers, total_skel, 1
         )
-        order = np.lexsort((j, i, distances[i, j], ts_labels[i, j]))
+        order = numpy.lexsort((j, i, distances[i, j], ts_labels[i, j]))
         #
         # Get a linear space of self.max_points elements with bounds at
         # 0 and len(order)-1 and use that to select the points.
         #
-        order = order[np.linspace(0, len(order) - 1, max_points).astype(int)]
+        order = order[numpy.linspace(0, len(order) - 1, max_points).astype(int)]
         return i[order], j[order]
 
     return i, j
@@ -391,16 +391,16 @@ def get_kmeans_points(
             of j coordinates
     """
 
-    ijv = np.vstack((src_ijv, dest_ijv))
+    ijv = numpy.vstack((src_ijv, dest_ijv))
     if len(ijv) <= max_points:
         return ijv[:, 0], ijv[:, 1]
-    random_state = np.random.RandomState()
+    random_state = numpy.random.RandomState()
     random_state.seed(ijv.astype(int).flatten())
     kmeans = KMeans(n_clusters=max_points, tol=2, random_state=random_state)
     kmeans.fit(ijv[:, :2])
     return ( # TODO: why uint32 below?
-        kmeans.cluster_centers_[:, 0].astype(np.uint32).astype(np.int64),
-        kmeans.cluster_centers_[:, 1].astype(np.uint32).astype(np.int64),
+        kmeans.cluster_centers_[:, 0].astype(numpy.uint32).astype(numpy.int64),
+        kmeans.cluster_centers_[:, 1].astype(numpy.uint32).astype(numpy.int64),
     )
 
 
@@ -417,8 +417,8 @@ def get_weights(
     #
     # Create a mapping of chosen points to their index in the i,j array
     #
-    total_skel = np.zeros(labels_mask.shape, int)
-    total_skel[i, j] = np.arange(1, len(i) + 1)
+    total_skel = numpy.zeros(labels_mask.shape, int)
+    total_skel[i, j] = numpy.arange(1, len(i) + 1)
     #
     # Compute the distance from each chosen point to all others in image,
     # return the nearest point.
@@ -431,13 +431,13 @@ def get_weights(
     #
     ii, jj = [x[labels_mask] for x in (ii, jj)]
     if len(ii) == 0:
-        return np.zeros(0, np.int32)
+        return numpy.zeros(0, numpy.int32)
     #
     # Use total_skel to look up the indices of the chosen points and
     # bincount the indices.
     #
-    result = np.zeros(len(i), np.int32)
-    bc = np.bincount(total_skel[ii, jj])[1:]
+    result = numpy.zeros(len(i), numpy.int32)
+    bc = numpy.bincount(total_skel[ii, jj])[1:]
     result[: len(bc)] = bc
     return result
 
@@ -663,44 +663,44 @@ def measure_object_size_shape(
 
 def get_sum_per_object(
     im_pixels:  NDArray[Pixel], 
-    mask:       NDArray[np.bool_], 
+    mask:       NDArray[numpy.bool_], 
     labels:     NDArray[ObjectLabel], 
-    lrange:     NDArray[np.int32]
-    ) -> NDArray[np.float64]:
+    lrange:     NDArray[numpy.int32]
+    ) -> NDArray[numpy.float64]:
     """Computes the sum of the pixel internsities for each object in the lrange, uses object numbers from labels to group objects
 
     Args:
         im_pixels (NDArray[Pixel]): Input image pixels
-        mask (NDArray[np.bool_]): Mask of where the summation should be performed
-        labels (NDArray[np.int32]): Object labels for pixels in `im_pixels`
-        lrange (NDArray[np.int32]): Range over which the summation should be performed
+        mask (NDArray[numpy.bool_]): Mask of where the summation should be performed
+        labels (NDArray[numpy.int32]): Object labels for pixels in `im_pixels`
+        lrange (NDArray[numpy.int32]): Range over which the summation should be performed
 
     Returns:
-        NDArray[np.float64]: Pixel intensity totals for each object in `lrange`
+        NDArray[numpy.float64]: Pixel intensity totals for each object in `lrange`
     """
-    S = np.array(
+    S = numpy.array(
         scipy.ndimage.sum(
             im_pixels, labels[mask], lrange
         )
-    ).astype(np.float64)
+    ).astype(numpy.float64)
     return S
 
 def get_threshold_values_for_objects(
     image_threshold_percentage: float, 
     pixels: NDArray[Pixel], 
     labels: NDArray[ObjectLabel],
-    lrange: Optional[NDArray[np.int32]] = None
-    ) -> NDArray[np.float64]:
+    lrange: Optional[NDArray[numpy.int32]] = None
+    ) -> NDArray[numpy.float64]:
     """Finds threshold values as a percentage of the maximum intensity for each object
 
     Args:
         image_threshold_percentage (float): Percentage value to use when finding threshold values
         pixels (NDArray[Pixel]): Array of pixel intensities
         labels (NDArray[ObjectLabel]): Segmentation labels for each pixel
-        lrange (Optional[NDArray[np.int32]], optional): Range of labels over which to find the maximum. Defaults to None.
+        lrange (Optional[NDArray[numpy.int32]], optional): Range of labels over which to find the maximum. Defaults to None.
 
     Returns:
-        NDArray[np.float64]: Returns an array of threshold values for each object. Same length as `lrange`.
+        NDArray[numpy.float64]: Returns an array of threshold values for each object. Same length as `lrange`.
     """
     lrange = lrange if lrange is not None else numpy.arange(labels.max(), dtype=numpy.int32) + 1
     object_threshold_values = (image_threshold_percentage / 100) * fix(
@@ -710,44 +710,44 @@ def get_threshold_values_for_objects(
 
 def get_thresholded_sum(
         pixels: NDArray[Pixel],
-        object_threshold_values: NDArray[np.float64],
+        object_threshold_values: NDArray[numpy.float64],
         labels: NDArray[ObjectLabel],
-        lrange: Optional[NDArray[np.int32]] = None
-        ) -> NDArray[np.float64]:
+        lrange: Optional[NDArray[numpy.int32]] = None
+        ) -> NDArray[numpy.float64]:
     """Gets the sum of the pixels that are above the threshold value for each object grouped by label
 
     Args:
         pixels (NDArray[Pixel]): Array of pixel intensities
-        object_threshold_values (NDArray[np.float64]): Array of threshold values for each object
+        object_threshold_values (NDArray[numpy.float64]): Array of threshold values for each object
         labels (NDArray[ObjectLabel]): Segmentation labels for each pixel
-        lrange (Optional[NDArray[np.int32]], optional): Range of labels over which to find the sum. Defaults to None.
+        lrange (Optional[NDArray[numpy.int32]], optional): Range of labels over which to find the sum. Defaults to None.
 
     Returns:
-        NDArray[np.float64]: Returns an array of sums of the pixel intensities that are above the threshold value for each object. Same length as `lrange`.
+        NDArray[numpy.float64]: Returns an array of sums of the pixel intensities that are above the threshold value for each object. Same length as `lrange`.
     """
     lrange = lrange if lrange is not None else numpy.arange(labels.max(), dtype=numpy.int32) + 1
     return scipy.ndimage.sum(
         pixels[pixels >= object_threshold_values[labels - 1]],
         labels[pixels >= object_threshold_values[labels - 1]],
         lrange,
-    ).astype(np.float64)
+    ).astype(numpy.float64)
 
 def get_threshold_sum_and_mask(
         image_threshold_percentage: float,
         pixels: NDArray[Pixel],
         labels: NDArray[ObjectLabel],
-        lrange: Optional[NDArray[np.int32]] = None
-        ) -> Tuple[NDArray[np.float64], NDArray[np.bool_]]:
+        lrange: Optional[NDArray[numpy.int32]] = None
+        ) -> Tuple[NDArray[numpy.float64], NDArray[numpy.bool_]]:
     """Gets the sum of the thresholds and a mask of the pixels that are above the threshold value for each object
 
     Args:
         image_threshold_percentage (float): Percentage value to use when finding threshold values
         pixels (NDArray[Pixel]): Array of pixel intensities
         labels (NDArray[ObjectLabel]): Segmentation labels for each pixel
-        lrange (Optional[NDArray[np.int32]], optional): Range of labels over which to threshold. Defaults to None.
+        lrange (Optional[NDArray[numpy.int32]], optional): Range of labels over which to threshold. Defaults to None.
 
     Returns:
-        Tuple[NDArray[np.float64], NDArray[np.bool_]]: Returns a tuple of the sum of the thresholds and a mask of the pixels that are above the threshold value for each object. 
+        Tuple[NDArray[numpy.float64], NDArray[numpy.bool_]]: Returns a tuple of the sum of the thresholds and a mask of the pixels that are above the threshold value for each object. 
     """
     lrange = lrange if lrange is not None else numpy.arange(labels.max(), dtype=numpy.int32) + 1
     object_threshold_values = get_threshold_values_for_objects(image_threshold_percentage, pixels, labels, lrange) # tff / tss
@@ -762,9 +762,9 @@ def get_thresholded_images_and_counts(
     im2_thr_percent: float,
     labels: Optional[NDArray[ObjectLabel]] = None
 ) -> Tuple[
-    NDArray[np.float64], 
-    NDArray[np.float64], 
-    NDArray[np.bool_]
+    NDArray[numpy.float64], 
+    NDArray[numpy.float64], 
+    NDArray[numpy.bool_]
     ]:
     """Finds the threshold sums and the intersection of the masks after thresholding each image
 
@@ -776,7 +776,7 @@ def get_thresholded_images_and_counts(
         labels (Optional[NDArray[ObjectLabel]], optional): Segmentation labels for each pixel. Defaults to None.
 
     Returns:
-        Tuple[ NDArray[np.float64], NDArray[np.float64], NDArray[np.bool_] ]: Returns a tuple of the sum of the thresholds for each image and the intersection of the masks after thresholding each image.
+        Tuple[ NDArray[numpy.float64], NDArray[numpy.float64], NDArray[numpy.bool_] ]: Returns a tuple of the sum of the thresholds for each image and the intersection of the masks after thresholding each image.
     """
 
     if labels is None:
@@ -800,19 +800,19 @@ def get_thresholded_images_and_counts(
 def measure_correlation_and_slope(
         im1_pixels: NDArray[Pixel], 
         im2_pixels: NDArray[Pixel],
-    ) -> Tuple[np.float64, np.float64]:
+    ) -> Tuple[numpy.float64, numpy.float64]:
     #
     # Perform the correlation, which returns:
     # [ [ii, ij],
     #   [ji, jj] ]
     #
-    corr = np.corrcoef((im1_pixels, im2_pixels))[1, 0]
+    corr = numpy.corrcoef((im1_pixels, im2_pixels))[1, 0]
     #
     # Find the slope as a linear regression to
     # A * i1 + B = i2
     #
     least_squares_solution = lstsq(
-        np.array((im1_pixels, np.ones_like(im1_pixels))).transpose(), 
+        numpy.array((im1_pixels, numpy.ones_like(im1_pixels))).transpose(), 
         im2_pixels)
     assert least_squares_solution is not None
     coeffs = least_squares_solution[0]
@@ -825,8 +825,8 @@ def measure_correlation_and_slope_from_objects(
     im1_pixels: NDArray[Pixel],
     im2_pixels: NDArray[Pixel],
     labels: NDArray[ObjectLabel],
-    lrange: NDArray[np.int32]
-) -> NDArray[np.float64]:
+    lrange: NDArray[numpy.int32]
+) -> NDArray[numpy.float64]:
     #
     # The correlation is sum((x-mean(x))(y-mean(y)) /
     #                         ((n-1) * std(x) *std(y)))
@@ -867,10 +867,10 @@ def measure_correlation_and_slope_from_objects(
 #
 def get_manders_coefficient(
         im_thr_common_pixels: NDArray[Pixel],
-        thr_mask_intersection: NDArray[np.bool_],
-        im_thr_sum: NDArray[np.float64],
+        thr_mask_intersection: NDArray[numpy.bool_],
+        im_thr_sum: NDArray[numpy.float64],
         labels: NDArray[ObjectLabel],
-        lrange: NDArray[np.int32]
+        lrange: NDArray[numpy.int32]
         ):
     M = get_sum_per_object(im_thr_common_pixels, thr_mask_intersection, labels, lrange)
     M = M / im_thr_sum
@@ -879,10 +879,10 @@ def get_manders_coefficient(
 def measure_manders_coefficient(
     im1_pixels: NDArray[Pixel],
     im2_pixels: NDArray[Pixel],
-    im1_thr_sum: np.float64,
-    im2_thr_sum: np.float64,
-    thr_mask_intersection: NDArray[np.bool_],
-    ) -> Tuple[np.float64, np.float64]:
+    im1_thr_sum: numpy.float64,
+    im2_thr_sum: numpy.float64,
+    thr_mask_intersection: NDArray[numpy.bool_],
+    ) -> Tuple[numpy.float64, numpy.float64]:
 
     im1_thr_common_pixels = im1_pixels[thr_mask_intersection] # fi_thresh
     im2_thr_common_pixels = im2_pixels[thr_mask_intersection] # si_thresh
@@ -897,12 +897,12 @@ def measure_manders_coefficient(
 def measure_manders_coefficient_from_objects(
     im1_pixels: NDArray[Pixel],
     im2_pixels: NDArray[Pixel],
-    im1_thr_sum: NDArray[np.float64],
-    im2_thr_sum: NDArray[np.float64],
-    thr_mask_intersection: NDArray[np.bool_],
+    im1_thr_sum: NDArray[numpy.float64],
+    im2_thr_sum: NDArray[numpy.float64],
+    thr_mask_intersection: NDArray[numpy.bool_],
     labels: NDArray[ObjectLabel],
-    lrange: NDArray[np.int32],
-    ) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
+    lrange: NDArray[numpy.int32],
+    ) -> Tuple[NDArray[numpy.float64], NDArray[numpy.float64]]:
 
     # TODO: Many methods use this. Should it be cached?
     im1_thr_common_pixels = im1_pixels[thr_mask_intersection]
@@ -923,23 +923,23 @@ def measure_manders_coefficient_from_objects(
 def get_image_rank(
         im_pixels: NDArray[Pixel], 
         labels: Optional[NDArray[ObjectLabel]]=None
-    ) -> NDArray[np.int32]:
+    ) -> NDArray[numpy.int32]:
 
     if labels is None:
-        Rank = np.lexsort([im_pixels])
+        Rank = numpy.lexsort([im_pixels])
     else:
-        [Rank] = np.lexsort(([labels], [im_pixels]))
+        [Rank] = numpy.lexsort(([labels], [im_pixels]))
 
-    Rank_U = np.hstack([[False], im_pixels[Rank[:-1]] != im_pixels[Rank[1:]]])
-    Rank_S = np.cumsum(Rank_U)
-    Rank_im = np.zeros(im_pixels.shape, dtype=int)
+    Rank_U = numpy.hstack([[False], im_pixels[Rank[:-1]] != im_pixels[Rank[1:]]])
+    Rank_S = numpy.cumsum(Rank_U)
+    Rank_im = numpy.zeros(im_pixels.shape, dtype=int)
     Rank_im[Rank] = Rank_S
     return Rank_im
 
 def calculate_rank_weight(
-        Rank_im1: NDArray[np.int32], 
-        Rank_im2: NDArray[np.int32]
-    ) -> NDArray[np.float64]:
+        Rank_im1: NDArray[numpy.int32], 
+        Rank_im2: NDArray[numpy.int32]
+    ) -> NDArray[numpy.float64]:
 
     R = max(Rank_im1.max(), Rank_im2.max()) + 1
     Di = abs(Rank_im1 - Rank_im2)
@@ -948,24 +948,24 @@ def calculate_rank_weight(
     
 def get_rwc_coefficient(
         im1_thr_common_pixels: NDArray[Pixel],
-        weight_thresh: NDArray[np.float64],
-        thr_mask_intersection: NDArray[np.bool_],
-        im1_thr_sum: NDArray[np.float64],
+        weight_thresh: NDArray[numpy.float64],
+        thr_mask_intersection: NDArray[numpy.bool_],
+        im1_thr_sum: NDArray[numpy.float64],
         labels: NDArray[ObjectLabel],
-        lrange: NDArray[np.int32]
+        lrange: NDArray[numpy.int32]
         ):
     weighted_pixels = im1_thr_common_pixels * weight_thresh
     RWC = get_sum_per_object(weighted_pixels, thr_mask_intersection, labels, lrange)
-    RWC = RWC / np.array(im1_thr_sum)
+    RWC = RWC / numpy.array(im1_thr_sum)
     return RWC
 
 def measure_rwc_coefficient(
         im1_pixels: NDArray[Pixel], 
         im2_pixels: NDArray[Pixel],
-        im1_thr_sum: np.float64,
-        im2_thr_sum: np.float64,
-        thr_mask_intersection: NDArray[np.bool_]
-    ) -> Tuple[np.float64, np.float64]:
+        im1_thr_sum: numpy.float64,
+        im2_thr_sum: numpy.float64,
+        thr_mask_intersection: NDArray[numpy.bool_]
+    ) -> Tuple[numpy.float64, numpy.float64]:
 
     im1_thr_common_pixels = im1_pixels[thr_mask_intersection]
     im2_thr_common_pixels = im2_pixels[thr_mask_intersection]
@@ -984,15 +984,15 @@ def measure_rwc_coefficient(
 def measure_rwc_coefficient_from_objects(
     im1_pixels: NDArray[Pixel],
     im2_pixels: NDArray[Pixel],
-    im1_thr_sum: NDArray[np.float64],
-    im2_thr_sum: NDArray[np.float64],
-    thr_mask_intersection: NDArray[np.bool_],
+    im1_thr_sum: NDArray[numpy.float64],
+    im2_thr_sum: NDArray[numpy.float64],
+    thr_mask_intersection: NDArray[numpy.bool_],
     labels: NDArray[ObjectLabel],
-    lrange: NDArray[np.int32],
-) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
+    lrange: NDArray[numpy.int32],
+) -> Tuple[NDArray[numpy.float64], NDArray[numpy.float64]]:
     # RWC Coefficient
-    RWC1 = np.zeros(len(lrange))
-    RWC2 = np.zeros(len(lrange))
+    RWC1 = numpy.zeros(len(lrange))
+    RWC2 = numpy.zeros(len(lrange))
 
     im1_thr_common_pixels = im1_pixels[thr_mask_intersection]
     im2_thr_common_pixels = im2_pixels[thr_mask_intersection]
@@ -1002,7 +1002,7 @@ def measure_rwc_coefficient_from_objects(
     weight = calculate_rank_weight(Rank_im1, Rank_im2)
     weight_thresh = weight[thr_mask_intersection]
 
-    if thr_mask_intersection is not None and np.any(thr_mask_intersection):
+    if thr_mask_intersection is not None and numpy.any(thr_mask_intersection):
         RWC1 = get_rwc_coefficient(im1_thr_common_pixels, weight_thresh, thr_mask_intersection, im1_thr_sum, labels, lrange)
         RWC2 = get_rwc_coefficient(im2_thr_common_pixels, weight_thresh, thr_mask_intersection, im2_thr_sum, labels, lrange)
     
@@ -1014,14 +1014,14 @@ def measure_rwc_coefficient_from_objects(
 def measure_overlap_coefficient(
     im1_pixels: NDArray[Pixel],
     im2_pixels: NDArray[Pixel],
-    thr_mask_intersection: NDArray[np.bool_],
-    ) -> Tuple[np.float64, np.float64, np.float64]:
+    thr_mask_intersection: NDArray[numpy.bool_],
+    ) -> Tuple[numpy.float64, numpy.float64, numpy.float64]:
 
     im1_thr_common_pixels = im1_pixels[thr_mask_intersection]
     im2_thr_common_pixels = im2_pixels[thr_mask_intersection]
     # Overlap Coefficient
     overlap = 0
-    overlap = (im1_thr_common_pixels * im2_thr_common_pixels).sum() / np.sqrt(
+    overlap = (im1_thr_common_pixels * im2_thr_common_pixels).sum() / numpy.sqrt(
         (im1_thr_common_pixels ** 2).sum() * (im2_thr_common_pixels ** 2).sum()
     )
     K1 = (im1_thr_common_pixels * im2_thr_common_pixels).sum() / (im1_thr_common_pixels ** 2).sum()
@@ -1032,10 +1032,10 @@ def measure_overlap_coefficient(
 def measure_overlap_coefficient_from_objects(
     im1_pixels: NDArray[Pixel],
     im2_pixels: NDArray[Pixel],
-    thr_mask_intersection: Optional[NDArray[np.bool_]],
+    thr_mask_intersection: Optional[NDArray[numpy.bool_]],
     labels: NDArray[ObjectLabel],
-    lrange: NDArray[np.int32]
-) -> Tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]]:
+    lrange: NDArray[numpy.int32]
+) -> Tuple[NDArray[numpy.float64], NDArray[numpy.float64], NDArray[numpy.float64]]:
     # Overlap Coefficient
     if thr_mask_intersection is not None and numpy.any(thr_mask_intersection):
         im1_pixels_sq = im1_pixels[thr_mask_intersection] ** 2
@@ -1066,19 +1066,19 @@ def get_costes_thresholded_pixels_and_mask(
         im2_pixels: NDArray[Pixel],
         im1_costes_pixels: NDArray[Pixel],
         im2_costes_pixels: NDArray[Pixel],
-        im1_scale: Optional[np.float64],
-        im2_scale: Optional[np.float64],
+        im1_scale: Optional[numpy.float64],
+        im2_scale: Optional[numpy.float64],
         costes_method: CostesMethod
         ) -> Tuple[
-            NDArray[np.bool_], 
-            NDArray[np.bool_], 
-            NDArray[np.bool_],
+            NDArray[numpy.bool_], 
+            NDArray[numpy.bool_], 
+            NDArray[numpy.bool_],
             NDArray[Pixel],
             NDArray[Pixel]
             ]:
     # Orthogonal Regression for Costes' automated threshold
     scale = get_scale_for_costes_threshold(im1_scale, im2_scale)
-    costes_function: Dict[CostesMethod, Callable[[NDArray[Pixel], NDArray[Pixel], np.float64], Tuple[np.float64, np.float64]]] = {
+    costes_function: Dict[CostesMethod, Callable[[NDArray[Pixel], NDArray[Pixel], numpy.float64], Tuple[numpy.float64, numpy.float64]]] = {
         CostesMethod.FASTER: bisection_costes,
         CostesMethod.ACCURATE: linear_costes,
         CostesMethod.FAST: linear_costes,
@@ -1093,17 +1093,17 @@ def get_costes_thresholded_pixels_and_mask(
     return im1_costes_thr_mask, im2_costes_thr_mask, combined_thresh_c, im1_costes_thr_common_pixels, im2_costes_thr_common_pixels
 
 def get_costes_threshold_pixel_sum(
-        im_costes_thr_mask: NDArray[np.bool_],
+        im_costes_thr_mask: NDArray[numpy.bool_],
         im_pixels: NDArray[Pixel],
         labels: NDArray[ObjectLabel],
-        lrange: NDArray[np.int32]
-        ) -> NDArray[np.float64]:
+        lrange: NDArray[numpy.int32]
+        ) -> NDArray[numpy.float64]:
     if numpy.any(im_costes_thr_mask):
         im_costes_thr_sum = scipy.ndimage.sum(
             im_pixels[im_costes_thr_mask],
             labels[im_costes_thr_mask],
             lrange,
-        ).astype(np.float64)
+        ).astype(numpy.float64)
     else:
         im_costes_thr_sum = numpy.zeros(len(lrange))
 
@@ -1111,13 +1111,13 @@ def get_costes_threshold_pixel_sum(
 
 def get_costes_coefficient(
         im_costes_thr_common_pixels: NDArray[Pixel],
-        combined_thresh_c: NDArray[np.bool_],
-        im_costes_thr_sum: NDArray[np.float64],
+        combined_thresh_c: NDArray[numpy.bool_],
+        im_costes_thr_sum: NDArray[numpy.float64],
         labels: NDArray[ObjectLabel],
-        lrange: NDArray[np.int32]
+        lrange: NDArray[numpy.int32]
         ):
     C = get_sum_per_object(im_costes_thr_common_pixels, combined_thresh_c, labels, lrange) 
-    C = C / np.array(im_costes_thr_sum)
+    C = C / numpy.array(im_costes_thr_sum)
     return C
 
 def measure_costes_coefficient(
@@ -1126,7 +1126,7 @@ def measure_costes_coefficient(
         im1_scale: Optional[float] = None,
         im2_scale: Optional[float] = None,
         costes_method: CostesMethod = CostesMethod.FAST,
-    ) -> Tuple[ np.float64, np.float64]:
+    ) -> Tuple[ numpy.float64, numpy.float64]:
     #
     # Find the Costes threshold for each image
     #
@@ -1163,11 +1163,11 @@ def measure_costes_coefficient_from_objects(
     im1_costes_pixels: NDArray[Pixel],
     im2_costes_pixels: NDArray[Pixel],
     labels: NDArray[ObjectLabel],
-    lrange: NDArray[np.int32],
+    lrange: NDArray[numpy.int32],
     im1_scale: numpy.float64,
     im2_scale: numpy.float64,
     costes_method: CostesMethod = CostesMethod.FAST,
-) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
+) -> Tuple[NDArray[numpy.float64], NDArray[numpy.float64]]:
     (
         im1_costes_thr_mask, 
         im2_costes_thr_mask, 
@@ -1196,7 +1196,7 @@ def measure_costes_coefficient_from_objects(
 
     return C1, C2
 
-def get_scale_for_costes_threshold(scale_1: Optional[np.float64], scale_2: Optional[np.float64]) -> np.float64:
+def get_scale_for_costes_threshold(scale_1: Optional[numpy.float64], scale_2: Optional[numpy.float64]) -> numpy.float64:
     if scale_1 is not None and scale_2 is not None:
         return max(scale_1, scale_2)
     elif scale_1 is not None:
@@ -1204,13 +1204,13 @@ def get_scale_for_costes_threshold(scale_1: Optional[np.float64], scale_2: Optio
     elif scale_2 is not None:
         return scale_2
     else:
-        return np.float64(255)
+        return numpy.float64(255)
 
 def bisection_costes(
         im1_costes_pixels: NDArray[Pixel], 
         im2_costes_pixels: NDArray[Pixel], 
-        scale_max:np.float64=np.float64(255)
-        ) -> Tuple[np.float64, np.float64]:
+        scale_max:numpy.float64=numpy.float64(255)
+        ) -> Tuple[numpy.float64, numpy.float64]:
     """
     Finds the Costes Automatic Threshold for colocalization using a bisection algorithm.
     Candidate thresholds are selected from within a window of possible intensities,
@@ -1221,19 +1221,19 @@ def bisection_costes(
     """
 
     non_zero = (im1_costes_pixels > 0) | (im2_costes_pixels > 0)
-    xvar = np.var(im1_costes_pixels[non_zero], axis=0, ddof=1)
-    yvar = np.var(im2_costes_pixels[non_zero], axis=0, ddof=1)
+    xvar = numpy.var(im1_costes_pixels[non_zero], axis=0, ddof=1)
+    yvar = numpy.var(im2_costes_pixels[non_zero], axis=0, ddof=1)
 
-    xmean = np.mean(im1_costes_pixels[non_zero], axis=0)
-    ymean = np.mean(im2_costes_pixels[non_zero], axis=0)
+    xmean = numpy.mean(im1_costes_pixels[non_zero], axis=0)
+    ymean = numpy.mean(im2_costes_pixels[non_zero], axis=0)
 
     z = im1_costes_pixels[non_zero] + im2_costes_pixels[non_zero]
-    zvar = np.var(z, axis=0, ddof=1)
+    zvar = numpy.var(z, axis=0, ddof=1)
 
     covar = 0.5 * (zvar - (xvar + yvar))
 
     denom = 2 * covar
-    num = (yvar - xvar) + np.sqrt(
+    num = (yvar - xvar) + numpy.sqrt(
         (yvar - xvar) * (yvar - xvar) + 4 * (covar * covar)
     )
     a = num / denom
@@ -1250,8 +1250,8 @@ def bisection_costes(
     while lastmid != mid:
         thr_fi_c = mid / scale_max
         thr_si_c = (a * thr_fi_c) + b
-        combt: NDArray[np.bool_] = (im1_costes_pixels < thr_fi_c) | (im2_costes_pixels < thr_si_c)
-        if np.count_nonzero(combt) <= 2:
+        combt: NDArray[numpy.bool_] = (im1_costes_pixels < thr_fi_c) | (im2_costes_pixels < thr_si_c)
+        if numpy.count_nonzero(combt) <= 2:
             # Can't run pearson with only 2 values.
             left = mid - 1
         else:
@@ -1279,9 +1279,9 @@ def bisection_costes(
 def linear_costes(
         im1_costes_pixels: NDArray[Pixel], 
         im2_costes_pixels: NDArray[Pixel], 
-        scale_max:np.float64=np.float64(255), 
+        scale_max:numpy.float64=numpy.float64(255), 
         costes_method: CostesMethod = CostesMethod.FAST
-        ) -> Tuple[np.float64, np.float64]:
+        ) -> Tuple[numpy.float64, numpy.float64]:
     """
     Finds the Costes Automatic Threshold for colocalization using a linear algorithm.
     Candiate thresholds are gradually decreased until Pearson R falls below 0.
@@ -1290,19 +1290,19 @@ def linear_costes(
     """
     i_step = 1 / scale_max
     non_zero = (im1_costes_pixels > 0) | (im2_costes_pixels > 0)
-    xvar = np.var(im1_costes_pixels[non_zero], axis=0, ddof=1)
-    yvar = np.var(im2_costes_pixels[non_zero], axis=0, ddof=1)
+    xvar = numpy.var(im1_costes_pixels[non_zero], axis=0, ddof=1)
+    yvar = numpy.var(im2_costes_pixels[non_zero], axis=0, ddof=1)
 
-    xmean = np.mean(im1_costes_pixels[non_zero], axis=0)
-    ymean = np.mean(im2_costes_pixels[non_zero], axis=0)
+    xmean = numpy.mean(im1_costes_pixels[non_zero], axis=0)
+    ymean = numpy.mean(im2_costes_pixels[non_zero], axis=0)
 
     z = im1_costes_pixels[non_zero] + im2_costes_pixels[non_zero]
-    zvar = np.var(z, axis=0, ddof=1)
+    zvar = numpy.var(z, axis=0, ddof=1)
 
     covar = 0.5 * (zvar - (xvar + yvar))
 
     denom = 2 * covar
-    num = (yvar - xvar) + np.sqrt(
+    num = (yvar - xvar) + numpy.sqrt(
         (yvar - xvar) * (yvar - xvar) + 4 * (covar * covar)
     )
     a = num / denom
@@ -1328,7 +1328,7 @@ def linear_costes(
         combt = (im1_costes_pixels < thr_fi_c) | (im2_costes_pixels < thr_si_c)
         try:
             # Only run pearsonr if the input has changed.
-            if (positives := np.count_nonzero(combt)) != num_true:
+            if (positives := numpy.count_nonzero(combt)) != num_true:
                 costReg, _ = scipy.stats.pearsonr(im1_costes_pixels[combt], im2_costes_pixels[combt])
                 num_true = positives
 
@@ -1366,18 +1366,18 @@ class ObjectRecord(object):
             ):
         self.name = name
         self.labels = segmented
-        self.nobjects = np.max(self.labels)
+        self.nobjects = numpy.max(self.labels)
         if self.nobjects != 0:
             assert im_mask is not None
             assert im_pixel_data is not None
-            self.range = np.arange(1, np.max(self.labels) + 1)
+            self.range = numpy.arange(1, numpy.max(self.labels) + 1)
             self.labels = self.labels.copy()
             self.labels[~im_mask] = 0
             self.current_mean = fix(
                 scipy.ndimage.mean(im_pixel_data, self.labels, self.range)
             )
-            self.start_mean = np.maximum(
-                self.current_mean, np.finfo(float).eps
+            self.start_mean = numpy.maximum(
+                self.current_mean, numpy.finfo(float).eps
             )
 
 
@@ -1403,14 +1403,14 @@ def get_granularity_measurements(
     #
     footprint = get_morphology_footprint(1, dimensions)
     ng = granular_spectrum_length
-    startmean = np.mean(pixels[mask])
+    startmean = numpy.mean(pixels[mask])
     ero = pixels.copy()
     # Mask the test image so that masked pixels will have no effect
     # during reconstruction
     #
     ero[~mask] = 0
     currentmean = startmean
-    startmean = max(startmean, np.finfo(float).eps)
+    startmean = max(startmean, numpy.finfo(float).eps)
     measurements_arr = []
     image_measurements_arr = []
 
@@ -1418,7 +1418,7 @@ def get_granularity_measurements(
         prevmean = currentmean
         ero = masked_erode(ero, mask, footprint)
         rec = skimage.morphology.reconstruction(ero, pixels, footprint=footprint)
-        currentmean = np.mean(rec[mask])
+        currentmean = numpy.mean(rec[mask])
         gs = (prevmean - currentmean) * 100 / startmean
         image_measurements_arr += [gs]
         # measurements.add_image_measurement(feature, gs)
@@ -1448,7 +1448,7 @@ def get_granularity_measurements(
                 )
                 object_record.current_mean = new_mean
             else:
-                gss = np.zeros((0,))
+                gss = numpy.zeros((0,))
             obj_measurements += [[object_record.name, gss]]
         measurements_arr += [obj_measurements]
     return measurements_arr, image_measurements_arr
@@ -1461,8 +1461,8 @@ def get_granularity_measurements(
 def measure_surface_area(
         label_image: Union[ImageBinary, ObjectLabelsDense], 
         spacing: Optional[Tuple[float, ...]]=None, 
-        index: Optional[NDArray[np.int32]]=None,
-        ) -> NDArray[np.float64]:
+        index: Optional[NDArray[numpy.int32]]=None,
+        ) -> NDArray[numpy.float64]:
     if spacing is None:
         spacing = (1.0,) * label_image.ndim
 
@@ -1473,26 +1473,26 @@ def measure_surface_area(
 
         return skimage.measure.mesh_surface_area(verts, faces)
 
-    return np.sum(
+    return numpy.sum(
         [
-            np.round(measure_label_surface_area(label_image, label, spacing))
+            numpy.round(measure_label_surface_area(label_image, label, spacing))
             for label in index
         ]
     )
 
 
-def measure_perimeter(im_pixel_data: ImageBinary, im_volumetric: bool, im_spacing: Optional[Tuple[float, ...]] = None) -> np.float_:
+def measure_perimeter(im_pixel_data: ImageBinary, im_volumetric: bool, im_spacing: Optional[Tuple[float, ...]] = None) -> numpy.float_:
     if im_volumetric:
         perimeter = measure_surface_area(im_pixel_data > 0, spacing=im_spacing)
     else:
         perimeter = skimage.measure.perimeter(im_pixel_data > 0)
     return perimeter
 
-def measure_area_occupied(im_pixel_data: ImageBinary) -> np.float_:
-    return np.sum(im_pixel_data > 0)
+def measure_area_occupied(im_pixel_data: ImageBinary) -> numpy.float_:
+    return numpy.sum(im_pixel_data > 0)
 
-def measure_total_area(im_pixel_data: ImageBinary) -> np.int_:
-    return np.prod(np.shape(im_pixel_data))
+def measure_total_area(im_pixel_data: ImageBinary) -> numpy.int_:
+    return numpy.prod(numpy.shape(im_pixel_data))
 
 
 def measure_object_perimeter(
@@ -1501,22 +1501,22 @@ def measure_object_perimeter(
         regionprops: Optional[List[Any]] = None,
         volumetric: bool = False,
         spacing: Optional[Tuple[float, ...]] = None
-        ) -> np.float_:
+        ) -> numpy.float_:
     """ Uses skimage.measure.regionprops to calculate the perimeter for 2D. Uses skimage.measure.mesh_surface_area to calculate the perimeter for 3D"""
     if regionprops is None:
         if mask is not None:
             label_image[~mask] = 0
         regionprops = skimage.measure.regionprops(label_image)
     if volumetric:
-        labels = np.unique(label_image)
+        labels = numpy.unique(label_image)
         if labels[0] == 0:
             labels = labels[1:]
         
     if volumetric:
         perimeter = measure_surface_area(label_image, spacing=spacing, index=labels)
     else:
-        perimeter = np.sum(
-            [np.round(region["perimeter"]) for region in regionprops]
+        perimeter = numpy.sum(
+            [numpy.round(region["perimeter"]) for region in regionprops]
         )
     return perimeter
 
@@ -1524,7 +1524,7 @@ def measure_objects_area_occupied(
     label_image: Optional[ObjectLabelsDense],
     mask: Optional[ImageAny] = None,
     regionprops: Optional[List[Any]] = None,
-    ) -> np.float_:
+    ) -> numpy.float_:
     """ Area occupied can either be calculated from the label image (with/without mask) or if regionprops are already computed, they can be passed in"""
     if regionprops is None:
         assert label_image is not None, "Either label_image or region_properties must be provided"
@@ -1532,17 +1532,17 @@ def measure_objects_area_occupied(
             label_image[~mask] = 0
         regionprops = skimage.measure.regionprops(label_image)
 
-    return np.sum([region["area"] for region in regionprops])
+    return numpy.sum([region["area"] for region in regionprops])
 
 def measure_objects_total_area(
     label_image: Optional[ObjectLabelsDense],
     mask: Optional[ImageAny] = None,
-    ) -> np.int_:
+    ) -> numpy.int_:
     """ Total area can either be calculated from the label image or from the mask"""
     if mask is not None:
-        total_area = np.sum(mask)
+        total_area = numpy.sum(mask)
     else:
-        total_area = np.product(label_image.shape)
+        total_area = numpy.product(label_image.shape)
     return total_area
 
 
@@ -1564,7 +1564,7 @@ def measure_label_surface_area(
 ###############################################################################
 
 def measure_image_intensities(
-        pixels: NDArray[np.float32], 
+        pixels: NDArray[numpy.float32], 
         percentiles: List[int]=[]
     ) -> Tuple[List[float], Dict[int, float]]:
     pixel_count = numpy.product(pixels.shape)
@@ -2132,7 +2132,7 @@ def compute_earth_movers_distance_objects(
         max_points: int=250,
         max_distance: int=250,
         penalize_missing: bool=False,
-        ) -> np.float_:
+        ) -> numpy.float_:
     src_objects_shape = src_objects_label_set[0][0].shape
     dest_objects_shape = dest_objects_label_set[0][0].shape
 
@@ -2162,9 +2162,9 @@ def compute_earth_movers_distance_objects(
         ):
         if left_count == 0:
             if penalize_missing:
-                return np.sum(right_areas) * max_distance
+                return numpy.sum(right_areas) * max_distance
             else:
-                return np.float64(0)
+                return numpy.float64(0)
     
     if decimation_method in (ObjectDecimationMethod.KMEANS, mio.DM.KMEANS):
         isrc, jsrc = get_kmeans_points(src_obj_ijv, dest_obj_ijv, max_points)
@@ -2186,16 +2186,16 @@ def compute_earth_movers_distance_objects(
     dest_weights = get_weights(idest, jdest, dest_labels_mask)
 
     ioff, joff = [
-        src[:, np.newaxis] - dest[np.newaxis, :]
+        src[:, numpy.newaxis] - dest[numpy.newaxis, :]
         for src, dest in ((isrc, idest), (jsrc, jdest))
     ]
-    c = np.sqrt(ioff * ioff + joff * joff).astype(np.int32)
+    c = numpy.sqrt(ioff * ioff + joff * joff).astype(numpy.int32)
     c[c > max_distance] = max_distance
     extra_mass_penalty = max_distance if penalize_missing else 0
 
     emd = centrosome.fastemd.emd_hat_int32(
-        src_weights.astype(np.int32),
-        dest_weights.astype(np.int32),
+        src_weights.astype(numpy.int32),
+        dest_weights.astype(numpy.int32),
         c,
         extra_mass_penalty=extra_mass_penalty,
     )

--- a/src/subpackages/library/cellprofiler_library/modules/_measureobjectskeleton.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_measureobjectskeleton.py
@@ -1,429 +1,56 @@
 import numpy
-import scipy.ndimage
-import centrosome.cpmorphology
-import centrosome.propagate as propagate
-from centrosome.cpmorphology import fixup_scipy_ndimage_result as fix
-from scipy.ndimage import grey_dilation, grey_erosion
-from typing import Tuple, Optional, Any, Dict, Union
-
+from typing import Tuple, Optional, Any, Dict, Union, Annotated
 from numpy.typing import NDArray
-from cellprofiler_library.types import Image2DBinary, ObjectSegmentation, Image2DColor, Image2D, Image2DGrayscale
+from cellprofiler_library.types import Image2DBinary, ObjectSegmentation, Image2DColor, Image2DGrayscale
 from pydantic import Field, validate_call, ConfigDict
-from cellprofiler_library.opts.measureobjectskeleton import VF_I, VF_J, VF_LABELS, VF_KIND, EF_V1, EF_V2, EF_LENGTH, EF_TOTAL_INTENSITY
-
-@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
-def get_ring_with_trunks(
-        skeleton: Image2DBinary, 
-        labels: ObjectSegmentation
-        ) -> Tuple[
-            ObjectSegmentation,
-            Image2DBinary,
-            Image2DBinary
-        ]:
-    #
-    # The following code makes a ring around the seed objects with
-    # the skeleton trunks sticking out of it.
-    #
-    # Create a new skeleton with holes at the seed objects
-    # First combine the seed objects with the skeleton so
-    # that the skeleton trunks come out of the seed objects.
-    #
-    # Erode the labels once so that all of the trunk branchpoints
-    # will be within the labels
-    #
-    #
-    # Dilate the objects, then subtract them to make a ring
-    #
-    my_disk = centrosome.cpmorphology.strel_disk(1.5).astype(int)
-    dilated_labels = grey_dilation(labels, footprint=my_disk)
-    seed_mask = dilated_labels > 0
-    combined_skel = skeleton | seed_mask
-
-    closed_labels = grey_erosion(dilated_labels, footprint=my_disk)
-    seed_center = closed_labels > 0
-    combined_skel = combined_skel & (~seed_center)
-    return dilated_labels, combined_skel, seed_center
+from cellprofiler_library.functions.measurement import calculate_object_skeleton
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def measure_object_skeleton(
-        skeleton: Image2DBinary, 
-        cropped_labels: ObjectSegmentation, 
-        labels_count: numpy.integer[Any],
-        label_range: NDArray[numpy.int32], 
-        fill_small_holes: bool, 
-        max_hole_size: int,
-        wants_objskeleton_graph: bool,
-        intensity_image_pixel_data: Optional[Image2DGrayscale],
-        wants_branchpoint_image: bool
+        skeleton:                   Annotated[Image2DBinary, Field(description="Input image")],
+        cropped_labels:             Annotated[ObjectSegmentation, Field(description="Input labels")],
+        labels_count:               Annotated[numpy.integer[Any], Field(description="Number of labels in the original segmentation prior to cropping")],
+        fill_small_holes:           Annotated[bool, Field(description="Fill small holes?")],
+        max_hole_size:              Annotated[Optional[int], Field(description="Maximum hole size", ge=1)]=None,
+        wants_objskeleton_graph:    Annotated[bool, Field(description="Return the skeleton graph relationships along with the measurements?")]=False,
+        intensity_image_pixel_data: Annotated[Optional[Image2DGrayscale], Field(description="Intensity image used for graph relationships")]=None,
+        wants_branchpoint_image:    Annotated[bool, Field(description="Return the branchpoint image?")]=False,
         ) -> Tuple[
-            NDArray[numpy.float_], # trunk counts
-            NDArray[numpy.float_], # branch counts
-            NDArray[numpy.float_], # end counts
-            NDArray[numpy.float_], # total distance
+            NDArray[numpy.float_],
+            NDArray[numpy.float_],
+            NDArray[numpy.float_],
+            NDArray[numpy.float_],
             Optional[Dict[str, NDArray[Union[numpy.float_, numpy.int_]]]],
             Optional[Dict[str, NDArray[Union[numpy.float_, numpy.int_]]]],
             Optional[Image2DColor],
         ]:
-    #
-    # The following code makes a ring around the seed objects with
-    # the skeleton trunks sticking out of it.
-    #
-    dilated_labels, combined_skel, seed_center = get_ring_with_trunks(skeleton, cropped_labels)
     
-    #
-    # Fill in single holes (but not a one-pixel hole made by
-    # a one-pixel image)
-    #
-    if fill_small_holes:
-        def size_fn(area, is_object):
-            return (~is_object) and (area <= max_hole_size)
-
-        combined_skel = centrosome.cpmorphology.fill_labeled_holes(
-            combined_skel, ~seed_center, size_fn
-        )
-    #
-    # Reskeletonize to make true branchpoints at the ring boundaries
-    #
-    combined_skel = centrosome.cpmorphology.skeletonize(combined_skel)
-    #
-    # The skeleton outside of the labels
-    #
-    outside_skel = combined_skel & (dilated_labels == 0)
-    #
-    # Associate all skeleton points with seed objects
-    #
-    dlabels, distance_map = propagate.propagate(
-        numpy.zeros(cropped_labels.shape), dilated_labels, combined_skel, 1
-    )
-    #
-    # Get rid of any branchpoints not connected to seeds
-    #
-    combined_skel[dlabels == 0] = False
-    #
-    # Find the branchpoints
-    #
-    branch_points = centrosome.cpmorphology.branchpoints(combined_skel)
-
-    #
-    # Odd case: when four branches meet like this, branchpoints are not
-    # assigned because they are arbitrary. So assign them.
-    #
-    # .  .
-    #  B.
-    #  .B
-    # .  .
-    #
-    odd_case = (
-        combined_skel[:-1, :-1]
-        & combined_skel[1:, :-1]
-        & combined_skel[:-1, 1:]
-        & combined_skel[1, 1]
-    )
-    branch_points[:-1, :-1][odd_case] = True
-    branch_points[1:, 1:][odd_case] = True
-    #
-    # Find the branching counts for the trunks (# of extra branches
-    # emanating from a point other than the line it might be on).
-    #
-    branching_counts = centrosome.cpmorphology.branchings(combined_skel)
-    branching_counts = numpy.array([0, 0, 0, 1, 2])[branching_counts]
-    #
-    # Only take branches within 1 of the outside skeleton
-    #
-    dilated_skel = scipy.ndimage.binary_dilation(
-        outside_skel, centrosome.cpmorphology.eight_connect
-    )
-    branching_counts[~dilated_skel] = 0
-    #
-    # Find the endpoints
-    #
-    end_points = centrosome.cpmorphology.endpoints(combined_skel)
-    #
-    # We use two ranges for classification here:
-    # * anything within one pixel of the dilated image is a trunk
-    # * anything outside of that range is a branch
-    #
-    nearby_labels = dlabels.copy()
-    nearby_labels[distance_map > 1.5] = 0
-
-    outside_labels = dlabels.copy()
-    outside_labels[nearby_labels > 0] = 0
-    #
-    # The trunks are the branchpoints that lie within one pixel of
-    # the dilated image.
-    #
-    if labels_count > 0:
-        trunk_counts = fix(
-            scipy.ndimage.sum(branching_counts, nearby_labels, label_range)
-        ).astype(int)
-    else:
-        trunk_counts = numpy.zeros((0,), int)
-    #
-    # The branches are the branchpoints that lie outside the seed objects
-    #
-    if labels_count > 0:
-        branch_counts = fix(
-            scipy.ndimage.sum(branch_points, outside_labels, label_range)
-        )
-    else:
-        branch_counts = numpy.zeros((0,), int)
-    #
-    # Save the endpoints
-    #
-    if labels_count > 0:
-        end_counts = fix(scipy.ndimage.sum(end_points, outside_labels, label_range))
-    else:
-        end_counts = numpy.zeros((0,), int)
-    #
-    # Calculate the distances
-    #
-    total_distance = centrosome.cpmorphology.skeleton_length(
-        dlabels * outside_skel, label_range
-    ).astype(numpy.float64)
-    edge_graph = None
-    vertex_graph = None
     
-    branchpoint_image = None
-    if wants_objskeleton_graph or wants_branchpoint_image:
-        trunk_mask = (branching_counts > 0) & (nearby_labels != 0)
-        
-        if wants_objskeleton_graph:
-            assert intensity_image_pixel_data is not None
-            edge_graph, vertex_graph = make_objskeleton_graph(
-                combined_skel,
-                dlabels,
-                trunk_mask,
-                branch_points & ~trunk_mask,
-                end_points,
-                intensity_image_pixel_data,
-            )
-        if wants_branchpoint_image:
-            branchpoint_image = numpy.zeros((skeleton.shape[0], skeleton.shape[1], 3))
-            branch_mask = branch_points & (outside_labels != 0)
-            end_mask = end_points & (outside_labels != 0)
-            branchpoint_image[outside_skel, :] = 1
-            branchpoint_image[trunk_mask | branch_mask | end_mask, :] = 0
-            branchpoint_image[trunk_mask, 0] = 1
-            branchpoint_image[branch_mask, 1] = 1
-            branchpoint_image[end_mask, 2] = 1
-            branchpoint_image[dilated_labels != 0, :] *= 0.875
-            branchpoint_image[dilated_labels != 0, :] += 0.1
-
-    return (
-        trunk_counts, 
-        branch_counts,
-        end_counts,
-        total_distance,
-        edge_graph, 
-        vertex_graph,
-        branchpoint_image
-    )
-
-
-@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
-def make_objskeleton_graph(
-    skeleton: Image2DBinary, 
-    skeleton_labels: ObjectSegmentation, 
-    trunks: Image2DBinary, 
-    branchpoints: Image2DBinary, 
-    endpoints: Image2DBinary, 
-    image: Image2DGrayscale
-    ) -> Tuple[
-        Dict[str, NDArray[Union[numpy.float_, numpy.int_]]],
-        Dict[str, NDArray[Union[numpy.float_, numpy.int_]]]
-    ]:
-    """Make a table that captures the graph relationship of the skeleton
-
-    skeleton - binary skeleton image + outline of seed objects
-    skeleton_labels - labels matrix of skeleton
-    trunks - binary image with trunk points as 1
-    branchpoints - binary image with branchpoints as 1
-    endpoints - binary image with endpoints as 1
-    image - image for intensity measurement
-
-    returns two tables.
-    Table 1: edge table
-    The edge table is a numpy record array with the following named
-    columns in the following order:
-    v1: index into vertex table of first vertex of edge
-    v2: index into vertex table of second vertex of edge
-    length: # of intermediate pixels + 2 (for two vertices)
-    total_intensity: sum of intensities along the edge
-
-    Table 2: vertex table
-    The vertex table is a numpy record array:
-    i: I coordinate of the vertex
-    j: J coordinate of the vertex
-    label: the vertex's label
-    kind: kind of vertex = "T" for trunk, "B" for branchpoint or "E" for endpoint.
-    """
-    i, j = numpy.mgrid[0 : skeleton.shape[0], 0 : skeleton.shape[1]]
-    #
-    # Give each point of interest a unique number
-    #
-    points_of_interest = trunks | branchpoints | endpoints
-    number_of_points = numpy.sum(points_of_interest)
-    #
-    # Make up the vertex table
-    #
-    tbe = numpy.zeros(points_of_interest.shape, "|S1")
-    tbe[trunks] = "T"
-    tbe[branchpoints] = "B"
-    tbe[endpoints] = "E"
-    i_idx = i[points_of_interest]
-    j_idx = j[points_of_interest]
-    poe_labels = skeleton_labels[points_of_interest]
-    tbe = tbe[points_of_interest]
-    vertex_table = {
-        VF_I: i_idx,
-        VF_J: j_idx,
-        VF_LABELS: poe_labels,
-        VF_KIND: tbe,
-    }
-    #
-    # First, break the skeleton by removing the branchpoints, endpoints
-    # and trunks
-    #
-    broken_skeleton = skeleton & (~points_of_interest)
-    #
-    # Label the broken skeleton: this labels each edge differently
-    #
-    edge_labels, nlabels = centrosome.cpmorphology.label_skeleton(skeleton)
-    #
-    # Reindex after removing the points of interest
-    #
-    edge_labels[points_of_interest] = 0
-    if nlabels > 0:
-        indexer = numpy.arange(nlabels + 1)
-        unique_labels = numpy.sort(numpy.unique(edge_labels))
-        nlabels = len(unique_labels) - 1
-        indexer[unique_labels] = numpy.arange(len(unique_labels))
-        edge_labels = indexer[edge_labels]
-        #
-        # find magnitudes and lengths for all edges
-        #
-        magnitudes = fix(
-            scipy.ndimage.sum(
-                image, edge_labels, numpy.arange(1, nlabels + 1, dtype=numpy.int32)
-            )
+        (
+            trunk_counts,
+            branch_counts,
+            end_counts,
+            total_distance,
+            edge_graph,
+            vertex_graph,
+            branchpoint_image
+        ) =  calculate_object_skeleton(
+        skeleton, 
+        cropped_labels, 
+        labels_count, 
+        fill_small_holes, 
+        max_hole_size, 
+        wants_objskeleton_graph, 
+        intensity_image_pixel_data,
+        wants_branchpoint_image
         )
-        lengths = fix(
-            scipy.ndimage.sum(
-                numpy.ones(edge_labels.shape),
-                edge_labels,
-                numpy.arange(1, nlabels + 1, dtype=numpy.int32),
-            )
-        ).astype(int)
-    else:
-        magnitudes = numpy.zeros(0)
-        lengths = numpy.zeros(0, int)
-    #
-    # combine the edge labels and indexes of points of interest with padding
-    #
-    edge_mask = edge_labels != 0
-    all_labels = numpy.zeros(numpy.array(edge_labels.shape) + 2, int)
-    all_labels[1:-1, 1:-1][edge_mask] = edge_labels[edge_mask] + number_of_points
-    all_labels[i_idx + 1, j_idx + 1] = numpy.arange(1, number_of_points + 1)
-    #
-    # Collect all 8 neighbors for each point of interest
-    #
-    p1 = numpy.zeros(0, int)
-    p2 = numpy.zeros(0, int)
-    for i_off, j_off in (
-        (0, 0),
-        (0, 1),
-        (0, 2),
-        (1, 0),
-        (1, 2),
-        (2, 0),
-        (2, 1),
-        (2, 2),
-    ):
-        p1 = numpy.hstack((p1, numpy.arange(1, number_of_points + 1)))
-        p2 = numpy.hstack((p2, all_labels[i_idx + i_off, j_idx + j_off]))
-    #
-    # Get rid of zeros which are background
-    #
-    p1 = p1[p2 != 0]
-    p2 = p2[p2 != 0]
-    #
-    # Find point_of_interest -> point_of_interest connections.
-    #
-    p1_poi = p1[(p2 <= number_of_points) & (p1 < p2)]
-    p2_poi = p2[(p2 <= number_of_points) & (p1 < p2)]
-    #
-    # Make sure matches are labeled the same
-    #
-    same_labels = (
-        skeleton_labels[i_idx[p1_poi - 1], j_idx[p1_poi - 1]]
-        == skeleton_labels[i_idx[p2_poi - 1], j_idx[p2_poi - 1]]
-    )
-    p1_poi = p1_poi[same_labels]
-    p2_poi = p2_poi[same_labels]
-    #
-    # Find point_of_interest -> edge
-    #
-    p1_edge = p1[p2 > number_of_points]
-    edge = p2[p2 > number_of_points]
-    #
-    # Now, each value that p2_edge takes forms a group and all
-    # p1_edge whose p2_edge are connected together by the edge.
-    # Possibly they touch each other without the edge, but we will
-    # take the minimum distance connecting each pair to throw out
-    # the edge.
-    #
-    edge, p1_edge, p2_edge = centrosome.cpmorphology.pairwise_permutations(
-        edge, p1_edge
-    )
-    indexer = edge - number_of_points - 1
-    lengths = lengths[indexer]
-    magnitudes = magnitudes[indexer]
-    #
-    # OK, now we make the edge table. First poi<->poi. Length = 2,
-    # magnitude = magnitude at each point
-    #
-    poi_length = numpy.ones(len(p1_poi)) * 2
-    poi_magnitude = (
-        image[i_idx[p1_poi - 1], j_idx[p1_poi - 1]]
-        + image[i_idx[p2_poi - 1], j_idx[p2_poi - 1]]
-    )
-    #
-    # Now the edges...
-    #
-    poi_edge_length = lengths + 2
-    poi_edge_magnitude = (
-        image[i_idx[p1_edge - 1], j_idx[p1_edge - 1]]
-        + image[i_idx[p2_edge - 1], j_idx[p2_edge - 1]]
-        + magnitudes
-    )
-    #
-    # Put together the columns
-    #
-    v1 = numpy.hstack((p1_poi, p1_edge))
-    v2 = numpy.hstack((p2_poi, p2_edge))
-    lengths = numpy.hstack((poi_length, poi_edge_length))
-    magnitudes = numpy.hstack((poi_magnitude, poi_edge_magnitude))
-    #
-    # Sort by p1, p2 and length in order to pick the shortest length
-    #
-    indexer = numpy.lexsort((lengths, v1, v2))
-    v1 = v1[indexer]
-    v2 = v2[indexer]
-    lengths = lengths[indexer]
-    magnitudes = magnitudes[indexer]
-    if len(v1) > 0:
-        to_keep = numpy.hstack(([True], (v1[1:] != v1[:-1]) | (v2[1:] != v2[:-1])))
-        v1 = v1[to_keep]
-        v2 = v2[to_keep]
-        lengths = lengths[to_keep]
-        magnitudes = magnitudes[to_keep]
-    #
-    # Put it all together into a table
-    #
-    edge_table = {
-        EF_V1: v1,
-        EF_V2: v2,
-        EF_LENGTH: lengths,
-        EF_TOTAL_INTENSITY: magnitudes,
-    }
-    return edge_table, vertex_table
+        return (
+            trunk_counts,
+            branch_counts,
+            end_counts,
+            total_distance,
+            edge_graph,
+            vertex_graph,
+            branchpoint_image
+        )
+

--- a/src/subpackages/library/cellprofiler_library/modules/_measureobjectskeleton.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_measureobjectskeleton.py
@@ -1,0 +1,429 @@
+import numpy
+import scipy.ndimage
+import centrosome.cpmorphology
+import centrosome.propagate as propagate
+from centrosome.cpmorphology import fixup_scipy_ndimage_result as fix
+from scipy.ndimage import grey_dilation, grey_erosion
+from typing import Tuple, Optional, Any, Dict, Union
+
+from numpy.typing import NDArray
+from cellprofiler_library.types import Image2DBinary, ObjectSegmentation, Image2DColor, Image2D, Image2DGrayscale
+from pydantic import Field, validate_call, ConfigDict
+from cellprofiler_library.opts.measureobjectskeleton import VF_I, VF_J, VF_LABELS, VF_KIND, EF_V1, EF_V2, EF_LENGTH, EF_TOTAL_INTENSITY
+
+@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
+def get_ring_with_trunks(
+        skeleton: Image2DBinary, 
+        labels: ObjectSegmentation
+        ) -> Tuple[
+            ObjectSegmentation,
+            Image2DBinary,
+            Image2DBinary
+        ]:
+    #
+    # The following code makes a ring around the seed objects with
+    # the skeleton trunks sticking out of it.
+    #
+    # Create a new skeleton with holes at the seed objects
+    # First combine the seed objects with the skeleton so
+    # that the skeleton trunks come out of the seed objects.
+    #
+    # Erode the labels once so that all of the trunk branchpoints
+    # will be within the labels
+    #
+    #
+    # Dilate the objects, then subtract them to make a ring
+    #
+    my_disk = centrosome.cpmorphology.strel_disk(1.5).astype(int)
+    dilated_labels = grey_dilation(labels, footprint=my_disk)
+    seed_mask = dilated_labels > 0
+    combined_skel = skeleton | seed_mask
+
+    closed_labels = grey_erosion(dilated_labels, footprint=my_disk)
+    seed_center = closed_labels > 0
+    combined_skel = combined_skel & (~seed_center)
+    return dilated_labels, combined_skel, seed_center
+
+@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
+def measure_object_skeleton(
+        skeleton: Image2DBinary, 
+        cropped_labels: ObjectSegmentation, 
+        labels_count: numpy.integer[Any],
+        label_range: NDArray[numpy.int32], 
+        fill_small_holes: bool, 
+        max_hole_size: int,
+        wants_objskeleton_graph: bool,
+        intensity_image_pixel_data: Optional[Image2DGrayscale],
+        wants_branchpoint_image: bool
+        ) -> Tuple[
+            NDArray[numpy.float_], # trunk counts
+            NDArray[numpy.float_], # branch counts
+            NDArray[numpy.float_], # end counts
+            NDArray[numpy.float_], # total distance
+            Optional[Dict[str, NDArray[Union[numpy.float_, numpy.int_]]]],
+            Optional[Dict[str, NDArray[Union[numpy.float_, numpy.int_]]]],
+            Optional[Image2DColor],
+        ]:
+    #
+    # The following code makes a ring around the seed objects with
+    # the skeleton trunks sticking out of it.
+    #
+    dilated_labels, combined_skel, seed_center = get_ring_with_trunks(skeleton, cropped_labels)
+    
+    #
+    # Fill in single holes (but not a one-pixel hole made by
+    # a one-pixel image)
+    #
+    if fill_small_holes:
+        def size_fn(area, is_object):
+            return (~is_object) and (area <= max_hole_size)
+
+        combined_skel = centrosome.cpmorphology.fill_labeled_holes(
+            combined_skel, ~seed_center, size_fn
+        )
+    #
+    # Reskeletonize to make true branchpoints at the ring boundaries
+    #
+    combined_skel = centrosome.cpmorphology.skeletonize(combined_skel)
+    #
+    # The skeleton outside of the labels
+    #
+    outside_skel = combined_skel & (dilated_labels == 0)
+    #
+    # Associate all skeleton points with seed objects
+    #
+    dlabels, distance_map = propagate.propagate(
+        numpy.zeros(cropped_labels.shape), dilated_labels, combined_skel, 1
+    )
+    #
+    # Get rid of any branchpoints not connected to seeds
+    #
+    combined_skel[dlabels == 0] = False
+    #
+    # Find the branchpoints
+    #
+    branch_points = centrosome.cpmorphology.branchpoints(combined_skel)
+
+    #
+    # Odd case: when four branches meet like this, branchpoints are not
+    # assigned because they are arbitrary. So assign them.
+    #
+    # .  .
+    #  B.
+    #  .B
+    # .  .
+    #
+    odd_case = (
+        combined_skel[:-1, :-1]
+        & combined_skel[1:, :-1]
+        & combined_skel[:-1, 1:]
+        & combined_skel[1, 1]
+    )
+    branch_points[:-1, :-1][odd_case] = True
+    branch_points[1:, 1:][odd_case] = True
+    #
+    # Find the branching counts for the trunks (# of extra branches
+    # emanating from a point other than the line it might be on).
+    #
+    branching_counts = centrosome.cpmorphology.branchings(combined_skel)
+    branching_counts = numpy.array([0, 0, 0, 1, 2])[branching_counts]
+    #
+    # Only take branches within 1 of the outside skeleton
+    #
+    dilated_skel = scipy.ndimage.binary_dilation(
+        outside_skel, centrosome.cpmorphology.eight_connect
+    )
+    branching_counts[~dilated_skel] = 0
+    #
+    # Find the endpoints
+    #
+    end_points = centrosome.cpmorphology.endpoints(combined_skel)
+    #
+    # We use two ranges for classification here:
+    # * anything within one pixel of the dilated image is a trunk
+    # * anything outside of that range is a branch
+    #
+    nearby_labels = dlabels.copy()
+    nearby_labels[distance_map > 1.5] = 0
+
+    outside_labels = dlabels.copy()
+    outside_labels[nearby_labels > 0] = 0
+    #
+    # The trunks are the branchpoints that lie within one pixel of
+    # the dilated image.
+    #
+    if labels_count > 0:
+        trunk_counts = fix(
+            scipy.ndimage.sum(branching_counts, nearby_labels, label_range)
+        ).astype(int)
+    else:
+        trunk_counts = numpy.zeros((0,), int)
+    #
+    # The branches are the branchpoints that lie outside the seed objects
+    #
+    if labels_count > 0:
+        branch_counts = fix(
+            scipy.ndimage.sum(branch_points, outside_labels, label_range)
+        )
+    else:
+        branch_counts = numpy.zeros((0,), int)
+    #
+    # Save the endpoints
+    #
+    if labels_count > 0:
+        end_counts = fix(scipy.ndimage.sum(end_points, outside_labels, label_range))
+    else:
+        end_counts = numpy.zeros((0,), int)
+    #
+    # Calculate the distances
+    #
+    total_distance = centrosome.cpmorphology.skeleton_length(
+        dlabels * outside_skel, label_range
+    ).astype(numpy.float64)
+    edge_graph = None
+    vertex_graph = None
+    
+    branchpoint_image = None
+    if wants_objskeleton_graph or wants_branchpoint_image:
+        trunk_mask = (branching_counts > 0) & (nearby_labels != 0)
+        
+        if wants_objskeleton_graph:
+            assert intensity_image_pixel_data is not None
+            edge_graph, vertex_graph = make_objskeleton_graph(
+                combined_skel,
+                dlabels,
+                trunk_mask,
+                branch_points & ~trunk_mask,
+                end_points,
+                intensity_image_pixel_data,
+            )
+        if wants_branchpoint_image:
+            branchpoint_image = numpy.zeros((skeleton.shape[0], skeleton.shape[1], 3))
+            branch_mask = branch_points & (outside_labels != 0)
+            end_mask = end_points & (outside_labels != 0)
+            branchpoint_image[outside_skel, :] = 1
+            branchpoint_image[trunk_mask | branch_mask | end_mask, :] = 0
+            branchpoint_image[trunk_mask, 0] = 1
+            branchpoint_image[branch_mask, 1] = 1
+            branchpoint_image[end_mask, 2] = 1
+            branchpoint_image[dilated_labels != 0, :] *= 0.875
+            branchpoint_image[dilated_labels != 0, :] += 0.1
+
+    return (
+        trunk_counts, 
+        branch_counts,
+        end_counts,
+        total_distance,
+        edge_graph, 
+        vertex_graph,
+        branchpoint_image
+    )
+
+
+@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
+def make_objskeleton_graph(
+    skeleton: Image2DBinary, 
+    skeleton_labels: ObjectSegmentation, 
+    trunks: Image2DBinary, 
+    branchpoints: Image2DBinary, 
+    endpoints: Image2DBinary, 
+    image: Image2DGrayscale
+    ) -> Tuple[
+        Dict[str, NDArray[Union[numpy.float_, numpy.int_]]],
+        Dict[str, NDArray[Union[numpy.float_, numpy.int_]]]
+    ]:
+    """Make a table that captures the graph relationship of the skeleton
+
+    skeleton - binary skeleton image + outline of seed objects
+    skeleton_labels - labels matrix of skeleton
+    trunks - binary image with trunk points as 1
+    branchpoints - binary image with branchpoints as 1
+    endpoints - binary image with endpoints as 1
+    image - image for intensity measurement
+
+    returns two tables.
+    Table 1: edge table
+    The edge table is a numpy record array with the following named
+    columns in the following order:
+    v1: index into vertex table of first vertex of edge
+    v2: index into vertex table of second vertex of edge
+    length: # of intermediate pixels + 2 (for two vertices)
+    total_intensity: sum of intensities along the edge
+
+    Table 2: vertex table
+    The vertex table is a numpy record array:
+    i: I coordinate of the vertex
+    j: J coordinate of the vertex
+    label: the vertex's label
+    kind: kind of vertex = "T" for trunk, "B" for branchpoint or "E" for endpoint.
+    """
+    i, j = numpy.mgrid[0 : skeleton.shape[0], 0 : skeleton.shape[1]]
+    #
+    # Give each point of interest a unique number
+    #
+    points_of_interest = trunks | branchpoints | endpoints
+    number_of_points = numpy.sum(points_of_interest)
+    #
+    # Make up the vertex table
+    #
+    tbe = numpy.zeros(points_of_interest.shape, "|S1")
+    tbe[trunks] = "T"
+    tbe[branchpoints] = "B"
+    tbe[endpoints] = "E"
+    i_idx = i[points_of_interest]
+    j_idx = j[points_of_interest]
+    poe_labels = skeleton_labels[points_of_interest]
+    tbe = tbe[points_of_interest]
+    vertex_table = {
+        VF_I: i_idx,
+        VF_J: j_idx,
+        VF_LABELS: poe_labels,
+        VF_KIND: tbe,
+    }
+    #
+    # First, break the skeleton by removing the branchpoints, endpoints
+    # and trunks
+    #
+    broken_skeleton = skeleton & (~points_of_interest)
+    #
+    # Label the broken skeleton: this labels each edge differently
+    #
+    edge_labels, nlabels = centrosome.cpmorphology.label_skeleton(skeleton)
+    #
+    # Reindex after removing the points of interest
+    #
+    edge_labels[points_of_interest] = 0
+    if nlabels > 0:
+        indexer = numpy.arange(nlabels + 1)
+        unique_labels = numpy.sort(numpy.unique(edge_labels))
+        nlabels = len(unique_labels) - 1
+        indexer[unique_labels] = numpy.arange(len(unique_labels))
+        edge_labels = indexer[edge_labels]
+        #
+        # find magnitudes and lengths for all edges
+        #
+        magnitudes = fix(
+            scipy.ndimage.sum(
+                image, edge_labels, numpy.arange(1, nlabels + 1, dtype=numpy.int32)
+            )
+        )
+        lengths = fix(
+            scipy.ndimage.sum(
+                numpy.ones(edge_labels.shape),
+                edge_labels,
+                numpy.arange(1, nlabels + 1, dtype=numpy.int32),
+            )
+        ).astype(int)
+    else:
+        magnitudes = numpy.zeros(0)
+        lengths = numpy.zeros(0, int)
+    #
+    # combine the edge labels and indexes of points of interest with padding
+    #
+    edge_mask = edge_labels != 0
+    all_labels = numpy.zeros(numpy.array(edge_labels.shape) + 2, int)
+    all_labels[1:-1, 1:-1][edge_mask] = edge_labels[edge_mask] + number_of_points
+    all_labels[i_idx + 1, j_idx + 1] = numpy.arange(1, number_of_points + 1)
+    #
+    # Collect all 8 neighbors for each point of interest
+    #
+    p1 = numpy.zeros(0, int)
+    p2 = numpy.zeros(0, int)
+    for i_off, j_off in (
+        (0, 0),
+        (0, 1),
+        (0, 2),
+        (1, 0),
+        (1, 2),
+        (2, 0),
+        (2, 1),
+        (2, 2),
+    ):
+        p1 = numpy.hstack((p1, numpy.arange(1, number_of_points + 1)))
+        p2 = numpy.hstack((p2, all_labels[i_idx + i_off, j_idx + j_off]))
+    #
+    # Get rid of zeros which are background
+    #
+    p1 = p1[p2 != 0]
+    p2 = p2[p2 != 0]
+    #
+    # Find point_of_interest -> point_of_interest connections.
+    #
+    p1_poi = p1[(p2 <= number_of_points) & (p1 < p2)]
+    p2_poi = p2[(p2 <= number_of_points) & (p1 < p2)]
+    #
+    # Make sure matches are labeled the same
+    #
+    same_labels = (
+        skeleton_labels[i_idx[p1_poi - 1], j_idx[p1_poi - 1]]
+        == skeleton_labels[i_idx[p2_poi - 1], j_idx[p2_poi - 1]]
+    )
+    p1_poi = p1_poi[same_labels]
+    p2_poi = p2_poi[same_labels]
+    #
+    # Find point_of_interest -> edge
+    #
+    p1_edge = p1[p2 > number_of_points]
+    edge = p2[p2 > number_of_points]
+    #
+    # Now, each value that p2_edge takes forms a group and all
+    # p1_edge whose p2_edge are connected together by the edge.
+    # Possibly they touch each other without the edge, but we will
+    # take the minimum distance connecting each pair to throw out
+    # the edge.
+    #
+    edge, p1_edge, p2_edge = centrosome.cpmorphology.pairwise_permutations(
+        edge, p1_edge
+    )
+    indexer = edge - number_of_points - 1
+    lengths = lengths[indexer]
+    magnitudes = magnitudes[indexer]
+    #
+    # OK, now we make the edge table. First poi<->poi. Length = 2,
+    # magnitude = magnitude at each point
+    #
+    poi_length = numpy.ones(len(p1_poi)) * 2
+    poi_magnitude = (
+        image[i_idx[p1_poi - 1], j_idx[p1_poi - 1]]
+        + image[i_idx[p2_poi - 1], j_idx[p2_poi - 1]]
+    )
+    #
+    # Now the edges...
+    #
+    poi_edge_length = lengths + 2
+    poi_edge_magnitude = (
+        image[i_idx[p1_edge - 1], j_idx[p1_edge - 1]]
+        + image[i_idx[p2_edge - 1], j_idx[p2_edge - 1]]
+        + magnitudes
+    )
+    #
+    # Put together the columns
+    #
+    v1 = numpy.hstack((p1_poi, p1_edge))
+    v2 = numpy.hstack((p2_poi, p2_edge))
+    lengths = numpy.hstack((poi_length, poi_edge_length))
+    magnitudes = numpy.hstack((poi_magnitude, poi_edge_magnitude))
+    #
+    # Sort by p1, p2 and length in order to pick the shortest length
+    #
+    indexer = numpy.lexsort((lengths, v1, v2))
+    v1 = v1[indexer]
+    v2 = v2[indexer]
+    lengths = lengths[indexer]
+    magnitudes = magnitudes[indexer]
+    if len(v1) > 0:
+        to_keep = numpy.hstack(([True], (v1[1:] != v1[:-1]) | (v2[1:] != v2[:-1])))
+        v1 = v1[to_keep]
+        v2 = v2[to_keep]
+        lengths = lengths[to_keep]
+        magnitudes = magnitudes[to_keep]
+    #
+    # Put it all together into a table
+    #
+    edge_table = {
+        EF_V1: v1,
+        EF_V2: v2,
+        EF_LENGTH: lengths,
+        EF_TOTAL_INTENSITY: magnitudes,
+    }
+    return edge_table, vertex_table

--- a/src/subpackages/library/cellprofiler_library/modules/_measureobjectskeleton.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_measureobjectskeleton.py
@@ -1,12 +1,15 @@
 import numpy
-from typing import Tuple, Optional, Any, Dict, Union, Annotated
+from typing import Tuple, Optional, Any, Dict, Union, Annotated, List
 from numpy.typing import NDArray
 from cellprofiler_library.types import Image2DBinary, ObjectSegmentation, Image2DColor, Image2DGrayscale
 from pydantic import Field, validate_call, ConfigDict
 from cellprofiler_library.functions.measurement import calculate_object_skeleton
+from cellprofiler_library.opts.measureobjectskeleton import SkeletonMeasurements, C_OBJSKELETON
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def measure_object_skeleton(
+        object_name:                Annotated[str, Field(description="Name of the object being measured")],
+        image_name:                 Annotated[str, Field(description="Name of the image being measured")],
         skeleton:                   Annotated[Image2DBinary, Field(description="Input image")],
         cropped_labels:             Annotated[ObjectSegmentation, Field(description="Input labels")],
         labels_count:               Annotated[numpy.integer[Any], Field(description="Number of labels in the original segmentation prior to cropping")],
@@ -16,25 +19,21 @@ def measure_object_skeleton(
         intensity_image_pixel_data: Annotated[Optional[Image2DGrayscale], Field(description="Intensity image used for graph relationships")]=None,
         wants_branchpoint_image:    Annotated[bool, Field(description="Return the branchpoint image?")]=False,
         ) -> Tuple[
-            NDArray[numpy.float_],
-            NDArray[numpy.float_],
-            NDArray[numpy.float_],
-            NDArray[numpy.float_],
+            Dict[str, Any],
             Optional[Dict[str, NDArray[Union[numpy.float_, numpy.int_]]]],
             Optional[Dict[str, NDArray[Union[numpy.float_, numpy.int_]]]],
             Optional[Image2DColor],
         ]:
     
-    
-        (
-            trunk_counts,
-            branch_counts,
-            end_counts,
-            total_distance,
-            edge_graph,
-            vertex_graph,
-            branchpoint_image
-        ) =  calculate_object_skeleton(
+    (
+        trunk_counts,
+        branch_counts,
+        end_counts,
+        total_distance,
+        edge_graph,
+        vertex_graph,
+        branchpoint_image
+    ) = calculate_object_skeleton(
         skeleton, 
         cropped_labels, 
         labels_count, 
@@ -43,14 +42,46 @@ def measure_object_skeleton(
         wants_objskeleton_graph, 
         intensity_image_pixel_data,
         wants_branchpoint_image
-        )
-        return (
-            trunk_counts,
-            branch_counts,
-            end_counts,
-            total_distance,
-            edge_graph,
-            vertex_graph,
-            branchpoint_image
-        )
+    )
+
+    measurements = {
+        "Image": {},
+        "Object": {
+            object_name: {}
+        }
+    }
+    
+    # Per-object measurements
+    feature_map = {
+        SkeletonMeasurements.NUMBER_TRUNKS: trunk_counts,
+        SkeletonMeasurements.NUMBER_NON_TRUNK_BRANCHES: branch_counts,
+        SkeletonMeasurements.NUMBER_BRANCH_ENDS: end_counts,
+        SkeletonMeasurements.TOTAL_OBJSKELETON_LENGTH: total_distance,
+    }
+
+    for feature_name, values in feature_map.items():
+        # Feature name format: ObjectSkeleton_Feature_Image
+        full_feature_name = f"{C_OBJSKELETON}_{feature_name}_{image_name}"
+        measurements["Object"][object_name][full_feature_name] = values
+        
+        # Calculate summary statistics
+        if len(values) > 0:
+            measurements["Image"][f"Mean_{full_feature_name}"] = numpy.mean(values)
+            measurements["Image"][f"Median_{full_feature_name}"] = numpy.median(values)
+            measurements["Image"][f"StDev_{full_feature_name}"] = numpy.std(values)
+            measurements["Image"][f"Min_{full_feature_name}"] = numpy.min(values)
+            measurements["Image"][f"Max_{full_feature_name}"] = numpy.max(values)
+        else:
+            measurements["Image"][f"Mean_{full_feature_name}"] = 0.0
+            measurements["Image"][f"Median_{full_feature_name}"] = 0.0
+            measurements["Image"][f"StDev_{full_feature_name}"] = 0.0
+            measurements["Image"][f"Min_{full_feature_name}"] = 0.0
+            measurements["Image"][f"Max_{full_feature_name}"] = 0.0
+
+    return (
+        measurements,
+        edge_graph,
+        vertex_graph,
+        branchpoint_image
+    )
 

--- a/src/subpackages/library/cellprofiler_library/modules/_measureobjectskeleton.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_measureobjectskeleton.py
@@ -2,11 +2,24 @@ import numpy
 from typing import Tuple, Optional, Any, Dict, Union, Annotated, List
 from numpy.typing import NDArray
 from cellprofiler_library.types import Image2DBinary, ObjectSegmentation, Image2DColor, Image2DGrayscale
-from pydantic import Field, validate_call, ConfigDict
+from pydantic import Field, validate_call, ConfigDict, BaseModel
 from cellprofiler_library.functions.measurement import calculate_object_skeleton
 from cellprofiler_library.opts.measureobjectskeleton import SkeletonMeasurements, C_OBJSKELETON
-
 from cellprofiler_library.measurement_model import LibraryMeasurements
+
+
+ObjectSkeletonStatistics = List[None]
+
+class ObjectSkeletonDisplayData(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True, 
+        populate_by_name=True
+    )
+
+    statistics: ObjectSkeletonStatistics
+    edge_graph: Optional[Dict[str, NDArray[Union[numpy.float_, numpy.int_]]]]
+    vertex_graph: Optional[Dict[str, NDArray[Union[numpy.float_, numpy.int_]]]]
+    branchpoint_image: Optional[Image2DColor]
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def measure_object_skeleton(
@@ -17,16 +30,10 @@ def measure_object_skeleton(
         labels_count:               Annotated[numpy.integer[Any], Field(description="Number of labels in the original segmentation prior to cropping")],
         fill_small_holes:           Annotated[bool, Field(description="Fill small holes?")],
         max_hole_size:              Annotated[Optional[int], Field(description="Maximum hole size", ge=1)]=None,
-        wants_objskeleton_graph:    Annotated[bool, Field(description="Return the skeleton graph relationships along with the measurements?")]=False,
+        wants_objskeleton_graph:    Annotated[bool, Field(description="Return the skeleton graph relationships along with the measurements in the display data?")]=False,
         intensity_image_pixel_data: Annotated[Optional[Image2DGrayscale], Field(description="Intensity image used for graph relationships")]=None,
-        wants_branchpoint_image:    Annotated[bool, Field(description="Return the branchpoint image?")]=False,
-        ) -> Tuple[
-            LibraryMeasurements,
-            Optional[Dict[str, NDArray[Union[numpy.float_, numpy.int_]]]],
-            Optional[Dict[str, NDArray[Union[numpy.float_, numpy.int_]]]],
-            Optional[Image2DColor],
-        ]:
-    
+        wants_branchpoint_image:    Annotated[bool, Field(description="Return the branchpoint image in display data?")]=False,
+        ) -> Union[LibraryMeasurements, Tuple[LibraryMeasurements, ObjectSkeletonDisplayData]]:
     (
         trunk_counts,
         branch_counts,
@@ -75,10 +82,12 @@ def measure_object_skeleton(
             measurements.add_image_measurement(f"Min_{full_feature_name}", 0.0)
             measurements.add_image_measurement(f"Max_{full_feature_name}", 0.0)
 
-    return (
-        measurements,
-        edge_graph,
-        vertex_graph,
-        branchpoint_image
-    )
+    if wants_objskeleton_graph or wants_branchpoint_image:
+        return measurements, ObjectSkeletonDisplayData(
+                statistics=[],
+                edge_graph=edge_graph,
+                vertex_graph=vertex_graph,
+                branchpoint_image=branchpoint_image,
+        )
+    return measurements
 

--- a/src/subpackages/library/cellprofiler_library/opts/measureobjectskeleton.py
+++ b/src/subpackages/library/cellprofiler_library/opts/measureobjectskeleton.py
@@ -17,5 +17,31 @@ F_ALL = [
     SkeletonMeasurements.TOTAL_OBJSKELETON_LENGTH,
 ]
 
+VF_IMAGE_NUMBER = "image_number"
+VF_VERTEX_NUMBER = "vertex_number"
+
+VF_I = "i"
+VF_J = "j"
+VF_LABELS = "labels"
+VF_KIND = "kind"
+
+vertex_file_columns = (
+    VF_IMAGE_NUMBER,
+    VF_VERTEX_NUMBER,
+    VF_I,
+    VF_J,
+    VF_LABELS,
+    VF_KIND,
+)
+
+EF_IMAGE_NUMBER = "image_number"
+
+EF_V1 = "v1"
+EF_V2 = "v2"
+EF_LENGTH = "length"
+EF_TOTAL_INTENSITY = "total_intensity"
+
+edge_file_columns = (EF_IMAGE_NUMBER, EF_V1, EF_V2, EF_LENGTH, EF_TOTAL_INTENSITY)
+
 """The measurement category"""
 C_OBJSKELETON = "ObjectSkeleton"

--- a/src/subpackages/library/cellprofiler_library/opts/measureobjectskeleton.py
+++ b/src/subpackages/library/cellprofiler_library/opts/measureobjectskeleton.py
@@ -1,0 +1,21 @@
+from enum import Enum
+
+class SkeletonMeasurements(str, Enum):
+    """The trunk count feature"""
+    NUMBER_TRUNKS = "NumberTrunks"
+    """The branch feature"""
+    NUMBER_NON_TRUNK_BRANCHES = "NumberNonTrunkBranches"
+    """The endpoint feature"""
+    NUMBER_BRANCH_ENDS = "NumberBranchEnds"
+    """The neurite length feature"""
+    TOTAL_OBJSKELETON_LENGTH = "TotalObjectSkeletonLength"
+
+F_ALL = [
+    SkeletonMeasurements.NUMBER_TRUNKS,
+    SkeletonMeasurements.NUMBER_NON_TRUNK_BRANCHES,
+    SkeletonMeasurements.NUMBER_BRANCH_ENDS,
+    SkeletonMeasurements.TOTAL_OBJSKELETON_LENGTH,
+]
+
+"""The measurement category"""
+C_OBJSKELETON = "ObjectSkeleton"

--- a/tests/frontend/modules/test_measureobjectskeleton.py
+++ b/tests/frontend/modules/test_measureobjectskeleton.py
@@ -16,7 +16,7 @@ import cellprofiler_core.preferences
 import cellprofiler_core.setting
 import cellprofiler_core.workspace
 import tests.frontend.modules
-
+from cellprofiler_library.opts.measureobjectskeleton import SkeletonMeasurements, C_OBJSKELETON, F_ALL
 
 IMAGE_NAME = "MyImage"
 INTENSITY_IMAGE_NAME = "MyIntensityImage"
@@ -125,13 +125,13 @@ def test_empty():
     columns = module.get_measurement_columns(None)
     features = [c[1] for c in columns]
     features.sort()
-    expected = cellprofiler.modules.measureobjectskeleton.F_ALL
+    expected = F_ALL
     expected.sort()
     coltypes = {}
     for feature, expected in zip(features, expected):
         expected_feature = "_".join(
             (
-                cellprofiler.modules.measureobjectskeleton.C_OBJSKELETON,
+                C_OBJSKELETON,
                 expected,
                 IMAGE_NAME,
             )
@@ -140,7 +140,7 @@ def test_empty():
         coltypes[expected_feature] = (
             COLTYPE_FLOAT
             if expected
-            == cellprofiler.modules.measureobjectskeleton.F_TOTAL_OBJSKELETON_LENGTH
+            == SkeletonMeasurements.TOTAL_OBJSKELETON_LENGTH
             else COLTYPE_INTEGER
         )
     assert all([c[0] == OBJECT_NAME for c in columns])
@@ -148,33 +148,33 @@ def test_empty():
 
     categories = module.get_categories(None, OBJECT_NAME)
     assert len(categories) == 1
-    assert categories[0] == cellprofiler.modules.measureobjectskeleton.C_OBJSKELETON
+    assert categories[0] == C_OBJSKELETON
     assert len(module.get_categories(None, "Foo")) == 0
 
     measurements = module.get_measurements(
-        None, OBJECT_NAME, cellprofiler.modules.measureobjectskeleton.C_OBJSKELETON
+        None, OBJECT_NAME, C_OBJSKELETON
     )
-    assert len(measurements) == len(cellprofiler.modules.measureobjectskeleton.F_ALL)
+    assert len(measurements) == len(F_ALL)
     assert measurements[0] != measurements[1]
     assert all(
-        [m in cellprofiler.modules.measureobjectskeleton.F_ALL for m in measurements]
+        [m in F_ALL for m in measurements]
     )
 
     assert (
         len(
             module.get_measurements(
-                None, "Foo", cellprofiler.modules.measureobjectskeleton.C_OBJSKELETON
+                None, "Foo", C_OBJSKELETON
             )
         )
         == 0
     )
     assert len(module.get_measurements(None, OBJECT_NAME, "Foo")) == 0
 
-    for feature in cellprofiler.modules.measureobjectskeleton.F_ALL:
+    for feature in F_ALL:
         images = module.get_measurement_images(
             None,
             OBJECT_NAME,
-            cellprofiler.modules.measureobjectskeleton.C_OBJSKELETON,
+            C_OBJSKELETON,
             feature,
         )
         assert len(images) == 1
@@ -183,10 +183,10 @@ def test_empty():
     module.run(workspace)
     m = workspace.measurements
     assert isinstance(m,cellprofiler_core.measurement.Measurements)
-    for feature in cellprofiler.modules.measureobjectskeleton.F_ALL:
+    for feature in F_ALL:
         mname = "_".join(
             (
-                cellprofiler.modules.measureobjectskeleton.C_OBJSKELETON,
+                C_OBJSKELETON,
                 expected,
                 IMAGE_NAME,
             )
@@ -206,12 +206,12 @@ def test_trunk():
     m = workspace.measurements
     assert isinstance(m,cellprofiler_core.measurement.Measurements)
     for feature, expected in (
-        (cellprofiler.modules.measureobjectskeleton.F_NUMBER_NON_TRUNK_BRANCHES, 0),
-        (cellprofiler.modules.measureobjectskeleton.F_NUMBER_TRUNKS, 1),
+        (SkeletonMeasurements.NUMBER_NON_TRUNK_BRANCHES, 0),
+        (SkeletonMeasurements.NUMBER_TRUNKS, 1),
     ):
         mname = "_".join(
             (
-                cellprofiler.modules.measureobjectskeleton.C_OBJSKELETON,
+                C_OBJSKELETON,
                 feature,
                 IMAGE_NAME,
             )
@@ -234,14 +234,14 @@ def test_trunks():
     assert isinstance(m,cellprofiler_core.measurement.Measurements)
     for feature, expected in (
         (
-            cellprofiler.modules.measureobjectskeleton.F_NUMBER_NON_TRUNK_BRANCHES,
+            SkeletonMeasurements.NUMBER_NON_TRUNK_BRANCHES,
             [0, 0],
         ),
-        (cellprofiler.modules.measureobjectskeleton.F_NUMBER_TRUNKS, [2, 1]),
+        (SkeletonMeasurements.NUMBER_TRUNKS, [2, 1]),
     ):
         mname = "_".join(
             (
-                cellprofiler.modules.measureobjectskeleton.C_OBJSKELETON,
+                C_OBJSKELETON,
                 feature,
                 IMAGE_NAME,
             )
@@ -265,12 +265,12 @@ def test_branch():
     m = workspace.measurements
     assert isinstance(m,cellprofiler_core.measurement.Measurements)
     for feature, expected in (
-        (cellprofiler.modules.measureobjectskeleton.F_NUMBER_NON_TRUNK_BRANCHES, 1),
-        (cellprofiler.modules.measureobjectskeleton.F_NUMBER_TRUNKS, 1),
+        (SkeletonMeasurements.NUMBER_NON_TRUNK_BRANCHES, 1),
+        (SkeletonMeasurements.NUMBER_TRUNKS, 1),
     ):
         mname = "_".join(
             (
-                cellprofiler.modules.measureobjectskeleton.C_OBJSKELETON,
+                C_OBJSKELETON,
                 feature,
                 IMAGE_NAME,
             )
@@ -296,12 +296,12 @@ def test_img_667():
     m = workspace.measurements
     assert isinstance(m,cellprofiler_core.measurement.Measurements)
     for feature, expected in (
-        (cellprofiler.modules.measureobjectskeleton.F_NUMBER_NON_TRUNK_BRANCHES, 1),
-        (cellprofiler.modules.measureobjectskeleton.F_NUMBER_TRUNKS, 2),
+        (SkeletonMeasurements.NUMBER_NON_TRUNK_BRANCHES, 1),
+        (SkeletonMeasurements.NUMBER_TRUNKS, 2),
     ):
         mname = "_".join(
             (
-                cellprofiler.modules.measureobjectskeleton.C_OBJSKELETON,
+                C_OBJSKELETON,
                 feature,
                 IMAGE_NAME,
             )
@@ -340,12 +340,12 @@ def test_quadrabranch():
     m = workspace.measurements
     assert isinstance(m,cellprofiler_core.measurement.Measurements)
     for feature, expected in (
-        (cellprofiler.modules.measureobjectskeleton.F_NUMBER_NON_TRUNK_BRANCHES, 0),
-        (cellprofiler.modules.measureobjectskeleton.F_NUMBER_TRUNKS, 3),
+        (SkeletonMeasurements.NUMBER_NON_TRUNK_BRANCHES, 0),
+        (SkeletonMeasurements.NUMBER_TRUNKS, 3),
     ):
         mname = "_".join(
             (
-                cellprofiler.modules.measureobjectskeleton.C_OBJSKELETON,
+                C_OBJSKELETON,
                 feature,
                 IMAGE_NAME,
             )
@@ -376,14 +376,14 @@ def test_wrong_size():
     assert isinstance(m,cellprofiler_core.measurement.Measurements)
     for feature, expected in (
         (
-            cellprofiler.modules.measureobjectskeleton.F_NUMBER_NON_TRUNK_BRANCHES,
+            SkeletonMeasurements.NUMBER_NON_TRUNK_BRANCHES,
             [0, 0],
         ),
-        (cellprofiler.modules.measureobjectskeleton.F_NUMBER_TRUNKS, [2, 1]),
+        (SkeletonMeasurements.NUMBER_TRUNKS, [2, 1]),
     ):
         mname = "_".join(
             (
-                cellprofiler.modules.measureobjectskeleton.C_OBJSKELETON,
+                C_OBJSKELETON,
                 feature,
                 IMAGE_NAME,
             )
@@ -407,8 +407,8 @@ def test_skeleton_length():
     m = workspace.measurements
     ftr = "_".join(
         (
-            cellprofiler.modules.measureobjectskeleton.C_OBJSKELETON,
-            cellprofiler.modules.measureobjectskeleton.F_TOTAL_OBJSKELETON_LENGTH,
+            C_OBJSKELETON,
+            SkeletonMeasurements.TOTAL_OBJSKELETON_LENGTH,
             IMAGE_NAME,
         )
     )

--- a/tests/frontend/modules/test_measureobjectskeleton.py
+++ b/tests/frontend/modules/test_measureobjectskeleton.py
@@ -13,7 +13,6 @@ import cellprofiler.modules.measureobjectskeleton
 import cellprofiler_core.object
 import cellprofiler_core.pipeline
 import cellprofiler_core.preferences
-import cellprofiler_core.setting
 import cellprofiler_core.workspace
 import tests.frontend.modules
 from cellprofiler_library.opts.measureobjectskeleton import SkeletonMeasurements, C_OBJSKELETON, F_ALL


### PR DESCRIPTION
# Refactor MeasureObjectSkeleton to use LibraryMeasurements

## Description
This PR refactors the `MeasureObjectSkeleton` module to adhere to the new 3-layer architecture (Frontend -> Library Module -> Functions)
It refactors `MeasureObjectSkeleton` to use the `LibraryMeasurements` Pydantic model. This change ensures type safety, standardized measurement handling, and clean separation between the algorithmic core and the frontend.

## Key Changes

### 1. Library Layer (`cellprofiler_library/modules/_measureobjectskeleton.py`)
- Updated `measure_object_skeleton` to act as a proper orchestrator.
- **Input**: Now accepts pure data types (images, masks, settings) and naming strings (`object_name`, `image_name`).
- **Output**: Returns a `LibraryMeasurements` instance.
- **Graph & Images**: continues to return `edge_graph`, `vertex_graph`, and `branchpoint_image` as separate return values for the frontend to handle.
-  Implemented `add_measurement` and `add_image_measurement` for robust data recording.

### 2. Frontend Layer (`cellprofiler/modules/measureobjectskeleton.py`)
- Refactored the `run` method to delegate all calculation to the library module.
- Updated `run()` to consume and unpack the `LibraryMeasurements` object.
- Handles the interaction and display of the skeleton graph and branchpoint images using the data returned by the library.

### 3. Functional Layer (`functions/measurement.py`)
- Leveraged the existing pure `calculate_object_skeleton` function.

## Verification
- **Algorithmic Equivalence**: Verified that the refactored code produces identical measurements to the previous implementation.
- **Integration Tests**: Passed existing frontend tests (`tests/frontend/modules/test_measureobjectskeleton.py`).
- **Type Safety**: Leveraged Pydantic validation for measurement data.
