### PR TITLE
fix: use isinstance() to detect NamesAndTypes for volumetric detection

### DIFF
--- a/src/subpackages/core/cellprofiler_core/pipeline/_pipeline.py
+++ b/src/subpackages/core/cellprofiler_core/pipeline/_pipeline.py
@@ -668,7 +668,9 @@ class Pipeline:
                 "Module %s did not have a variable revision # attribute" % module_name
             )
         module.set_settings_from_values(settings, variable_revision_number, module_name)
-        if module_name == "NamesAndTypes":
+        # Import here to avoid circular imports
+        from cellprofiler_core.modules.namesandtypes import NamesAndTypes
+        if isinstance(module, NamesAndTypes):
             self.__volumetric = module.process_as_3d.value
 
         return module


### PR DESCRIPTION
## Problem
When loading a pipeline in headless mode, the 3D (volumetric) setting was not being respected because the code checked for module name "NamesAndTypes" which may be localized.

## Solution
Use isinstance() to properly detect the NamesAndTypes module instead of comparing names.

```diff
-if module_name == "NamesAndTypes":
+from cellprofiler_core.modules.namesandtypes import NamesAndTypes
+if isinstance(module, NamesAndTypes):
```

## Testing
This fix ensures volumetric detection works regardless of module name localization.

Fixes #5125