### PR TITLE
Move Object Processing Measurements to Library

### DIFF
--- a/src/subpackages/core/cellprofiler_core/module/image_segmentation/_image_segmentation.py
+++ b/src/subpackages/core/cellprofiler_core/module/image_segmentation/_image_segmentation.py
@@ -1,4 +1,3 @@
-import numpy
 from cellprofiler_core.object import Objects
 
 from .._module import Module
@@ -19,7 +18,8 @@ from ...constants.measurement import M_LOCATION_CENTER_Z
 from ...constants.measurement import M_NUMBER_OBJECT_NUMBER
 from ...setting.subscriber import ImageSubscriber
 from ...setting.text import LabelName
-
+from cellprofiler_core.utilities.core.workspace import add_library_measurements_to_workspace_measurements
+from cellprofiler_library.functions.measurement import get_image_segmentation_measurements
 
 class ImageSegmentation(Module):
     category = "Image Segmentation"
@@ -33,38 +33,15 @@ class ImageSegmentation(Module):
             object_name = self.y_name.value
 
         objects = workspace.object_set.get_objects(object_name)
-
-        centers = objects.center_of_mass()
-
-        if len(centers) == 0:
-            center_z, center_y, center_x = [], [], []
-        else:
-            if objects.volumetric:
-                center_z, center_y, center_x = centers.transpose()
-            else:
-                center_z = [0] * len(centers)
-
-                center_y, center_x = centers.transpose()
-
-        workspace.measurements.add_measurement(
-            object_name, M_LOCATION_CENTER_X, center_x,
+        # I have tested this when debugging relateobjects while working on the library/object_count _measurements branch and confirmed that it works.
+        lib_measurements = get_image_segmentation_measurements(
+            objects.segmented,
+            objects.volumetric,
+            objects.count,
+            object_name,
         )
 
-        workspace.measurements.add_measurement(
-            object_name, M_LOCATION_CENTER_Y, center_y,
-        )
-
-        workspace.measurements.add_measurement(
-            object_name, M_LOCATION_CENTER_Z, center_z,
-        )
-
-        workspace.measurements.add_measurement(
-            object_name, M_NUMBER_OBJECT_NUMBER, numpy.arange(1, objects.count + 1),
-        )
-
-        workspace.measurements.add_measurement(
-            IMAGE, FF_COUNT % object_name, numpy.array([objects.count], dtype=float),
-        )
+        add_library_measurements_to_workspace_measurements(workspace.measurements, lib_measurements)
 
     def create_settings(self):
         self.x_name = ImageSubscriber(

--- a/src/subpackages/core/cellprofiler_core/module/image_segmentation/_object_processing.py
+++ b/src/subpackages/core/cellprofiler_core/module/image_segmentation/_object_processing.py
@@ -10,7 +10,8 @@ from ...constants.measurement import FF_COUNT
 from ...constants.measurement import FF_PARENT
 from ...constants.measurement import FTR_OBJECT_NUMBER
 from ...object import Objects
-
+from cellprofiler_library.functions.measurement import get_object_processing_measurements
+from cellprofiler_core.utilities.core.workspace import add_library_measurements_to_workspace_measurements
 
 class ObjectProcessing(ImageSegmentation):
     category = "Object Processing"
@@ -24,25 +25,29 @@ class ObjectProcessing(ImageSegmentation):
         if output_object_name is None:
             output_object_name = self.y_name.value
 
-        super(ObjectProcessing, self).add_measurements(workspace, output_object_name)
+        #
+        # Output object name, labels, volumetric, count needed to run get_image_segmentation_measurements
+        #
+        output_objects = workspace.object_set.get_objects(output_object_name)
+        output_objects_labels = output_objects.segmented
+        output_objects_volumetric = output_objects.volumetric
+        output_objects_count = output_objects.count
 
-        objects = workspace.object_set.get_objects(output_object_name)
+        #
+        # Input object name, labels, ijv, and output object ijv needed to run relate_children inside get_object_processing_measurements, This is the parent object
+        #
+        input_objects = workspace.object_set.get_objects(input_object_name)
+        input_objects_labels = input_objects.segmented
+        input_objects_ijv = input_objects.ijv
+        output_objects_ijv = output_objects.ijv
 
-        parent_objects = workspace.object_set.get_objects(input_object_name)
-
-        children_per_parent, parents_of_children = parent_objects.relate_children(
-            objects
+        lib_measurements = get_object_processing_measurements(
+            output_objects_labels, output_objects_volumetric, output_objects_count, 
+            output_object_name, output_objects_ijv, 
+            input_object_name, input_objects_labels, input_objects_ijv, 
         )
+        add_library_measurements_to_workspace_measurements(workspace.measurements, lib_measurements)
 
-        workspace.measurements.add_measurement(
-            input_object_name,
-            FF_CHILDREN_COUNT % output_object_name,
-            children_per_parent,
-        )
-
-        workspace.measurements.add_measurement(
-            output_object_name, FF_PARENT % input_object_name, parents_of_children,
-        )
 
     def create_settings(self):
         super(ObjectProcessing, self).create_settings()

--- a/src/subpackages/library/cellprofiler_library/functions/measurement.py
+++ b/src/subpackages/library/cellprofiler_library/functions/measurement.py
@@ -32,6 +32,7 @@ from cellprofiler_library.functions.segmentation import count_from_ijv
 from cellprofiler_library.functions.segmentation import areas_from_ijv
 from cellprofiler_library.functions.segmentation import cast_labels_to_label_set
 from cellprofiler_library.functions.segmentation import convert_label_set_to_ijv
+from cellprofiler_library.functions.segmentation import relate_children
 from cellprofiler_library.functions.image_processing import masked_erode, restore_scale, get_morphology_footprint
 from cellprofiler_library.functions.segmentation import relate_labels
 
@@ -55,6 +56,7 @@ from cellprofiler_library.opts.measurement import (
     M_LOCATION_CENTER_Z,
     C_LOCATION,
     M_NUMBER_OBJECT_NUMBER,
+    FF_CHILDREN_COUNT,
 )
 
 ###############################################################################
@@ -4263,12 +4265,88 @@ def get_object_count_measurements(object_name, object_count):
     lib_measurements.add_image_measurement(FF_COUNT % object_name, object_count)
     return lib_measurements
 
-def get_object_processing_measurements(*args, **kwargs):
-    # TODO: #5117 implement add_measurements from src/subpackages/core/cellprofiler_core/module/image_segmentation/_object_processing.py
-    pass
+def get_object_processing_measurements(
+        object_labels,
+        object_volumetric,
+        object_count,
+        object_name,
+        object_ijv,
+        parent_object_name,  
+        parent_object_labels,
+        parent_object_ijv,
+    ):
 
-def get_image_segmentation_measurements(*args, **kwargs):
-    # TODO: #5117 implement add_measurements from src/subpackages/core/cellprofiler_core/module/image_segmentation/_image_segmentation.py
-    pass
+    lib_measurements = get_image_segmentation_measurements(
+        object_labels, object_volumetric, object_count, object_name
+    )
+    lib_measurements_relate = get_relate_object_measurements(
+        object_labels, object_volumetric, object_name, object_ijv, 
+        parent_object_name, parent_object_labels, parent_object_ijv, 
+    )
+    lib_measurements = lib_measurements.merge(lib_measurements_relate)
 
+    return lib_measurements
+
+def get_relate_object_measurements(
+        object_labels, object_volumetric, object_name, object_ijv,
+        parent_object_name, parent_object_labels, parent_object_ijv,
+    ):
+    lib_measurements = LibraryMeasurements()
+    children_per_parent, parents_of_children = relate_children(
+        parent_object_labels, 
+        object_labels, 
+        parent_object_ijv, 
+        object_ijv, 
+        volumetric=object_volumetric
+    )
+    lib_measurements.add_measurement(
+        parent_object_name,
+        FF_CHILDREN_COUNT % object_name,
+        children_per_parent,
+    )
+
+    lib_measurements.add_measurement(
+        object_name, FF_PARENT % parent_object_name, parents_of_children,
+    )
+    return lib_measurements
+
+def get_image_segmentation_measurements(
+        object_labels, 
+        objects_volumetric, 
+        objects_count, 
+        object_name
+    ):
+    lib_measurements = LibraryMeasurements()
+    centers = center_of_labels_mass(object_labels, validate=False)
+
+    if len(centers) == 0:
+        center_z, center_y, center_x = [], [], []
+    else:
+        if objects_volumetric:
+            center_z, center_y, center_x = centers.transpose()
+        else:
+            center_z = [0] * len(centers)
+
+            center_y, center_x = centers.transpose()
+
+    lib_measurements.add_measurement(
+        object_name, M_LOCATION_CENTER_X, center_x,
+    )
+
+    lib_measurements.add_measurement(
+        object_name, M_LOCATION_CENTER_Y, center_y,
+    )
+
+    lib_measurements.add_measurement(
+        object_name, M_LOCATION_CENTER_Z, center_z,
+    )
+
+    lib_measurements.add_measurement(
+        object_name, M_NUMBER_OBJECT_NUMBER, numpy.arange(1, objects_count + 1),
+    )
+
+    lib_measurements.add_image_measurement( 
+        FF_COUNT % object_name, numpy.array([objects_count], dtype=float),
+    )
+    return lib_measurements
 


### PR DESCRIPTION
These are measurements that are not present in the modules' files but rather in the parent class, `ObjectProcessing` and are called inside of the modules that inherit it. Also implemented the same for `ImageSegmentation` as it too has some measurement functions and is inherited by `ObjectProcessing`.