### PR TITLE
Move `correctilluminationcalculate` to Library

### DIFF
--- a/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
+++ b/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
@@ -63,35 +63,21 @@ from cellprofiler_core.setting.subscriber import ImageSubscriber
 from cellprofiler_core.setting.text import Float
 from cellprofiler_core.setting.text import ImageName
 from cellprofiler_core.setting.text import Integer
+from cellprofiler_library.opts.correctilluminationapply import Method as CorrectIlluminationApplyMethod
+from cellprofiler_library.opts.correctilluminationcalculate import (
+    IntensityChoice,
+    RescaleIlluminationFunction,
+    CalculateFunctionTarget,
+    SmoothingMethod,
+    SmoothingFilterSize,
+    SplineBackgroundMode
+)
 
-IC_REGULAR = "Regular"
-IC_BACKGROUND = "Background"
-RE_MEDIAN = "Median"
-EA_EACH = "Each"
 EA_ALL = "All"
-EA_ALL_FIRST = "All: First cycle"
-EA_ALL_ACROSS = "All: Across cycles"
-SRC_LOAD_IMAGES = "Load Images module"
-SRC_PIPELINE = "Pipeline"
-SM_NONE = "No smoothing"
-SM_CONVEX_HULL = "Convex Hull"
-SM_FIT_POLYNOMIAL = "Fit Polynomial"
-SM_MEDIAN_FILTER = "Median Filter"
-SM_GAUSSIAN_FILTER = "Gaussian Filter"
-SM_TO_AVERAGE = "Smooth to Average"
-SM_SPLINES = "Splines"
-
-FI_AUTOMATIC = "Automatic"
-FI_OBJECT_SIZE = "Object size"
-FI_MANUALLY = "Manually"
 
 ROBUST_FACTOR = 0.02  # For rescaling, take 2nd percentile value
 
 OUTPUT_IMAGE = "OutputImage"
-
-DOS_DIVIDE = "Divide"
-DOS_SUBTRACT = "Subtract"
-
 
 class CorrectIlluminationCalculate(Module):
     module_name = "CorrectIlluminationCalculate"
@@ -114,8 +100,8 @@ class CorrectIlluminationCalculate(Module):
 
         self.intensity_choice = Choice(
             "Select how the illumination function is calculated",
-            [IC_REGULAR, IC_BACKGROUND],
-            IC_REGULAR,
+            [IntensityChoice.REGULAR.value, IntensityChoice.BACKGROUND.value],
+            IntensityChoice.REGULAR.value,
             doc="""\
 Choose which method you want to use to calculate the illumination
 function. You may chose from the following options:
@@ -152,12 +138,12 @@ illumination correction function along the interior well edge. Masking
 the image beforehand solves this problem.
 """.format(
                 **{
-                    "IC_REGULAR": IC_REGULAR,
+                    "IC_REGULAR": IntensityChoice.REGULAR.value,
                     "EA_ALL": EA_ALL,
-                    "EA_EACH": EA_EACH,
-                    "SM_NONE": SM_NONE,
-                    "IC_BACKGROUND": IC_BACKGROUND,
-                    "DOS_SUBTRACT": DOS_SUBTRACT,
+                    "EA_EACH": CalculateFunctionTarget.EACH.value,
+                    "SM_NONE": SmoothingMethod.NONE.value,
+                    "IC_BACKGROUND": IntensityChoice.BACKGROUND.value,
+                    "DOS_SUBTRACT": CorrectIlluminationApplyMethod.SUBTRACT.value,
                 }
             ),
         )
@@ -166,15 +152,16 @@ the image beforehand solves this problem.
             "Dilate objects in the final averaged image?",
             False,
             doc="""\
-*(Used only if the “%(IC_REGULAR)s” method is selected)*
+*(Used only if the “{IC_REGULAR}” method is selected)*
 
 For some applications, the incoming images are binary and each object
 should be dilated with a Gaussian filter in the final averaged
 (projection) image. This is for a sophisticated method of illumination
 correction where model objects are produced. Select *Yes* to dilate
 objects for this approach.
-"""
-            % globals(),
+""".format(
+                **{"IC_REGULAR": IntensityChoice.REGULAR.value}
+),
         )
 
         self.object_dilation_radius = Integer(
@@ -182,11 +169,12 @@ objects for this approach.
             1,
             0,
             doc="""\
-*(Used only if the “%(IC_REGULAR)s” method and dilation is selected)*
+*(Used only if the “{IC_REGULAR}” method and dilation is selected)*
 
 This value should be roughly equal to the original radius of the objects.
-"""
-            % globals(),
+""".format(
+                **{"IC_REGULAR": IntensityChoice.REGULAR.value}
+),
         )
 
         self.block_size = Integer(
@@ -194,42 +182,50 @@ This value should be roughly equal to the original radius of the objects.
             60,
             1,
             doc="""\
-*(Used only if “%(IC_BACKGROUND)s” is selected)*
+*(Used only if “{IC_BACKGROUND}” is selected)*
 
 The block size should be large enough that every square block of pixels
 is likely to contain some background pixels, where no objects are
 located.
-"""
-            % globals(),
+""".format(
+                **{"IC_BACKGROUND": IntensityChoice.BACKGROUND.value}
+),
         )
 
         self.rescale_option = Choice(
             "Rescale the illumination function?",
-            ["Yes", "No", RE_MEDIAN],
+            ["Yes", "No", RescaleIlluminationFunction.MEDIAN.value],
             doc="""\
 The illumination function can be rescaled so that the pixel intensities
 are all equal to or greater than 1. You have the following options:
 
 -  *Yes:* Rescaling is recommended if you plan to use the
-   *%(IC_REGULAR)s* method (and hence, the *%(DOS_DIVIDE)s* option in
+   *{IC_REGULAR}* method (and hence, the *{DOS_DIVIDE}* option in
    **CorrectIlluminationApply**). Rescaling the illumination function to
    >1 ensures that the values in your corrected image will stay between
    0-1 after division.
 -  *No:* Rescaling is not recommended if you plan to use the
-   *%(IC_BACKGROUND)s* method, which is paired with the
-   *%(DOS_SUBTRACT)s* option in **CorrectIlluminationApply**. Because
+   *{IC_BACKGROUND}* method, which is paired with the
+   *{DOS_SUBTRACT}* option in **CorrectIlluminationApply**. Because
    rescaling causes the illumination function to have values from 1 to
    infinity, subtracting those values from your image would cause the
    corrected images to be very dark, even negative.
--  %(RE_MEDIAN)s\ *:* This option chooses the median value in the image
+-  {RE_MEDIAN}\ *:* This option chooses the median value in the image
    to rescale so that division increases some values and decreases others.
-"""
-            % globals(),
+""".format(
+                **{
+                    "IC_REGULAR": IntensityChoice.REGULAR.value, 
+                    "IC_BACKGROUND": IntensityChoice.BACKGROUND.value,
+                    "DOS_SUBTRACT": CorrectIlluminationApplyMethod.SUBTRACT.value,
+                    "DOS_DIVIDE": CorrectIlluminationApplyMethod.DIVIDE.value,
+                    "RE_MEDIAN": RescaleIlluminationFunction.MEDIAN.value,
+                    }  
+),
         )
 
         self.each_or_all = Choice(
             "Calculate function for each image individually, or based on all images?",
-            [EA_EACH, EA_ALL_FIRST, EA_ALL_ACROSS],
+            [CalculateFunctionTarget.EACH.value, CalculateFunctionTarget.ALL_FIRST.value, CalculateFunctionTarget.ALL_ACROSS.value],
             doc="""\
 Calculate a separate function for each image, or one for all the
 images? You can calculate the illumination function using just the
@@ -237,9 +233,9 @@ current image or you can calculate the illumination function using all
 of the images in each group (or in the entire experiment). The
 illumination function can be calculated in one of the three ways:
 
--  *%(EA_EACH)s:* Calculate an illumination function for each image
+-  *{EA_EACH}:* Calculate an illumination function for each image
    individually.
--  *%(EA_ALL_FIRST)s:* Calculate an illumination function based on all
+-  *{EA_ALL_FIRST}:* Calculate an illumination function based on all
    of the images in a group, performing the calculation before
    proceeding to the next module. This means that the illumination
    function will be created in the first cycle (making the first cycle
@@ -251,7 +247,7 @@ illumination function can be calculated in one of the three ways:
    other modules will yield an error. Thus, typically,
    **CorrectIlluminationCalculate** will be the first module after the
    input modules.
--  *%(EA_ALL_ACROSS)s:* Calculate an illumination function across all
+-  *{EA_ALL_ACROSS}:* Calculate an illumination function across all
    cycles in each group. This option takes any image as input; however,
    the illumination function will not be completed until the end of the
    last cycle in the group. You can use **SaveImages** to save the
@@ -259,19 +255,24 @@ illumination function can be calculated in one of the three ways:
    the resulting image in another pipeline. The option is useful if you
    want to exclude images that are filtered by a prior **FlagImage**
    module.
-"""
-            % globals(),
+""".format(
+                **{
+                    "EA_EACH": CalculateFunctionTarget.EACH.value, 
+                    "EA_ALL_FIRST": CalculateFunctionTarget.ALL_FIRST.value, 
+                    "EA_ALL_ACROSS": CalculateFunctionTarget.ALL_ACROSS.value
+                   }
+),
         )
         self.smoothing_method = Choice(
             "Smoothing method",
             [
-                SM_NONE,
-                SM_CONVEX_HULL,
-                SM_FIT_POLYNOMIAL,
-                SM_MEDIAN_FILTER,
-                SM_GAUSSIAN_FILTER,
-                SM_TO_AVERAGE,
-                SM_SPLINES,
+                SmoothingMethod.NONE.value,
+                SmoothingMethod.CONVEX_HULL.value,
+                SmoothingMethod.FIT_POLYNOMIAL.value,
+                SmoothingMethod.MEDIAN_FILTER.value,
+                SmoothingMethod.GAUSSIAN_FILTER.value,
+                SmoothingMethod.TO_AVERAGE.value,
+                SmoothingMethod.SPLINES.value,
             ],
             doc="""\
 If requested, the resulting image is smoothed. If you are using *Each* mode,
@@ -284,7 +285,7 @@ illumination problem, apply smoothing until you obtain a fairly smooth
 pattern without sharp bright or dim regions. Note that smoothing is a
 time-consuming process, but some methods are faster than others.
 
--  *%(SM_FIT_POLYNOMIAL)s:* This method is fastest but does not allow
+-  *{SM_FIT_POLYNOMIAL}:* This method is fastest but does not allow
    a very tight “fit” compared to the other methods. Thus, it will usually be less
    accurate. The method treats the intensity of the image
    pixels as a polynomial function of the x and y position of each
@@ -296,24 +297,24 @@ time-consuming process, but some methods are faster than others.
    view), this method will produce an image with a bright central region
    and dimmer edges. But, in some cases the peak/trough of the
    polynomial may actually occur outside of the image itself.
--  *%(SM_MEDIAN_FILTER)s* and *%(SM_GAUSSIAN_FILTER)s:*
+-  *{SM_MEDIAN_FILTER}* and *{SM_GAUSSIAN_FILTER}:*
    We typically recommend
-   *%(SM_MEDIAN_FILTER)s* vs. *%(SM_GAUSSIAN_FILTER)s* because the
+   *{SM_MEDIAN_FILTER}* vs. *{SM_GAUSSIAN_FILTER}* because the
    median is less sensitive to outliers, although the results are also
    slightly less smooth and the fact that images are in the range of 0
    to 1 means that outliers typically will not dominate too strongly
-   anyway. The *%(SM_GAUSSIAN_FILTER)s* convolves the image with a
+   anyway. The *{SM_GAUSSIAN_FILTER}* convolves the image with a
    Gaussian whose full width at half maximum is the artifact diameter
    entered. Its effect is to blur and obscure features smaller than the
    specified diameter and spread bright or dim features larger than the
-   specified diameter. The *%(SM_MEDIAN_FILTER)s* finds the median pixel value within
+   specified diameter. The *{SM_MEDIAN_FILTER}* finds the median pixel value within
    the diameter you specify. It removes bright or dim features
    that are significantly smaller than the specified diameter.
--  *%(SM_TO_AVERAGE)s:* A less commonly used option is to completely
+-  *{SM_TO_AVERAGE}:* A less commonly used option is to completely
    smooth the entire image, which will create a flat, smooth image where
    every pixel of the image is the average of what the illumination
    function would otherwise have been.
--  *%(SM_SPLINES)s:* This method (*Lindblad and Bengtsson, 2001*) fits
+-  *{SM_SPLINES}:* This method (*Lindblad and Bengtsson, 2001*) fits
    a grid of cubic splines to the background while excluding foreground
    pixels from the calculation. It operates iteratively, classifying
    pixels as background, computing a best fit spline to this background
@@ -321,7 +322,7 @@ time-consuming process, but some methods are faster than others.
    converges on its final value. This method is best for backgrounds that
    are highly variable and irregular. Note that the computation time can
    be significant, especially with a large number of control points.
--  *%(SM_CONVEX_HULL)s:* This method can be used on an image whose objects are
+-  *{SM_CONVEX_HULL}:* This method can be used on an image whose objects are
    darker than their background and whose illumination intensity
    decreases monotonically from the brightest point. It proceeds as follows:
    
@@ -336,7 +337,7 @@ time-consuming process, but some methods are faster than others.
    -  Set the intensity of the output image within the convex hull to
       the current intensity
 
-   The *%(SM_CONVEX_HULL)s* method is useful for calculating illumination correction
+   The *{SM_CONVEX_HULL}* method is useful for calculating illumination correction
    images in empty brightfield images. It is a good option if the image contains a whole well.
    The edges of the well will be preserved, where there is a sharp transition in
    intensity, because there is no smoothing involved with this method.
@@ -346,47 +347,62 @@ time-consuming process, but some methods are faster than others.
 of intensity nonuniformities in 2D and 3D microscope images of fluorescence
 stained cells.”, Proceedings of the 12th Scandinavian Conference on Image Analysis
 (SCIA), pp. 264-271
-"""
-            % globals(),
+""".format(
+                **{
+                    "SM_FIT_POLYNOMIAL": SmoothingMethod.FIT_POLYNOMIAL.value,
+                    "SM_MEDIAN_FILTER": SmoothingMethod.MEDIAN_FILTER.value,
+                    "SM_GAUSSIAN_FILTER": SmoothingMethod.GAUSSIAN_FILTER.value,
+                    "SM_TO_AVERAGE": SmoothingMethod.TO_AVERAGE.value,
+                    "SM_SPLINES": SmoothingMethod.SPLINES.value,
+                    "SM_CONVEX_HULL": SmoothingMethod.CONVEX_HULL.value,
+                }
+),
         )
 
         self.automatic_object_width = Choice(
             "Method to calculate smoothing filter size",
-            [FI_AUTOMATIC, FI_OBJECT_SIZE, FI_MANUALLY],
+            [SmoothingFilterSize.AUTOMATIC.value, SmoothingFilterSize.OBJECT_SIZE.value, SmoothingFilterSize.MANUALLY.value],
             doc="""\
 *(Used only if a smoothing method other than Fit Polynomial is selected)*
 
 Calculate the smoothing filter size. There are three options:
 
--  *%(FI_AUTOMATIC)s:* The size is computed as 1/40 the size of the
+-  *{FI_AUTOMATIC}:* The size is computed as 1/40 the size of the
    image or 30 pixels, whichever is smaller.
--  *%(FI_OBJECT_SIZE)s:* The module will calculate the smoothing size
+-  *{FI_OBJECT_SIZE}:* The module will calculate the smoothing size
    based on the width of typical objects in your images.
--  *%(FI_MANUALLY)s:* You can enter a value yourself.
-"""
-            % globals(),
+-  *{FI_MANUALLY}:* You can enter a value yourself.
+""".format(
+                **{
+                    "FI_AUTOMATIC": SmoothingFilterSize.AUTOMATIC.value,
+                    "FI_OBJECT_SIZE": SmoothingFilterSize.OBJECT_SIZE.value,
+                    "FI_MANUALLY": SmoothingFilterSize.MANUALLY.value,
+                }
+),
         )
 
         self.object_width = Integer(
             "Approximate object diameter",
             10,
             doc="""\
-*(Used only if %(FI_OBJECT_SIZE)s is selected for smoothing filter size calculation)*
+*(Used only if {FI_OBJECT_SIZE} is selected for smoothing filter size calculation)*
 
 Enter the approximate diameter of typical objects, in pixels.
-"""
-            % globals(),
+""".format(
+                **{"FI_OBJECT_SIZE": SmoothingFilterSize.OBJECT_SIZE.value}
+),
         )
 
         self.size_of_smoothing_filter = Integer(
             "Smoothing filter size",
             10,
             doc="""\
-*(Used only if %(FI_MANUALLY)s is selected for smoothing filter size calculation)*
+*(Used only if {FI_MANUALLY} is selected for smoothing filter size calculation)*
 
 Enter the size of the desired smoothing filter, in pixels.
-"""
-            % globals(),
+""".format(
+                **{"FI_MANUALLY": SmoothingFilterSize.MANUALLY.value}
+),
         )
 
         self.save_average_image = Binary(
@@ -401,8 +417,7 @@ taking the time to recalculate the averaged image each time.
 
 Select *Yes* to retain this averaged image. Use the **SaveImages**
 module to save it to your hard drive.
-"""
-            % globals(),
+""",
         )
 
         self.average_image_name = ImageName(
@@ -424,8 +439,7 @@ not typically needed for downstream modules.
 
 Select *Yes* to retain this dilated image. Use the **SaveImages**
 module to save it to your hard drive.
-"""
-            % globals(),
+""",
         )
 
         self.dilated_image_name = ImageName(
@@ -442,51 +456,56 @@ the pipeline.""",
             "Automatically calculate spline parameters?",
             True,
             doc="""\
-*(Used only if %(SM_SPLINES)s are selected for the smoothing method)*
+*(Used only if {SM_SPLINES} are selected for the smoothing method)*
 
 Select *Yes* to automatically calculate the parameters for spline
 fitting.
 
 Select *No* to specify the background mode, background threshold,
 scale, maximum number of iterations and convergence.
-"""
-            % globals(),
+""".format(
+                **{"SM_SPLINES": SmoothingMethod.SPLINES.value,}
+),
         )
 
         self.spline_bg_mode = Choice(
             "Background mode",
             [
-                centrosome.bg_compensate.MODE_AUTO,
-                centrosome.bg_compensate.MODE_DARK,
-                centrosome.bg_compensate.MODE_BRIGHT,
-                centrosome.bg_compensate.MODE_GRAY,
+                SplineBackgroundMode.AUTO.value,
+                SplineBackgroundMode.DARK.value,
+                SplineBackgroundMode.BRIGHT.value,
+                SplineBackgroundMode.GRAY.value,
             ],
             doc="""\
-*(Used only if %(SM_SPLINES)s are selected for the smoothing method
+*(Used only if {SM_SPLINES} are selected for the smoothing method
 and spline parameters are not calculated automatically)*
 
 This setting determines which pixels are background and which are
 foreground.
 
--  *{auto}*: Determine the mode from the image. This will set
-   the mode to {dark} if most of the pixels are dark,
-   {bright} if most of the pixels are bright and %(MODE_GRAY)s
+-  *{MODE_AUTO}*: Determine the mode from the image. This will set
+   the mode to {MODE_DARK} if most of the pixels are dark,
+   {MODE_BRIGHT} if most of the pixels are bright and {MODE_GRAY}
    if there are relatively few dark and light pixels relative to the
    number of mid-level pixels
--  *{dark}s*: Fit the spline to the darkest pixels in the image,
+-  *{MODE_DARK}s*: Fit the spline to the darkest pixels in the image,
    excluding brighter pixels from consideration. This may be appropriate
    for a fluorescent image.
--  *{bright}*: Fit the spline to the lightest pixels in the
+-  *{MODE_BRIGHT}*: Fit the spline to the lightest pixels in the
    image, excluding the darker pixels. This may be appropriate for a
    histologically stained image.
--  *{gray}*: Fit the spline to mid-range pixels, excluding both
+-  *{MODE_GRAY}*: Fit the spline to mid-range pixels, excluding both
    dark and light pixels. This may be appropriate for a brightfield
    image where the objects of interest have light and dark features.
 """.format(
-                auto=centrosome.bg_compensate.MODE_AUTO,
-                bright=centrosome.bg_compensate.MODE_BRIGHT,
-                dark=centrosome.bg_compensate.MODE_DARK,
-                gray=centrosome.bg_compensate.MODE_GRAY,
+                **{
+                    "SM_SPLINES": SmoothingMethod.SPLINES.value,
+                    "MODE_AUTO": SplineBackgroundMode.AUTO.value, 
+                    "MODE_BRIGHT": SplineBackgroundMode.BRIGHT.value, 
+                    "MODE_DARK": SplineBackgroundMode.DARK.value, 
+                    "MODE_GRAY": SplineBackgroundMode.GRAY.value
+                    }
+                
             ),
         )
 
@@ -496,7 +515,7 @@ foreground.
             minval=0.1,
             maxval=5.0,
             doc="""\
-*(Used only if %(SM_SPLINES)s are selected for the smoothing method
+*(Used only if {SM_SPLINES} are selected for the smoothing method
 and spline parameters are not calculated automatically)*
 
 This setting determines the cutoff used when excluding foreground
@@ -510,8 +529,9 @@ You should enter a higher number to converge stabily and slowly on a
 final background and a lower number to converge more rapidly, but with
 lower stability. The default for this parameter is two standard
 deviations; this will provide a fairly stable, smooth background estimate.
-"""
-            % globals(),
+""".format(
+            **{"SM_SPLINES": SmoothingMethod.SPLINES.value}
+    ),
         )
 
         self.spline_points = Integer(
@@ -519,7 +539,7 @@ deviations; this will provide a fairly stable, smooth background estimate.
             5,
             4,
             doc="""\
-*(Used only if %(SM_SPLINES)s are selected for the smoothing method and
+*(Used only if {SM_SPLINES} are selected for the smoothing method and
 spline parameters are not calculated automatically)*
 
 This is the number of control points for the spline. A value of 5
@@ -527,8 +547,9 @@ results in a 5x5 grid of splines across the image and is the value
 suggested by the method’s authors. A lower value will give you a more
 stable background while a higher one will fit variations in the
 background more closely and take more time to compute.
-"""
-            % globals(),
+""".format(
+                **{"SM_SPLINES": SmoothingMethod.SPLINES.value}
+),
         )
 
         self.spline_rescale = Float(
@@ -536,7 +557,7 @@ background more closely and take more time to compute.
             2,
             minval=1,
             doc="""\
-*(Used only if %(SM_SPLINES)s are selected for the smoothing method and
+*(Used only if {SM_SPLINES} are selected for the smoothing method and
 spline parameters are not calculated automatically)*
 
 This setting controls how the image is resampled to make a smaller
@@ -545,8 +566,9 @@ if the resampling factor is larger than the diameter of foreground
 objects. The image will be downsampled by the factor you enter. For
 instance, a 500x600 image will be downsampled into a 250x300 image if a
 factor of 2 is entered.
-"""
-            % globals(),
+""".format(
+                **{"SM_SPLINES": SmoothingMethod.SPLINES.value}
+),
         )
 
         self.spline_maximum_iterations = Integer(
@@ -554,14 +576,15 @@ factor of 2 is entered.
             40,
             minval=1,
             doc="""\
-*(Used only if %(SM_SPLINES)s are selected for the smoothing method and
+*(Used only if {SM_SPLINES} are selected for the smoothing method and
 spline parameters are not calculated automatically)*
 
 This setting determines the maximum number of iterations of the
 algorithm to be performed. The algorithm will perform fewer iterations
 if it converges.
-"""
-            % globals(),
+""".format(
+                **{"SM_SPLINES": SmoothingMethod.SPLINES.value}
+),
         )
 
         self.spline_convergence = Float(
@@ -570,7 +593,7 @@ if it converges.
             minval=0.00001,
             maxval=0.1,
             doc="""\
-*(Used only if %(SM_SPLINES)s are selected for the smoothing method
+*(Used only if {SM_SPLINES} are selected for the smoothing method
 and spline parameters are not calculated automatically)*
 
 This setting determines the convergence criterion. The software sets
@@ -585,8 +608,9 @@ iteration is less than the convergence criterion.
 Enter a smaller number for the convergence to calculate a more accurate
 background. Enter a larger number to calculate the background using
 fewer iterations, but less accuracy.
-"""
-            % globals(),
+""".format(
+                **{"SM_SPLINES": SmoothingMethod.SPLINES.value}
+),
         )
 
     def settings(self):
@@ -621,21 +645,21 @@ fewer iterations, but less accuracy.
 
         """
         result = [self.image_name, self.illumination_image_name, self.intensity_choice]
-        if self.intensity_choice == IC_REGULAR:
+        if self.intensity_choice == IntensityChoice.REGULAR.value:
             result += [self.dilate_objects]
             if self.dilate_objects.value:
                 result += [self.object_dilation_radius]
-        elif self.smoothing_method != SM_SPLINES:
+        elif self.smoothing_method != SmoothingMethod.SPLINES.value:
             result += [self.block_size]
 
         result += [self.rescale_option, self.each_or_all, self.smoothing_method]
-        if self.smoothing_method in (SM_GAUSSIAN_FILTER, SM_MEDIAN_FILTER):
+        if self.smoothing_method in (SmoothingMethod.GAUSSIAN_FILTER.value, SmoothingMethod.MEDIAN_FILTER.value):
             result += [self.automatic_object_width]
-            if self.automatic_object_width == FI_OBJECT_SIZE:
+            if self.automatic_object_width == SmoothingFilterSize.OBJECT_SIZE.value:
                 result += [self.object_width]
-            elif self.automatic_object_width == FI_MANUALLY:
+            elif self.automatic_object_width == SmoothingFilterSize.MANUALLY.value:
                 result += [self.size_of_smoothing_filter]
-        elif self.smoothing_method == SM_SPLINES:
+        elif self.smoothing_method == SmoothingMethod.SPLINES.value:
             result += [self.automatic_splines]
             if not self.automatic_splines:
                 result += [
@@ -687,7 +711,7 @@ fewer iterations, but less accuracy.
         assert isinstance(pipeline, Pipeline)
         m = workspace.measurements
         assert isinstance(m, Measurements)
-        if self.each_or_all != EA_EACH and len(image_numbers) > 0:
+        if self.each_or_all != CalculateFunctionTarget.EACH.value and len(image_numbers) > 0:
             title = "#%d: CorrectIlluminationCalculate for %s" % (
                 self.module_num,
                 self.image_name,
@@ -700,7 +724,7 @@ fewer iterations, but less accuracy.
                 self.illumination_image_name.value, self
             )
             d = self.get_dictionary(image_set_list)[OUTPUT_IMAGE] = {}
-            if self.each_or_all == EA_ALL_FIRST:
+            if self.each_or_all == CalculateFunctionTarget.ALL_FIRST.value:
                 #
                 # Find the module that provides the image we need
                 #
@@ -722,12 +746,12 @@ fewer iterations, but less accuracy.
         return True
 
     def run(self, workspace):
-        if self.each_or_all != EA_EACH:
+        if self.each_or_all != CalculateFunctionTarget.EACH.value:
             d = self.get_dictionary(workspace.image_set_list)[OUTPUT_IMAGE]
             output_image_provider = CorrectIlluminationImageProvider.restore_from_state(
                 d, self
             )
-            if self.each_or_all == EA_ALL_ACROSS:
+            if self.each_or_all == CalculateFunctionTarget.ALL_ACROSS.value:
                 #
                 # We are accumulating a pipeline image. Add this image set's
                 # image to the output image provider.
@@ -741,7 +765,7 @@ fewer iterations, but less accuracy.
                 self.show_window
                 or self.save_average_image
                 or self.save_dilated_image
-                or self.each_or_all == EA_ALL_FIRST
+                or self.each_or_all == CalculateFunctionTarget.ALL_FIRST.value
             ):
                 avg_image = output_image_provider.provide_avg_image()
                 dilated_image = output_image_provider.provide_dilated_image()
@@ -772,7 +796,7 @@ fewer iterations, but less accuracy.
 
     def is_aggregation_module(self):
         """Return True if aggregation is performed within a group"""
-        return self.each_or_all != EA_EACH
+        return self.each_or_all != CalculateFunctionTarget.EACH.value
 
     def post_group(self, workspace, grouping):
         """Handle tasks to be performed after a group has been processed
@@ -781,7 +805,7 @@ fewer iterations, but less accuracy.
         set includes the aggregate image. "run" may not have run if an
         image was filtered out.
         """
-        if self.each_or_all != EA_EACH:
+        if self.each_or_all != CalculateFunctionTarget.EACH.value:
             image_set = workspace.image_set
             d = self.get_dictionary(workspace.image_set_list)[OUTPUT_IMAGE]
             output_image_provider = CorrectIlluminationImageProvider.restore_from_state(
@@ -837,9 +861,9 @@ fewer iterations, but less accuracy.
             ["Max value", round(numpy.max(output_image), 2)],
             ["Calculation type", self.intensity_choice.value],
         ]
-        if self.intensity_choice == IC_REGULAR:
+        if self.intensity_choice == IntensityChoice.REGULAR.value:
             statistics.append(["Radius", self.object_dilation_radius.value])
-        elif self.smoothing_method != SM_SPLINES:
+        elif self.smoothing_method != SmoothingMethod.SPLINES.value:
             statistics.append(["Block size", self.block_size.value])
         statistics.append(["Rescaling?", self.rescale_option.value])
         statistics.append(["Each or all?", self.each_or_all.value])
@@ -894,13 +918,13 @@ fewer iterations, but less accuracy.
         """Return the smoothing filter size based on the settings and image size
 
         """
-        if self.automatic_object_width == FI_MANUALLY:
+        if self.automatic_object_width == SmoothingFilterSize.MANUALLY.value:
             # Convert from full-width at half-maximum to standard deviation
             # (or so says CPsmooth.m)
             return self.size_of_smoothing_filter.value
-        elif self.automatic_object_width == FI_OBJECT_SIZE:
+        elif self.automatic_object_width == SmoothingFilterSize.OBJECT_SIZE.value:
             return self.object_width.value * 2.35 / 3.5
-        elif self.automatic_object_width == FI_AUTOMATIC:
+        elif self.automatic_object_width == SmoothingFilterSize.AUTOMATIC.value:
             return min(30, float(numpy.max(image_shape)) / 40.0)
 
     def preprocess_image_for_averaging(self, orig_image):
@@ -908,7 +932,7 @@ fewer iterations, but less accuracy.
 
         """
         pixels = orig_image.pixel_data
-        if self.intensity_choice == IC_REGULAR or self.smoothing_method == SM_SPLINES:
+        if self.intensity_choice == IntensityChoice.REGULAR.value or self.smoothing_method == SmoothingMethod.SPLINES.value:
             if orig_image.has_mask:
                 if pixels.ndim == 2:
                     pixels[~orig_image.mask] = 0
@@ -948,7 +972,7 @@ fewer iterations, but less accuracy.
         orig_image - the ancestor source image or None if ambiguous
         returns another instance of cpimage.Image
         """
-        if self.smoothing_method == SM_NONE:
+        if self.smoothing_method == SmoothingMethod.NONE.value:
             return image
 
         pixel_data = image.pixel_data
@@ -967,9 +991,9 @@ fewer iterations, but less accuracy.
         """Smooth one 2-d color plane of an image"""
 
         sigma = self.smoothing_filter_size(pixel_data.shape) / 2.35
-        if self.smoothing_method == SM_FIT_POLYNOMIAL:
+        if self.smoothing_method == SmoothingMethod.FIT_POLYNOMIAL.value:
             output_pixels = centrosome.smooth.fit_polynomial(pixel_data, mask)
-        elif self.smoothing_method == SM_GAUSSIAN_FILTER:
+        elif self.smoothing_method == SmoothingMethod.GAUSSIAN_FILTER.value:
             #
             # Smoothing with the mask is good, even if there's no mask
             # because the mechanism undoes the edge effects that are introduced
@@ -983,19 +1007,19 @@ fewer iterations, but less accuracy.
             output_pixels = centrosome.smooth.smooth_with_function_and_mask(
                 pixel_data, fn, mask
             )
-        elif self.smoothing_method == SM_MEDIAN_FILTER:
+        elif self.smoothing_method == SmoothingMethod.MEDIAN_FILTER.value:
             filter_sigma = max(1, int(sigma + 0.5))
             strel = centrosome.cpmorphology.strel_disk(filter_sigma)
             rescaled_pixel_data = pixel_data * 65535
             rescaled_pixel_data = rescaled_pixel_data.astype(numpy.uint16)
             rescaled_pixel_data *= mask
             output_pixels = skimage.filters.median(rescaled_pixel_data, strel, behavior="rank")
-        elif self.smoothing_method == SM_TO_AVERAGE:
+        elif self.smoothing_method == SmoothingMethod.TO_AVERAGE.value:
             mean = numpy.mean(pixel_data[mask])
             output_pixels = numpy.ones(pixel_data.shape, pixel_data.dtype) * mean
-        elif self.smoothing_method == SM_SPLINES:
+        elif self.smoothing_method == SmoothingMethod.SPLINES.value:
             output_pixels = self.smooth_with_splines(pixel_data, mask)
-        elif self.smoothing_method == SM_CONVEX_HULL:
+        elif self.smoothing_method == SmoothingMethod.CONVEX_HULL.value:
             output_pixels = self.smooth_with_convex_hull(pixel_data, mask)
         else:
             raise ValueError(
@@ -1071,7 +1095,7 @@ fewer iterations, but less accuracy.
                 robust_minimum = sorted_pixel_data[idx]
                 pixel_data = pixel_data.copy()
                 pixel_data[pixel_data < robust_minimum] = robust_minimum
-            elif self.rescale_option == RE_MEDIAN:
+            elif self.rescale_option == RescaleIlluminationFunction.MEDIAN.value:
                 idx = int(sorted_pixel_data.shape[0] / 2)
                 robust_minimum = sorted_pixel_data[idx]
             if robust_minimum == 0:
@@ -1091,7 +1115,7 @@ fewer iterations, but less accuracy.
         """Produce error if 'All:First' is selected and input image is not provided by the file image provider."""
         if (
             not pipeline.is_image_from_file(self.image_name.value)
-            and self.each_or_all == EA_ALL_FIRST
+            and self.each_or_all == CalculateFunctionTarget.ALL_FIRST.value
         ):
             raise ValidationError(
                 "All: First cycle requires that the input image be provided by the Input modules, or LoadImages/LoadData.",
@@ -1100,17 +1124,17 @@ fewer iterations, but less accuracy.
 
         """Modify the image provider attributes based on other setttings"""
         d = self.illumination_image_name.provided_attributes
-        if self.each_or_all == EA_ALL_ACROSS:
+        if self.each_or_all == CalculateFunctionTarget.ALL_ACROSS.value:
             d["available_on_last"] = True
         elif "available_on_last" in d:
             del d["available_on_last"]
 
     def validate_module_warnings(self, pipeline):
         """Warn user re: Test mode """
-        if self.each_or_all == EA_ALL_FIRST:
+        if self.each_or_all == CalculateFunctionTarget.ALL_FIRST.value:
             raise ValidationError(
                 "Pre-calculation of the illumination function is time-intensive, especially for Test Mode. The analysis will proceed, but consider using '%s' instead."
-                % EA_ALL_ACROSS,
+                % CalculateFunctionTarget.ALL_ACROSS.value,
                 self.each_or_all,
             )
 
@@ -1149,9 +1173,9 @@ fewer iterations, but less accuracy.
         """
         if self.each_or_all == EA_ALL:
             if pipeline.is_image_from_file(self.image_name.value):
-                self.each_or_all.value = EA_ALL_FIRST
+                self.each_or_all.value = CalculateFunctionTarget.ALL_FIRST.value
             else:
-                self.each_or_all.value = EA_ALL_ACROSS
+                self.each_or_all.value = CalculateFunctionTarget.ALL_ACROSS.value
 
 
 class CorrectIlluminationImageProvider(AbstractImage):

--- a/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
+++ b/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
@@ -934,15 +934,6 @@ fewer iterations, but less accuracy.
         if self.smoothing_method == SmoothingMethod.NONE.value:
             return image
 
-        # pixel_data = image.pixel_data
-        # if pixel_data.ndim == 3:
-        #     output_pixels = numpy.zeros(pixel_data.shape, pixel_data.dtype)
-        #     for i in range(pixel_data.shape[2]):
-        #         output_pixels[:, :, i] = self.smooth_plane(
-        #             pixel_data[:, :, i], image.mask
-        #         )
-        # else:
-        #     output_pixels = self.smooth_plane(pixel_data, image.mask)
         output_pixels = apply_smoothing(
             image_pixel_data=image.pixel_data,
             image_mask=image.mask,
@@ -964,92 +955,6 @@ fewer iterations, but less accuracy.
         output_image = Image(output_pixels, parent_image=orig_image)
         return output_image
 
-    # def smooth_plane(self, pixel_data, mask):
-    #     """Smooth one 2-d color plane of an image"""
-
-    #     sigma = self.smoothing_filter_size(pixel_data.shape) / 2.35
-    #     if self.smoothing_method == SmoothingMethod.FIT_POLYNOMIAL.value:
-    #         output_pixels = centrosome.smooth.fit_polynomial(pixel_data, mask)
-    #     elif self.smoothing_method == SmoothingMethod.GAUSSIAN_FILTER.value:
-    #         #
-    #         # Smoothing with the mask is good, even if there's no mask
-    #         # because the mechanism undoes the edge effects that are introduced
-    #         # by any choice of how to deal with border effects.
-    #         #
-    #         def fn(image):
-    #             return scipy.ndimage.gaussian_filter(
-    #                 image, sigma, mode="constant", cval=0
-    #             )
-
-    #         output_pixels = centrosome.smooth.smooth_with_function_and_mask(
-    #             pixel_data, fn, mask
-    #         )
-    #     elif self.smoothing_method == SmoothingMethod.MEDIAN_FILTER.value:
-    #         filter_sigma = max(1, int(sigma + 0.5))
-    #         strel = centrosome.cpmorphology.strel_disk(filter_sigma)
-    #         rescaled_pixel_data = pixel_data * 65535
-    #         rescaled_pixel_data = rescaled_pixel_data.astype(numpy.uint16)
-    #         rescaled_pixel_data *= mask
-    #         output_pixels = skimage.filters.median(rescaled_pixel_data, strel, behavior="rank")
-    #     elif self.smoothing_method == SmoothingMethod.TO_AVERAGE.value:
-    #         mean = numpy.mean(pixel_data[mask])
-    #         output_pixels = numpy.ones(pixel_data.shape, pixel_data.dtype) * mean
-    #     elif self.smoothing_method == SmoothingMethod.SPLINES.value:
-    #         output_pixels = self.smooth_with_splines(pixel_data, mask)
-    #     elif self.smoothing_method == SmoothingMethod.CONVEX_HULL.value:
-    #         output_pixels = self.smooth_with_convex_hull(pixel_data, mask)
-    #     else:
-    #         raise ValueError(
-    #             "Unimplemented smoothing method: %s:" % self.smoothing_method.value
-    #         )
-    #     return output_pixels
-
-    # def smooth_with_convex_hull(self, pixel_data, mask):
-    #     """Use the convex hull transform to smooth the image"""
-    #     #
-    #     # Apply an erosion, then the transform, then a dilation, heuristically
-    #     # to ignore little spikey noisy things.
-    #     #
-    #     image = centrosome.cpmorphology.grey_erosion(pixel_data, 2, mask)
-    #     image = centrosome.filter.convex_hull_transform(image, mask=mask)
-    #     image = centrosome.cpmorphology.grey_dilation(image, 2, mask)
-    #     return image
-
-    # def smooth_with_splines(self, pixel_data, mask):
-    #     if self.automatic_splines:
-    #         # Make the image 200 pixels long on its shortest side
-    #         shortest_side = min(pixel_data.shape)
-    #         if shortest_side < 200:
-    #             scale = 1
-    #         else:
-    #             scale = float(shortest_side) / 200
-    #         result = centrosome.bg_compensate.backgr(pixel_data, mask, scale=scale)
-    #     else:
-    #         mode = self.spline_bg_mode.value
-    #         spline_points = self.spline_points.value
-    #         threshold = self.spline_threshold.value
-    #         convergence = self.spline_convergence.value
-    #         iterations = self.spline_maximum_iterations.value
-    #         rescale = self.spline_rescale.value
-    #         result = centrosome.bg_compensate.backgr(
-    #             pixel_data,
-    #             mask,
-    #             mode=mode,
-    #             thresh=threshold,
-    #             splinepoints=spline_points,
-    #             scale=rescale,
-    #             maxiter=iterations,
-    #             convergence=convergence,
-    #         )
-    #     #
-    #     # The result is a fit to the background intensity, but we
-    #     # want to normalize the intensity by subtraction, leaving
-    #     # the mean intensity alone.
-    #     #
-    #     mean_intensity = numpy.mean(result[mask])
-    #     result[mask] -= mean_intensity
-    #     return result
-
     def apply_scaling(self, image, orig_image=None):
         """Return an image that is rescaled according to the settings
 
@@ -1059,32 +964,6 @@ fewer iterations, but less accuracy.
         if self.rescale_option == "No":
             return image
 
-        # def scaling_fn_2d(pixel_data):
-        #     if image.has_mask:
-        #         sorted_pixel_data = pixel_data[(pixel_data > 0) & image.mask]
-        #     else:
-        #         sorted_pixel_data = pixel_data[pixel_data > 0]
-        #     if sorted_pixel_data.shape[0] == 0:
-        #         return pixel_data
-        #     sorted_pixel_data.sort()
-        #     if self.rescale_option == "Yes":
-        #         idx = int(sorted_pixel_data.shape[0] * ROBUST_FACTOR)
-        #         robust_minimum = sorted_pixel_data[idx]
-        #         pixel_data = pixel_data.copy()
-        #         pixel_data[pixel_data < robust_minimum] = robust_minimum
-        #     elif self.rescale_option == RescaleIlluminationFunction.MEDIAN.value:
-        #         idx = int(sorted_pixel_data.shape[0] / 2)
-        #         robust_minimum = sorted_pixel_data[idx]
-        #     if robust_minimum == 0:
-        #         return pixel_data
-        #     return pixel_data / robust_minimum
-
-        # if image.pixel_data.ndim == 2:
-        #     output_pixels = scaling_fn_2d(image.pixel_data)
-        # else:
-        #     output_pixels = numpy.dstack(
-        #         [scaling_fn_2d(x) for x in image.pixel_data.transpose(2, 0, 1)]
-        #     )
         output_pixels = apply_scaling(image_pixel_data=image.pixel_data, image_mask=None if image.has_mask else image.mask, rescale_option=self.rescale_option.value)
         output_image = Image(output_pixels, parent_image=orig_image)
         return output_image

--- a/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
+++ b/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
@@ -70,15 +70,18 @@ from cellprofiler_library.opts.correctilluminationcalculate import (
     CalculateFunctionTarget,
     SmoothingMethod,
     SmoothingFilterSize,
-    SplineBackgroundMode
+    SplineBackgroundMode,
+    StateKey,
 )
 from cellprofiler_library.modules._correctilluminationcalculate import (
-    apply_smoothing, 
-    apply_dilation, 
-    get_smoothing_filter_size, 
-    preprocess_image_for_averaging, 
-    smooth_plane,
+    apply_smoothing,
+    apply_dilation,
     apply_scaling,
+    get_smoothing_filter_size,
+    preprocess_image_for_averaging,
+    initialize_illumination_accumulation,
+    accumulate_illumination_image,
+    calculate_average_from_state,
 )
 
 EA_ALL = "All"
@@ -726,7 +729,7 @@ fewer iterations, but less accuracy.
                 "CorrectIlluminationCalculate is averaging %d images while "
                 "preparing for run" % (len(image_numbers))
             )
-            output_image_provider = CorrectIlluminationImageProvider(
+            output_image_provider = CorrectIlluminationImageProvider.create(
                 self.illumination_image_name.value, self
             )
             d = self.get_dictionary(image_set_list)[OUTPUT_IMAGE] = {}
@@ -745,7 +748,10 @@ fewer iterations, but less accuracy.
                     workspace, grouping, image_numbers, last_module, title, message
                 ):
                     image = w.image_set.get_image(self.image_name.value, cache=False)
-                    output_image_provider.add_image(image)
+                    if not output_image_provider.has_image:
+                        output_image_provider.set_image(image)
+                    else:
+                        output_image_provider.accumulate_image(image)
                     w.image_set.clear_cache()
             output_image_provider.save_state(d)
 
@@ -754,16 +760,17 @@ fewer iterations, but less accuracy.
     def run(self, workspace):
         if self.each_or_all != CalculateFunctionTarget.EACH.value:
             d = self.get_dictionary(workspace.image_set_list)[OUTPUT_IMAGE]
-            output_image_provider = CorrectIlluminationImageProvider.restore_from_state(
-                d, self
-            )
+            output_image_provider = CorrectIlluminationImageProvider.restore_from_state(d)
             if self.each_or_all == CalculateFunctionTarget.ALL_ACROSS.value:
                 #
                 # We are accumulating a pipeline image. Add this image set's
                 # image to the output image provider.
                 #
                 orig_image = workspace.image_set.get_image(self.image_name.value)
-                output_image_provider.add_image(orig_image)
+                if not output_image_provider.has_image:
+                    output_image_provider.set_image(orig_image)
+                else:
+                    output_image_provider.accumulate_image(orig_image)
                 output_image_provider.save_state(d)
 
             # fetch images for display
@@ -781,11 +788,13 @@ fewer iterations, but less accuracy.
                 workspace.image_set.add_provider(output_image_provider)
         else:
             orig_image = workspace.image_set.get_image(self.image_name.value)
-            pixels = orig_image.pixel_data
-            avg_image = self.preprocess_image_for_averaging(orig_image)
-            dilated_image = self.apply_dilation(avg_image, orig_image)
-            smoothed_image = self.apply_smoothing(dilated_image, orig_image)
-            output_image = self.apply_scaling(smoothed_image, orig_image)
+            output_image_provider = CorrectIlluminationImageProvider.create(
+                self.illumination_image_name.value, self
+            )
+            output_image_provider.set_image(orig_image)
+            avg_image = output_image_provider.provide_avg_image()
+            dilated_image = output_image_provider.provide_dilated_image()
+            output_image = output_image_provider.provide_image(workspace.image_set)
             # for illumination correction, we want the smoothed function to extend beyond the mask.
             output_image.mask = numpy.ones(output_image.pixel_data.shape[:2], bool)
             workspace.image_set.add(self.illumination_image_name.value, output_image)
@@ -814,9 +823,7 @@ fewer iterations, but less accuracy.
         if self.each_or_all != CalculateFunctionTarget.EACH.value:
             image_set = workspace.image_set
             d = self.get_dictionary(workspace.image_set_list)[OUTPUT_IMAGE]
-            output_image_provider = CorrectIlluminationImageProvider.restore_from_state(
-                d, self
-            )
+            output_image_provider = CorrectIlluminationImageProvider.restore_from_state(d)
             assert isinstance(output_image_provider, CorrectIlluminationImageProvider)
             if not self.illumination_image_name.value in image_set.names:
                 workspace.image_set.add_provider(output_image_provider)
@@ -877,96 +884,20 @@ fewer iterations, but less accuracy.
         statistics.append(
             [
                 "Smoothing filter size",
-                round(self.smoothing_filter_size(output_image.size), 2),
+                round(
+                    get_smoothing_filter_size(
+                        self.automatic_object_width.value,
+                        self.size_of_smoothing_filter.value,
+                        self.object_width.value,
+                        output_image.size,
+                    ),
+                    2,
+                ),
             ]
         )
         figure.subplot_table(
             1, 1, [[x[1]] for x in statistics], row_labels=[x[0] for x in statistics]
         )
-
-    def apply_dilation(self, image, orig_image=None):
-        """Return an image that is dilated according to the settings
-
-        image - an instance of cpimage.Image
-
-        returns another instance of cpimage.Image
-        """
-        if self.dilate_objects.value:
-            dilated_pixels = apply_dilation(image, self.object_dilation_radius.value)
-            return Image(dilated_pixels, parent_image=orig_image)
-        else:
-            return image
-
-    def smoothing_filter_size(self, image_shape):
-        """Return the smoothing filter size based on the settings and image size
-
-        """
-        return get_smoothing_filter_size(
-            self.automatic_object_width.value,
-            self.size_of_smoothing_filter.value,
-            self.object_width.value,
-            image_shape
-        )
-
-    def preprocess_image_for_averaging(self, orig_image):
-        """Create a version of the image appropriate for averaging
-
-        """
-        if (self.intensity_choice == IntensityChoice.REGULAR.value or self.smoothing_method == SmoothingMethod.SPLINES.value) and (not orig_image.has_mask):
-            avg_image = orig_image
-        else:
-            _avg_image = preprocess_image_for_averaging(
-                orig_image,
-                self.intensity_choice.value,
-                self.smoothing_method.value,
-                self.block_size.value
-            )
-            avg_image = Image(_avg_image, parent_image=orig_image)
-        return avg_image
-
-    def apply_smoothing(self, image, orig_image=None):
-        """Return an image that is smoothed according to the settings
-
-        image - an instance of cpimage.Image containing the pixels to analyze
-        orig_image - the ancestor source image or None if ambiguous
-        returns another instance of cpimage.Image
-        """
-        if self.smoothing_method == SmoothingMethod.NONE.value:
-            return image
-
-        output_pixels = apply_smoothing(
-            image_pixel_data=image.pixel_data,
-            image_mask=image.mask,
-            smoothing_method=self.smoothing_method.value,
-            # smooth filter size args
-            automatic_object_width=self.automatic_object_width.value,
-            size_of_smoothing_filter=self.size_of_smoothing_filter.value,
-            object_width=self.object_width.value,
-            image_shape=image.pixel_data.shape[:2],
-            # spline args
-            automatic_splines=self.automatic_splines.value,
-            spline_bg_mode=self.spline_bg_mode.value,
-            spline_points=self.spline_points.value,
-            spline_threshold=self.spline_threshold.value,
-            spline_convergence=self.spline_convergence.value,
-            spline_maximum_iterations=self.spline_maximum_iterations.value,
-            spline_rescale=self.spline_rescale.value,
-        )
-        output_image = Image(output_pixels, parent_image=orig_image)
-        return output_image
-
-    def apply_scaling(self, image, orig_image=None):
-        """Return an image that is rescaled according to the settings
-
-        image - an instance of cpimage.Image
-        returns another instance of cpimage.Image
-        """
-        if self.rescale_option == "No":
-            return image
-
-        output_pixels = apply_scaling(image_pixel_data=image.pixel_data, image_mask=None if image.has_mask else image.mask, rescale_option=self.rescale_option.value)
-        output_image = Image(output_pixels, parent_image=orig_image)
-        return output_image
 
     def validate_module(self, pipeline):
         """Produce error if 'All:First' is selected and input image is not provided by the file image provider."""
@@ -1036,122 +967,313 @@ fewer iterations, but less accuracy.
 
 
 class CorrectIlluminationImageProvider(AbstractImage):
-    """CorrectIlluminationImageProvider provides the illumination correction image
+    """Provides the illumination correction image.
 
-    This class accumulates the image data from successive images and
-    calculates the illumination correction image when asked.
+    Accumulates image data from successive images and calculates the
+    illumination correction image on demand.  Follows the same style as
+    MakeProjection.ImageProvider – self-contained, no back-reference to
+    the module.
     """
-
-    def __init__(self, name, module):
-        super(CorrectIlluminationImageProvider, self).__init__()
-        self.__name = name
-        self.__module = module
-        self.__dirty = False
-        self.__image_sum = None
-        self.__mask_count = None
-        self.__cached_image = None
-        self.__cached_avg_image = None
-        self.__cached_dilated_image = None
-        self.__cached_mask_count = None
-
     D_NAME = "name"
-    D_IMAGE_SUM = "image_sum"
-    D_MASK_COUNT = "mask_count"
+    D_LIBRARY_STATE = "library_state"
+    D_INTENSITY_CHOICE = "intensity_choice"
+    D_DILATE_OBJECTS = "dilate_objects"
+    D_OBJECT_DILATION_RADIUS = "object_dilation_radius"
+    D_BLOCK_SIZE = "block_size"
+    D_RESCALE_OPTION = "rescale_option"
+    D_SMOOTHING_METHOD = "smoothing_method"
+    D_AUTOMATIC_OBJECT_WIDTH = "automatic_object_width"
+    D_SIZE_OF_SMOOTHING_FILTER = "size_of_smoothing_filter"
+    D_OBJECT_WIDTH = "object_width"
+    D_AUTOMATIC_SPLINES = "automatic_splines"
+    D_SPLINE_BG_MODE = "spline_bg_mode"
+    D_SPLINE_POINTS = "spline_points"
+    D_SPLINE_THRESHOLD = "spline_threshold"
+    D_SPLINE_CONVERGENCE = "spline_convergence"
+    D_SPLINE_MAXIMUM_ITERATIONS = "spline_maximum_iterations"
+    D_SPLINE_RESCALE = "spline_rescale"
 
-    def save_state(self, d):
-        """Save the internal state of the provider to a dictionary
-
-        d - save to this dictionary, numpy arrays and json serializable only
-        """
-        d[self.D_NAME] = self.__name
-        d[self.D_IMAGE_SUM] = self.__image_sum
-        d[self.D_MASK_COUNT] = self.__mask_count
+    def __init__(
+        self,
+        name,
+        intensity_choice,
+        dilate_objects,
+        object_dilation_radius,
+        block_size,
+        rescale_option,
+        smoothing_method,
+        automatic_object_width,
+        size_of_smoothing_filter,
+        object_width,
+        automatic_splines,
+        spline_bg_mode,
+        spline_points,
+        spline_threshold,
+        spline_convergence,
+        spline_maximum_iterations,
+        spline_rescale,
+    ):
+        super(CorrectIlluminationImageProvider, self).__init__()
+        # TODO: Do we need so many state variables in addition to the library_state? Why not place these inside of it?
+        self._name = name
+        self.intensity_choice = intensity_choice
+        self.dilate_objects = dilate_objects
+        self.object_dilation_radius = object_dilation_radius
+        self.block_size = block_size
+        self.rescale_option = rescale_option
+        self.smoothing_method = smoothing_method
+        self.automatic_object_width = automatic_object_width
+        self.size_of_smoothing_filter = size_of_smoothing_filter
+        self.object_width = object_width
+        self.automatic_splines = automatic_splines
+        self.spline_bg_mode = spline_bg_mode
+        self.spline_points = spline_points
+        self.spline_threshold = spline_threshold
+        self.spline_convergence = spline_convergence
+        self.spline_maximum_iterations = spline_maximum_iterations
+        self.spline_rescale = spline_rescale
+        self.library_state = {}
+        self._cached_image = None
+        self._cached_avg_image = None
+        self._cached_dilated_image = None
 
     @staticmethod
-    def restore_from_state(d, module):
-        """Restore a state saved by serialize
+    def create(name, module):
+        """Factory method: extract settings from the module.
 
-        d - dictionary containing the state
-        module - the module providing details on how to perform the correction
+        Args:
+            name: Name of the output illumination image.
+            module: The CorrectIlluminationCalculate module instance.
 
-        returns a provider set up with the restored state
+        Returns:
+            A new CorrectIlluminationImageProvider configured from module
+            settings.
         """
-        provider = CorrectIlluminationImageProvider(
-            d[CorrectIlluminationImageProvider.D_NAME], module
+        # TODO: look into splitting this into smaller providers with independent, single-purpose functions.
+        return CorrectIlluminationImageProvider(
+            name=name,
+            intensity_choice=module.intensity_choice.value,
+            dilate_objects=module.dilate_objects.value,
+            object_dilation_radius=module.object_dilation_radius.value,
+            block_size=module.block_size.value,
+            rescale_option=module.rescale_option.value,
+            smoothing_method=module.smoothing_method.value,
+            automatic_object_width=module.automatic_object_width.value,
+            size_of_smoothing_filter=module.size_of_smoothing_filter.value,
+            object_width=module.object_width.value,
+            automatic_splines=module.automatic_splines.value,
+            spline_bg_mode=module.spline_bg_mode.value,
+            spline_points=module.spline_points.value,
+            spline_threshold=module.spline_threshold.value,
+            spline_convergence=module.spline_convergence.value,
+            spline_maximum_iterations=module.spline_maximum_iterations.value,
+            spline_rescale=module.spline_rescale.value,
         )
-        provider.__dirty = True
-        provider.__image_sum = d[CorrectIlluminationImageProvider.D_IMAGE_SUM]
-        provider.__mask_count = d[CorrectIlluminationImageProvider.D_MASK_COUNT]
+
+    def save_state(self, d):
+        """Save provider state to a dictionary for cross-cycle persistence.
+
+        Args:
+            d: Dictionary to write state into (numpy arrays and JSON-serializable
+               values only).
+        """
+        # TODO: So many args needed? Look into splitting this into smaller providers with
+        # TODO: independent, single-purpose functions.
+        d[CorrectIlluminationImageProvider.D_NAME] = self._name
+        d[CorrectIlluminationImageProvider.D_LIBRARY_STATE] = self.library_state
+        d[CorrectIlluminationImageProvider.D_INTENSITY_CHOICE] = self.intensity_choice
+        d[CorrectIlluminationImageProvider.D_DILATE_OBJECTS] = self.dilate_objects
+        d[CorrectIlluminationImageProvider.D_OBJECT_DILATION_RADIUS] = self.object_dilation_radius
+        d[CorrectIlluminationImageProvider.D_BLOCK_SIZE] = self.block_size
+        d[CorrectIlluminationImageProvider.D_RESCALE_OPTION] = self.rescale_option
+        d[CorrectIlluminationImageProvider.D_SMOOTHING_METHOD] = self.smoothing_method
+        d[CorrectIlluminationImageProvider.D_AUTOMATIC_OBJECT_WIDTH] = self.automatic_object_width
+        d[CorrectIlluminationImageProvider.D_SIZE_OF_SMOOTHING_FILTER] = self.size_of_smoothing_filter
+        d[CorrectIlluminationImageProvider.D_OBJECT_WIDTH] = self.object_width
+        d[CorrectIlluminationImageProvider.D_AUTOMATIC_SPLINES] = self.automatic_splines
+        d[CorrectIlluminationImageProvider.D_SPLINE_BG_MODE] = self.spline_bg_mode
+        d[CorrectIlluminationImageProvider.D_SPLINE_POINTS] = self.spline_points
+        d[CorrectIlluminationImageProvider.D_SPLINE_THRESHOLD] = self.spline_threshold
+        d[CorrectIlluminationImageProvider.D_SPLINE_CONVERGENCE] = self.spline_convergence
+        d[CorrectIlluminationImageProvider.D_SPLINE_MAXIMUM_ITERATIONS] = self.spline_maximum_iterations
+        d[CorrectIlluminationImageProvider.D_SPLINE_RESCALE] = self.spline_rescale
+
+    @staticmethod
+    def restore_from_state(d):
+        """Reconstruct a provider from a previously saved state dictionary.
+
+        Args:
+            d: Dictionary from a prior call to save_state.
+
+        Returns:
+            A CorrectIlluminationImageProvider restored from d.
+        """
+        P = CorrectIlluminationImageProvider
+        # TODO: So many args needed? Look into splitting this into smaller providers with 
+        # TODO: independent, single-purpose functions.
+        provider = P(
+            name=d[P.D_NAME],
+            intensity_choice=d[P.D_INTENSITY_CHOICE],
+            dilate_objects=d[P.D_DILATE_OBJECTS],
+            object_dilation_radius=d[P.D_OBJECT_DILATION_RADIUS],
+            block_size=d[P.D_BLOCK_SIZE],
+            rescale_option=d[P.D_RESCALE_OPTION],
+            smoothing_method=d[P.D_SMOOTHING_METHOD],
+            automatic_object_width=d[P.D_AUTOMATIC_OBJECT_WIDTH],
+            size_of_smoothing_filter=d[P.D_SIZE_OF_SMOOTHING_FILTER],
+            object_width=d[P.D_OBJECT_WIDTH],
+            automatic_splines=d[P.D_AUTOMATIC_SPLINES],
+            spline_bg_mode=d[P.D_SPLINE_BG_MODE],
+            spline_points=d[P.D_SPLINE_POINTS],
+            spline_threshold=d[P.D_SPLINE_THRESHOLD],
+            spline_convergence=d[P.D_SPLINE_CONVERGENCE],
+            spline_maximum_iterations=d[P.D_SPLINE_MAXIMUM_ITERATIONS],
+            spline_rescale=d[P.D_SPLINE_RESCALE],
+        )
+        provider.library_state = d.get(P.D_LIBRARY_STATE, {})
         return provider
 
-    def add_image(self, image):
-        """Accumulate the data from the given image
-
-        image - an instance of cellprofiler.cpimage.Image, including
-                image data and a mask
-        """
-        self.__dirty = True
-        pimage = self.__module.preprocess_image_for_averaging(image)
-        pixel_data = pimage.pixel_data
-        if self.__image_sum is None:
-            self.__image_sum = numpy.zeros(pixel_data.shape, pixel_data.dtype)
-            self.__mask_count = numpy.zeros(pixel_data.shape[:2], numpy.int32)
-        if image.has_mask:
-            mask = image.mask
-            if self.__image_sum.ndim == 2:
-                self.__image_sum[mask] = self.__image_sum[mask] + pixel_data[mask]
-            else:
-                self.__image_sum[mask, :] = (
-                    self.__image_sum[mask, :] + pixel_data[mask, :]
-                )
-            self.__mask_count[mask] = self.__mask_count[mask] + 1
-        else:
-            self.__image_sum = self.__image_sum + pixel_data
-            self.__mask_count = self.__mask_count + 1
-
     def reset(self):
-        """Reset the image sum at the start of a group"""
-        self.__image_sum = None
-        self.__cached_image = None
-        self.__cached_avg_image = None
-        self.__cached_dilated_image = None
-        self.__cached_mask_count = None
+        """Reset accumulation at the start of a group."""
+        self.library_state = {}
+        self._cached_image = None
+        self._cached_avg_image = None
+        self._cached_dilated_image = None
+
+    @property
+    def has_image(self):
+        """True when at least one image has been accumulated."""
+        return len(self.library_state) > 0
+
+    def set_image(self, image):
+        """Initialize accumulation from the first image.
+
+        Args:
+            image: A cellprofiler_core.image.Image instance.
+        """
+        self._cached_image = None
+        self._cached_avg_image = None
+        self._cached_dilated_image = None
+        mask = image.mask if image.has_mask else None
+        preprocessed = preprocess_image_for_averaging(
+            image.pixel_data,
+            mask,
+            self.intensity_choice,
+            self.smoothing_method,
+            self.block_size,
+        )
+        self.library_state = initialize_illumination_accumulation(
+            preprocessed, mask
+        )
+
+    def accumulate_image(self, image):
+        """Accumulate a subsequent image into the running state.
+
+        Args:
+            image: A cellprofiler_core.image.Image instance.
+        """
+        self._cached_image = None
+        self._cached_avg_image = None
+        self._cached_dilated_image = None
+        mask = image.mask if image.has_mask else None
+        preprocessed = preprocess_image_for_averaging(
+            image.pixel_data,
+            mask,
+            self.intensity_choice,
+            self.smoothing_method,
+            self.block_size,
+        )
+        accumulate_illumination_image(
+            preprocessed, image.has_mask, mask, self.library_state
+        )
 
     def provide_image(self, image_set):
-        if self.__dirty:
-            self.calculate_image()
-        return self.__cached_image
+        # TODO: Currently provide image is updating all caches. Is this necessary?
+        """Return the final illumination correction Image.
 
-    def get_name(self):
-        return self.__name
+        Computes (and caches) the full average -> dilation -> smoothing ->
+        scaling pipeline on the first call; returns the cached result on
+        subsequent calls.
+
+        Args:
+            image_set: The current image set (may be None when called
+                internally to pre-compute intermediate images).
+
+        Returns:
+            cellprofiler_core.image.Image containing the illumination
+            function pixel data.
+        """
+        if self._cached_image is not None:
+            return self._cached_image
+
+        # --- Step 1: compute average ---
+        avg_pixel_data, avg_mask = calculate_average_from_state(self.library_state)
+        self._cached_avg_image = Image(avg_pixel_data, avg_mask)
+
+        # --- Step 2: apply dilation ---
+        if self.dilate_objects:
+            dilated_pixels = apply_dilation(
+                avg_pixel_data, avg_mask, self.object_dilation_radius
+            )
+            self._cached_dilated_image = Image(
+                dilated_pixels, parent_image=self._cached_avg_image
+            )
+        else:
+            self._cached_dilated_image = self._cached_avg_image
+
+        # --- Step 3: apply smoothing ---
+        if self.smoothing_method != SmoothingMethod.NONE.value:
+            dilated_image = self._cached_dilated_image
+            smoothed_pixels = apply_smoothing(
+                image_pixel_data=dilated_image.pixel_data,
+                image_mask=dilated_image.mask,
+                smoothing_method=self.smoothing_method,
+                automatic_object_width=self.automatic_object_width,
+                size_of_smoothing_filter=self.size_of_smoothing_filter,
+                object_width=self.object_width,
+                image_shape=dilated_image.pixel_data.shape[:2],
+                automatic_splines=self.automatic_splines,
+                spline_bg_mode=self.spline_bg_mode,
+                spline_points=self.spline_points,
+                spline_threshold=self.spline_threshold,
+                spline_convergence=self.spline_convergence,
+                spline_maximum_iterations=self.spline_maximum_iterations,
+                spline_rescale=self.spline_rescale,
+            )
+            smoothed_image = Image(smoothed_pixels, parent_image=self._cached_avg_image)
+        else:
+            smoothed_image = self._cached_dilated_image
+
+        # --- Step 4: apply scaling ---
+        if self.rescale_option != "No":
+            output_pixels = apply_scaling(
+                image_pixel_data=smoothed_image.pixel_data,
+                image_mask=None if smoothed_image.has_mask else smoothed_image.mask,
+                rescale_option=self.rescale_option,
+            )
+            self._cached_image = Image(output_pixels, parent_image=self._cached_avg_image)
+        else:
+            self._cached_image = smoothed_image
+
+        return self._cached_image
 
     def provide_avg_image(self):
-        if self.__dirty:
-            self.calculate_image()
-        return self.__cached_avg_image
+        """Return the averaged image (before dilation and smoothing)."""
+        if self._cached_avg_image is None:
+            # TODO: Function call below updates dilate as well and other caches too. Original code did not do this.
+            self.provide_image(None)
+        return self._cached_avg_image
 
     def provide_dilated_image(self):
-        if self.__dirty:
-            self.calculate_image()
-        return self.__cached_dilated_image
+        """Return the dilated image (after dilation, before smoothing)."""
+        if self._cached_dilated_image is None:
+            # TODO: Function call below updates avg as well and other caches too. Original code did not do this.
+            self.provide_image(None)
+        return self._cached_dilated_image
 
-    def calculate_image(self):
-        pixel_data = numpy.zeros(self.__image_sum.shape, self.__image_sum.dtype)
-        mask = self.__mask_count > 0
-        if pixel_data.ndim == 2:
-            pixel_data[mask] = self.__image_sum[mask] / self.__mask_count[mask]
-        else:
-            for i in range(pixel_data.shape[2]):
-                pixel_data[mask, i] = (
-                    self.__image_sum[mask, i] / self.__mask_count[mask]
-                )
-        self.__cached_avg_image = Image(pixel_data, mask)
-        self.__cached_dilated_image = self.__module.apply_dilation(
-            self.__cached_avg_image
-        )
-        smoothed_image = self.__module.apply_smoothing(self.__cached_dilated_image)
-        self.__cached_image = self.__module.apply_scaling(smoothed_image)
-        self.__dirty = False
+    def get_name(self):
+        """Return the name of the output image."""
+        return self._name
 
     def release_memory(self):
         # Memory is released during reset(), so this is a no-op

--- a/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
+++ b/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
@@ -717,14 +717,14 @@ fewer iterations, but less accuracy.
                     image = w.image_set.get_image(self.image_name.value, cache=False)
                     output_image_provider.add_image(image)
                     w.image_set.clear_cache()
-            output_image_provider.serialize(d)
+            output_image_provider.save_state(d)
 
         return True
 
     def run(self, workspace):
         if self.each_or_all != EA_EACH:
             d = self.get_dictionary(workspace.image_set_list)[OUTPUT_IMAGE]
-            output_image_provider = CorrectIlluminationImageProvider.deserialize(
+            output_image_provider = CorrectIlluminationImageProvider.restore_from_state(
                 d, self
             )
             if self.each_or_all == EA_ALL_ACROSS:
@@ -734,7 +734,7 @@ fewer iterations, but less accuracy.
                 #
                 orig_image = workspace.image_set.get_image(self.image_name.value)
                 output_image_provider.add_image(orig_image)
-                output_image_provider.serialize(d)
+                output_image_provider.save_state(d)
 
             # fetch images for display
             if (
@@ -784,7 +784,7 @@ fewer iterations, but less accuracy.
         if self.each_or_all != EA_EACH:
             image_set = workspace.image_set
             d = self.get_dictionary(workspace.image_set_list)[OUTPUT_IMAGE]
-            output_image_provider = CorrectIlluminationImageProvider.deserialize(
+            output_image_provider = CorrectIlluminationImageProvider.restore_from_state(
                 d, self
             )
             assert isinstance(output_image_provider, CorrectIlluminationImageProvider)
@@ -1177,7 +1177,7 @@ class CorrectIlluminationImageProvider(AbstractImage):
     D_IMAGE_SUM = "image_sum"
     D_MASK_COUNT = "mask_count"
 
-    def serialize(self, d):
+    def save_state(self, d):
         """Save the internal state of the provider to a dictionary
 
         d - save to this dictionary, numpy arrays and json serializable only
@@ -1187,7 +1187,7 @@ class CorrectIlluminationImageProvider(AbstractImage):
         d[self.D_MASK_COUNT] = self.__mask_count
 
     @staticmethod
-    def deserialize(d, module):
+    def restore_from_state(d, module):
         """Restore a state saved by serialize
 
         d - dictionary containing the state

--- a/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
+++ b/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
@@ -78,12 +78,10 @@ from cellprofiler_library.modules._correctilluminationcalculate import (
     get_smoothing_filter_size, 
     preprocess_image_for_averaging, 
     smooth_plane,
-    apply_scaling
+    apply_scaling,
 )
 
 EA_ALL = "All"
-
-ROBUST_FACTOR = 0.02  # For rescaling, take 2nd percentile value
 
 OUTPUT_IMAGE = "OutputImage"
 
@@ -1087,7 +1085,7 @@ fewer iterations, but less accuracy.
         #     output_pixels = numpy.dstack(
         #         [scaling_fn_2d(x) for x in image.pixel_data.transpose(2, 0, 1)]
         #     )
-        output_pixels = apply_scaling(image, self.rescale_option.value, orig_image)
+        output_pixels = apply_scaling(image_pixel_data=image.pixel_data, image_mask=None if image.has_mask else image.mask, rescale_option=self.rescale_option.value)
         output_image = Image(output_pixels, parent_image=orig_image)
         return output_image
 

--- a/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
+++ b/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
@@ -1184,7 +1184,7 @@ class CorrectIlluminationImageProvider(AbstractImage):
             self.block_size,
         )
         accumulate_illumination_image(
-            preprocessed, image.has_mask, mask, self.library_state
+            preprocessed, mask, self.library_state
         )
 
     def provide_image(self, image_set):
@@ -1226,7 +1226,7 @@ class CorrectIlluminationImageProvider(AbstractImage):
             dilated_image = self._cached_dilated_image
             smoothed_pixels = apply_smoothing(
                 image_pixel_data=dilated_image.pixel_data,
-                image_mask=dilated_image.mask,
+                image_mask = dilated_image.mask if dilated_image.has_mask else None,
                 smoothing_method=self.smoothing_method,
                 automatic_object_width=self.automatic_object_width,
                 size_of_smoothing_filter=self.size_of_smoothing_filter,
@@ -1248,7 +1248,7 @@ class CorrectIlluminationImageProvider(AbstractImage):
         if self.rescale_option != "No":
             output_pixels = apply_scaling(
                 image_pixel_data=smoothed_image.pixel_data,
-                image_mask=None if smoothed_image.has_mask else smoothed_image.mask,
+                image_mask=smoothed_image.mask if smoothed_image.has_mask else None,
                 rescale_option=self.rescale_option,
             )
             self._cached_image = Image(output_pixels, parent_image=self._cached_avg_image)

--- a/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
+++ b/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
@@ -1179,33 +1179,23 @@ class CorrectIlluminationImageProvider(AbstractImage):
             preprocessed, mask, self.library_state
         )
 
-    def provide_image(self, image_set):
-        # TODO: Currently provide image is updating all caches. Is this necessary?
-        """Return the final illumination correction Image.
+    def _calculate_images(self):
+        """Compute and cache the averaged, dilated, and final illumination images.
 
-        Computes (and caches) the full average -> dilation -> smoothing ->
-        scaling pipeline on the first call; returns the cached result on
-        subsequent calls.
-
-        Args:
-            image_set: The current image set (may be None when called
-                internally to pre-compute intermediate images).
-
-        Returns:
-            cellprofiler_core.image.Image containing the illumination
-            function pixel data.
+        Mirrors the original calculate_image() pattern: each stage receives
+        the previous stage's output as an explicit argument, and all three
+        caches are populated in one pass.
         """
-        if self._cached_image is not None:
-            return self._cached_image
-
-        # --- Step 1: compute average ---
+        # Step 1: compute average from accumulated state
         avg_pixel_data, avg_mask = calculate_average_from_state(self.library_state)
         self._cached_avg_image = Image(avg_pixel_data, avg_mask)
 
-        # --- Step 2: apply dilation ---
+        # Step 2: apply dilation to the averaged image
         if self.dilate_objects:
             dilated_pixels = apply_dilation(
-                avg_pixel_data, avg_mask, self.object_dilation_radius
+                self._cached_avg_image.pixel_data,
+                self._cached_avg_image.mask,
+                self.object_dilation_radius,
             )
             self._cached_dilated_image = Image(
                 dilated_pixels, parent_image=self._cached_avg_image
@@ -1213,17 +1203,16 @@ class CorrectIlluminationImageProvider(AbstractImage):
         else:
             self._cached_dilated_image = self._cached_avg_image
 
-        # --- Step 3: apply smoothing ---
+        # Step 3: apply smoothing to the dilated image
         if self.smoothing_method != SmoothingMethod.NONE.value:
-            dilated_image = self._cached_dilated_image
             smoothed_pixels = apply_smoothing(
-                image_pixel_data=dilated_image.pixel_data,
-                image_mask = dilated_image.mask if dilated_image.has_mask else None,
+                image_pixel_data=self._cached_dilated_image.pixel_data,
+                image_mask=self._cached_dilated_image.mask if self._cached_dilated_image.has_mask else None,
                 smoothing_method=self.smoothing_method,
                 automatic_object_width=self.automatic_object_width,
                 size_of_smoothing_filter=self.size_of_smoothing_filter,
                 object_width=self.object_width,
-                image_shape=dilated_image.pixel_data.shape[:2],
+                image_shape=self._cached_dilated_image.pixel_data.shape[:2],
                 automatic_splines=self.automatic_splines,
                 spline_bg_mode=self.spline_bg_mode,
                 spline_points=self.spline_points,
@@ -1236,8 +1225,8 @@ class CorrectIlluminationImageProvider(AbstractImage):
         else:
             smoothed_image = self._cached_dilated_image
 
-        # --- Step 4: apply scaling ---
-        if self.rescale_option != "No":
+        # Step 4: apply scaling to the smoothed image
+        if self.rescale_option != RescaleIlluminationFunction.NO.value:
             output_pixels = apply_scaling(
                 image_pixel_data=smoothed_image.pixel_data,
                 image_mask=smoothed_image.mask if smoothed_image.has_mask else None,
@@ -1247,21 +1236,32 @@ class CorrectIlluminationImageProvider(AbstractImage):
         else:
             self._cached_image = smoothed_image
 
-        return self._cached_image
-
     def provide_avg_image(self):
         """Return the averaged image (before dilation and smoothing)."""
         if self._cached_avg_image is None:
-            # TODO: Function call below updates dilate as well and other caches too. Original code did not do this.
-            self.provide_image(None)
+            self._calculate_images()
         return self._cached_avg_image
 
     def provide_dilated_image(self):
         """Return the dilated image (after dilation, before smoothing)."""
         if self._cached_dilated_image is None:
-            # TODO: Function call below updates avg as well and other caches too. Original code did not do this.
-            self.provide_image(None)
+            self._calculate_images()
         return self._cached_dilated_image
+
+    def provide_image(self, image_set):
+        """Return the final illumination correction Image.
+
+        Args:
+            image_set: The current image set (may be None when called
+                internally to pre-compute intermediate images).
+
+        Returns:
+            cellprofiler_core.image.Image containing the illumination
+            function pixel data.
+        """
+        if self._cached_image is None:
+            self._calculate_images()
+        return self._cached_image
 
     def get_name(self):
         """Return the name of the output image."""

--- a/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
+++ b/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
@@ -958,14 +958,181 @@ fewer iterations, but less accuracy.
                 self.each_or_all.value = CalculateFunctionTarget.ALL_ACROSS.value
 
 
-class CorrectIlluminationImageProvider(AbstractImage):
-    """Provides the illumination correction image.
+# ============================================================
+# Stage providers — internal pipeline steps used by
+# CorrectIlluminationCalculateProvider.  Each class encapsulates
+# exactly one transformation stage and lazily caches its output.
+# They are never added to the image set directly.
+# ============================================================
 
-    Accumulates image data from successive images and calculates the
-    illumination correction image on demand.  Follows the same style as
-    MakeProjection.ImageProvider – self-contained, no back-reference to
-    the module.
+class _AverageProvider:
+    """Computes the averaged illumination image from the accumulated state.
+
+    Holds a reference to the shared library_state dict.  The dict is
+    always mutated in place by the composite, so this reference never
+    goes stale across save/restore cycles.
     """
+
+    def __init__(self, library_state):
+        self._library_state = library_state
+        self._cached = None
+
+    def provide_image(self, image_set):
+        if self._cached is None:
+            avg_pixel_data, avg_mask = calculate_average_from_state(self._library_state)
+            self._cached = Image(avg_pixel_data, avg_mask)
+        return self._cached
+
+    def invalidate(self):
+        self._cached = None
+
+
+class _DilationProvider:
+    """Applies optional Gaussian dilation to the averaged image.
+
+    Receives the _AverageProvider as its upstream source.  When
+    dilate_objects is False this stage is a transparent pass-through.
+    """
+
+    def __init__(self, avg_provider, dilate_objects, object_dilation_radius):
+        self._avg = avg_provider
+        self.dilate_objects = dilate_objects
+        self.object_dilation_radius = object_dilation_radius
+        self._cached = None
+
+    def provide_image(self, image_set):
+        if self._cached is None:
+            avg_image = self._avg.provide_image(image_set)
+            if self.dilate_objects:
+                dilated_pixels = apply_dilation(
+                    avg_image.pixel_data,
+                    avg_image.mask,
+                    self.object_dilation_radius,
+                )
+                self._cached = Image(dilated_pixels, parent_image=avg_image)
+            else:
+                self._cached = avg_image
+        return self._cached
+
+    def invalidate(self):
+        self._cached = None
+
+
+class _SmoothingProvider:
+    """Applies optional smoothing to the dilated image.
+
+    Receives the _DilationProvider as its upstream source (which in turn
+    receives the _AverageProvider).  When the smoothing method is NONE
+    this stage is a transparent pass-through.
+    """
+
+    def __init__(
+        self,
+        dilated_provider,
+        smoothing_method,
+        automatic_object_width,
+        size_of_smoothing_filter,
+        object_width,
+        automatic_splines,
+        spline_bg_mode,
+        spline_points,
+        spline_threshold,
+        spline_convergence,
+        spline_maximum_iterations,
+        spline_rescale,
+    ):
+        self._dilated = dilated_provider
+        self.smoothing_method = smoothing_method
+        self.automatic_object_width = automatic_object_width
+        self.size_of_smoothing_filter = size_of_smoothing_filter
+        self.object_width = object_width
+        self.automatic_splines = automatic_splines
+        self.spline_bg_mode = spline_bg_mode
+        self.spline_points = spline_points
+        self.spline_threshold = spline_threshold
+        self.spline_convergence = spline_convergence
+        self.spline_maximum_iterations = spline_maximum_iterations
+        self.spline_rescale = spline_rescale
+        self._cached = None
+
+    def provide_image(self, image_set):
+        if self._cached is None:
+            dilated_image = self._dilated.provide_image(image_set)
+            if self.smoothing_method != SmoothingMethod.NONE.value:
+                smoothed_pixels = apply_smoothing(
+                    image_pixel_data=dilated_image.pixel_data,
+                    image_mask=dilated_image.mask if dilated_image.has_mask else None,
+                    smoothing_method=self.smoothing_method,
+                    automatic_object_width=self.automatic_object_width,
+                    size_of_smoothing_filter=self.size_of_smoothing_filter,
+                    object_width=self.object_width,
+                    image_shape=dilated_image.pixel_data.shape[:2],
+                    automatic_splines=self.automatic_splines,
+                    spline_bg_mode=self.spline_bg_mode,
+                    spline_points=self.spline_points,
+                    spline_threshold=self.spline_threshold,
+                    spline_convergence=self.spline_convergence,
+                    spline_maximum_iterations=self.spline_maximum_iterations,
+                    spline_rescale=self.spline_rescale,
+                )
+                self._cached = Image(smoothed_pixels, parent_image=dilated_image)
+            else:
+                self._cached = dilated_image
+        return self._cached
+
+    def invalidate(self):
+        self._cached = None
+
+
+class _ScalingProvider:
+    """Applies optional rescaling to the smoothed image.
+
+    Receives the _SmoothingProvider as its upstream source.  When
+    rescale_option is NO this stage is a transparent pass-through.
+    """
+
+    def __init__(self, smoothed_provider, rescale_option):
+        self._smoothed = smoothed_provider
+        self.rescale_option = rescale_option
+        self._cached = None
+
+    def provide_image(self, image_set):
+        if self._cached is None:
+            smoothed_image = self._smoothed.provide_image(image_set)
+            if self.rescale_option != RescaleIlluminationFunction.NO.value:
+                output_pixels = apply_scaling(
+                    image_pixel_data=smoothed_image.pixel_data,
+                    image_mask=smoothed_image.mask if smoothed_image.has_mask else None,
+                    rescale_option=self.rescale_option,
+                )
+                self._cached = Image(output_pixels, parent_image=smoothed_image)
+            else:
+                self._cached = smoothed_image
+        return self._cached
+
+    def invalidate(self):
+        self._cached = None
+
+
+class CorrectIlluminationImageProvider(AbstractImage):
+    """Composite provider for the illumination correction pipeline.
+
+    Wires four internal stage providers into a linear pipeline:
+
+        _AverageProvider
+            → _DilationProvider
+                → _SmoothingProvider
+                    → _ScalingProvider
+
+    Each stage is independently lazy-cached; requesting only the averaged
+    image does not trigger smoothing or scaling.  The composite coordinates
+    image accumulation and cache invalidation across all stages.
+
+    The library_state dict is always mutated in place so that
+    _AverageProvider's reference to it remains valid across
+    save_state / restore_from_state cycles.
+    """
+
     D_NAME = "name"
     D_LIBRARY_STATE = "library_state"
     D_INTENSITY_CHOICE = "intensity_choice"
@@ -1006,7 +1173,6 @@ class CorrectIlluminationImageProvider(AbstractImage):
         spline_rescale,
     ):
         super(CorrectIlluminationImageProvider, self).__init__()
-        # TODO: Do we need so many state variables in addition to the library_state? Why not place these inside of it?
         self._name = name
         self.intensity_choice = intensity_choice
         self.dilate_objects = dilate_objects
@@ -1024,24 +1190,61 @@ class CorrectIlluminationImageProvider(AbstractImage):
         self.spline_convergence = spline_convergence
         self.spline_maximum_iterations = spline_maximum_iterations
         self.spline_rescale = spline_rescale
+        # library_state is always mutated in place so _AverageProvider's
+        # reference to it stays valid across save_state / restore_from_state.
         self.library_state = {}
-        self._cached_image = None
-        self._cached_avg_image = None
-        self._cached_dilated_image = None
+        self._build_pipeline()
+
+    # ------------------------------------------------------------------
+    # Pipeline construction and cache management
+    # ------------------------------------------------------------------
+
+    def _build_pipeline(self):
+        """Wire the stage providers into a linear pipeline.
+
+        _AverageProvider receives a direct reference to self.library_state;
+        all other stages receive a reference to their upstream provider.
+        """
+        self._avg = _AverageProvider(self.library_state)
+        self._dilated = _DilationProvider(
+            self._avg, self.dilate_objects, self.object_dilation_radius
+        )
+        self._smoothed = _SmoothingProvider(
+            self._dilated,
+            self.smoothing_method,
+            self.automatic_object_width,
+            self.size_of_smoothing_filter,
+            self.object_width,
+            self.automatic_splines,
+            self.spline_bg_mode,
+            self.spline_points,
+            self.spline_threshold,
+            self.spline_convergence,
+            self.spline_maximum_iterations,
+            self.spline_rescale,
+        )
+        self._scaling = _ScalingProvider(self._smoothed, self.rescale_option)
+
+    def _invalidate_pipeline(self):
+        """Clear each stage's cached image."""
+        for stage in (self._avg, self._dilated, self._smoothed, self._scaling):
+            stage.invalidate()
+
+    # ------------------------------------------------------------------
+    # Factory and serialization
+    # ------------------------------------------------------------------
 
     @staticmethod
     def create(name, module):
-        """Factory method: extract settings from the module.
+        """Build a provider from a module's current settings.
 
         Args:
             name: Name of the output illumination image.
             module: The CorrectIlluminationCalculate module instance.
 
         Returns:
-            A new CorrectIlluminationImageProvider configured from module
-            settings.
+            A new CorrectIlluminationCalculateProvider.
         """
-        # TODO: look into splitting this into smaller providers with independent, single-purpose functions.
         return CorrectIlluminationImageProvider(
             name=name,
             intensity_choice=module.intensity_choice.value,
@@ -1063,32 +1266,34 @@ class CorrectIlluminationImageProvider(AbstractImage):
         )
 
     def save_state(self, d):
-        """Save provider state to a dictionary for cross-cycle persistence.
+        """Serialize provider state for cross-cycle persistence.
+
+        Only the accumulation state and settings are serialized; stage
+        caches are ephemeral and always recomputed from the state.
 
         Args:
-            d: Dictionary to write state into (numpy arrays and JSON-serializable
+            d: Dictionary to write into (numpy arrays and JSON-serializable
                values only).
         """
-        # TODO: So many args needed? Look into splitting this into smaller providers with
-        # TODO: independent, single-purpose functions.
-        d[CorrectIlluminationImageProvider.D_NAME] = self._name
-        d[CorrectIlluminationImageProvider.D_LIBRARY_STATE] = self.library_state
-        d[CorrectIlluminationImageProvider.D_INTENSITY_CHOICE] = self.intensity_choice
-        d[CorrectIlluminationImageProvider.D_DILATE_OBJECTS] = self.dilate_objects
-        d[CorrectIlluminationImageProvider.D_OBJECT_DILATION_RADIUS] = self.object_dilation_radius
-        d[CorrectIlluminationImageProvider.D_BLOCK_SIZE] = self.block_size
-        d[CorrectIlluminationImageProvider.D_RESCALE_OPTION] = self.rescale_option
-        d[CorrectIlluminationImageProvider.D_SMOOTHING_METHOD] = self.smoothing_method
-        d[CorrectIlluminationImageProvider.D_AUTOMATIC_OBJECT_WIDTH] = self.automatic_object_width
-        d[CorrectIlluminationImageProvider.D_SIZE_OF_SMOOTHING_FILTER] = self.size_of_smoothing_filter
-        d[CorrectIlluminationImageProvider.D_OBJECT_WIDTH] = self.object_width
-        d[CorrectIlluminationImageProvider.D_AUTOMATIC_SPLINES] = self.automatic_splines
-        d[CorrectIlluminationImageProvider.D_SPLINE_BG_MODE] = self.spline_bg_mode
-        d[CorrectIlluminationImageProvider.D_SPLINE_POINTS] = self.spline_points
-        d[CorrectIlluminationImageProvider.D_SPLINE_THRESHOLD] = self.spline_threshold
-        d[CorrectIlluminationImageProvider.D_SPLINE_CONVERGENCE] = self.spline_convergence
-        d[CorrectIlluminationImageProvider.D_SPLINE_MAXIMUM_ITERATIONS] = self.spline_maximum_iterations
-        d[CorrectIlluminationImageProvider.D_SPLINE_RESCALE] = self.spline_rescale
+        P = CorrectIlluminationImageProvider
+        d[P.D_NAME] = self._name
+        d[P.D_LIBRARY_STATE] = self.library_state
+        d[P.D_INTENSITY_CHOICE] = self.intensity_choice
+        d[P.D_DILATE_OBJECTS] = self.dilate_objects
+        d[P.D_OBJECT_DILATION_RADIUS] = self.object_dilation_radius
+        d[P.D_BLOCK_SIZE] = self.block_size
+        d[P.D_RESCALE_OPTION] = self.rescale_option
+        d[P.D_SMOOTHING_METHOD] = self.smoothing_method
+        d[P.D_AUTOMATIC_OBJECT_WIDTH] = self.automatic_object_width
+        d[P.D_SIZE_OF_SMOOTHING_FILTER] = self.size_of_smoothing_filter
+        d[P.D_OBJECT_WIDTH] = self.object_width
+        d[P.D_AUTOMATIC_SPLINES] = self.automatic_splines
+        d[P.D_SPLINE_BG_MODE] = self.spline_bg_mode
+        d[P.D_SPLINE_POINTS] = self.spline_points
+        d[P.D_SPLINE_THRESHOLD] = self.spline_threshold
+        d[P.D_SPLINE_CONVERGENCE] = self.spline_convergence
+        d[P.D_SPLINE_MAXIMUM_ITERATIONS] = self.spline_maximum_iterations
+        d[P.D_SPLINE_RESCALE] = self.spline_rescale
 
     @staticmethod
     def restore_from_state(d):
@@ -1098,11 +1303,9 @@ class CorrectIlluminationImageProvider(AbstractImage):
             d: Dictionary from a prior call to save_state.
 
         Returns:
-            A CorrectIlluminationImageProvider restored from d.
+            A CorrectIlluminationCalculateProvider restored from d.
         """
         P = CorrectIlluminationImageProvider
-        # TODO: So many args needed? Look into splitting this into smaller providers with 
-        # TODO: independent, single-purpose functions.
         provider = P(
             name=d[P.D_NAME],
             intensity_choice=d[P.D_INTENSITY_CHOICE],
@@ -1122,15 +1325,19 @@ class CorrectIlluminationImageProvider(AbstractImage):
             spline_maximum_iterations=d[P.D_SPLINE_MAXIMUM_ITERATIONS],
             spline_rescale=d[P.D_SPLINE_RESCALE],
         )
-        provider.library_state = d.get(P.D_LIBRARY_STATE, {})
+        # Restore accumulation state in place so _AverageProvider's
+        # reference (established in _build_pipeline) remains valid.
+        provider.library_state.update(d.get(P.D_LIBRARY_STATE, {}))
         return provider
+
+    # ------------------------------------------------------------------
+    # Accumulation
+    # ------------------------------------------------------------------
 
     def reset(self):
         """Reset accumulation at the start of a group."""
-        self.library_state = {}
-        self._cached_image = None
-        self._cached_avg_image = None
-        self._cached_dilated_image = None
+        self.library_state.clear()
+        self._invalidate_pipeline()
 
     @property
     def has_image(self):
@@ -1143,9 +1350,6 @@ class CorrectIlluminationImageProvider(AbstractImage):
         Args:
             image: A cellprofiler_core.image.Image instance.
         """
-        self._cached_image = None
-        self._cached_avg_image = None
-        self._cached_dilated_image = None
         mask = image.mask if image.has_mask else None
         preprocessed = preprocess_image_for_averaging(
             image.pixel_data,
@@ -1154,9 +1358,11 @@ class CorrectIlluminationImageProvider(AbstractImage):
             self.smoothing_method,
             self.block_size,
         )
-        self.library_state = initialize_illumination_accumulation(
-            preprocessed, mask
-        )
+        new_state = initialize_illumination_accumulation(preprocessed, mask)
+        # Mutate in place to keep _AverageProvider's reference valid.
+        self.library_state.clear()
+        self.library_state.update(new_state)
+        self._invalidate_pipeline()
 
     def accumulate_image(self, image):
         """Accumulate a subsequent image into the running state.
@@ -1164,9 +1370,6 @@ class CorrectIlluminationImageProvider(AbstractImage):
         Args:
             image: A cellprofiler_core.image.Image instance.
         """
-        self._cached_image = None
-        self._cached_avg_image = None
-        self._cached_dilated_image = None
         mask = image.mask if image.has_mask else None
         preprocessed = preprocess_image_for_averaging(
             image.pixel_data,
@@ -1175,140 +1378,29 @@ class CorrectIlluminationImageProvider(AbstractImage):
             self.smoothing_method,
             self.block_size,
         )
-        accumulate_illumination_image(
-            preprocessed, mask, self.library_state
-        )
+        accumulate_illumination_image(preprocessed, mask, self.library_state)
+        self._invalidate_pipeline()
 
-    def _calculate_images(self):
-        """Compute and cache the averaged, dilated, and final illumination images.
-
-        Mirrors the original calculate_image() pattern: each stage receives
-        the previous stage's output as an explicit argument, and all three
-        caches are populated in one pass.
-        """
-        # Step 1: compute average from accumulated state
-        avg_pixel_data, avg_mask = calculate_average_from_state(self.library_state)
-        self._cached_avg_image = Image(avg_pixel_data, avg_mask)
-
-        # Step 2: apply dilation to the averaged image
-        if self.dilate_objects:
-            dilated_pixels = apply_dilation(
-                self._cached_avg_image.pixel_data,
-                self._cached_avg_image.mask,
-                self.object_dilation_radius,
-            )
-            self._cached_dilated_image = Image(
-                dilated_pixels, parent_image=self._cached_avg_image
-            )
-        else:
-            self._cached_dilated_image = self._cached_avg_image
-
-        # Step 3: apply smoothing to the dilated image
-        if self.smoothing_method != SmoothingMethod.NONE.value:
-            smoothed_pixels = apply_smoothing(
-                image_pixel_data=self._cached_dilated_image.pixel_data,
-                image_mask=self._cached_dilated_image.mask if self._cached_dilated_image.has_mask else None,
-                smoothing_method=self.smoothing_method,
-                automatic_object_width=self.automatic_object_width,
-                size_of_smoothing_filter=self.size_of_smoothing_filter,
-                object_width=self.object_width,
-                image_shape=self._cached_dilated_image.pixel_data.shape[:2],
-                automatic_splines=self.automatic_splines,
-                spline_bg_mode=self.spline_bg_mode,
-                spline_points=self.spline_points,
-                spline_threshold=self.spline_threshold,
-                spline_convergence=self.spline_convergence,
-                spline_maximum_iterations=self.spline_maximum_iterations,
-                spline_rescale=self.spline_rescale,
-            )
-            smoothed_image = Image(smoothed_pixels, parent_image=self._cached_avg_image)
-        else:
-            smoothed_image = self._cached_dilated_image
-
-        # Step 4: apply scaling to the smoothed image
-        if self.rescale_option != RescaleIlluminationFunction.NO.value:
-            output_pixels = apply_scaling(
-                image_pixel_data=smoothed_image.pixel_data,
-                image_mask=smoothed_image.mask if smoothed_image.has_mask else None,
-                rescale_option=self.rescale_option,
-            )
-            self._cached_image = Image(output_pixels, parent_image=self._cached_avg_image)
-        else:
-            self._cached_image = smoothed_image
+    # ------------------------------------------------------------------
+    # Image access — delegates to stage providers
+    # ------------------------------------------------------------------
 
     def provide_avg_image(self):
         """Return the averaged image (before dilation and smoothing)."""
-        if self._cached_avg_image is None:
-            self._calculate_images()
-        return self._cached_avg_image
+        return self._avg.provide_image(None)
 
     def provide_dilated_image(self):
         """Return the dilated image (after dilation, before smoothing)."""
-        if self._cached_dilated_image is None:
-            self._calculate_images()
-        return self._cached_dilated_image
+        return self._dilated.provide_image(None)
 
     def provide_image(self, image_set):
-        """Return the final illumination correction Image.
-
-        Args:
-            image_set: The current image set (may be None when called
-                internally to pre-compute intermediate images).
-
-        Returns:
-            cellprofiler_core.image.Image containing the illumination
-            function pixel data.
-        """
-        if self._cached_image is None:
-            self._calculate_images()
-        return self._cached_image
+        """Return the final (scaled) illumination correction image."""
+        return self._scaling.provide_image(image_set)
 
     def get_name(self):
-        """Return the name of the output image."""
+        """Return the name of the output illumination image."""
         return self._name
 
     def release_memory(self):
-        # Memory is released during reset(), so this is a no-op
+        # Memory is released during reset(); this is a no-op.
         pass
-
-
-class CorrectIlluminationAvgImageProvider(AbstractImage):
-    """Provide the image after averaging but before dilation and smoothing"""
-
-    def __init__(self, name, ci_provider):
-        """Construct using a parent provider that does the real work
-
-        name - name of the image provided
-        ci_provider - a CorrectIlluminationProvider that does the actual
-                      accumulation and calculation
-        """
-        super(CorrectIlluminationAvgImageProvider, self).__init__()
-        self.__name = name
-        self.__ci_provider = ci_provider
-
-    def provide_image(self, image_set):
-        return self.__ci_provider.provide_avg_image()
-
-    def get_name(self):
-        return self.__name
-
-
-class CorrectIlluminationDilatedImageProvider(AbstractImage):
-    """Provide the image after averaging but before dilation and smoothing"""
-
-    def __init__(self, name, ci_provider):
-        """Construct using a parent provider that does the real work
-
-        name - name of the image provided
-        ci_provider - a CorrectIlluminationProvider that does the actual
-                      accumulation and calculation
-        """
-        super(CorrectIlluminationDilatedImageProvider, self).__init__()
-        self.__name = name
-        self.__ci_provider = ci_provider
-
-    def provide_image(self, image_set):
-        return self.__ci_provider.provide_dilated_image()
-
-    def get_name(self):
-        return self.__name

--- a/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
+++ b/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
@@ -43,14 +43,7 @@ References
 .. _tutorials: https://tutorials.cellprofiler.org
 """
 
-import centrosome.bg_compensate
-import centrosome.cpmorphology
-import centrosome.cpmorphology
-import centrosome.filter
-import centrosome.smooth
 import numpy
-import scipy.ndimage
-import skimage.filters
 from cellprofiler_core.image import AbstractImage
 from cellprofiler_core.image import Image
 from cellprofiler_core.measurement import Measurements
@@ -71,13 +64,12 @@ from cellprofiler_library.opts.correctilluminationcalculate import (
     SmoothingMethod,
     SmoothingFilterSize,
     SplineBackgroundMode,
-    StateKey,
 )
+from cellprofiler_library.functions.image_processing import get_smoothing_filter_size
 from cellprofiler_library.modules._correctilluminationcalculate import (
     apply_smoothing,
     apply_dilation,
     apply_scaling,
-    get_smoothing_filter_size,
     preprocess_image_for_averaging,
     initialize_illumination_accumulation,
     accumulate_illumination_image,
@@ -941,7 +933,7 @@ fewer iterations, but less accuracy.
             # Added spline parameters
             setting_values = setting_values + [
                 "Yes",  # automatic_splines
-                centrosome.bg_compensate.MODE_AUTO,  # spline_bg_mode
+                SplineBackgroundMode.AUTO,  # spline_bg_mode
                 "5",  # spline points
                 "2",  # spline threshold
                 "2",  # spline rescale

--- a/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
+++ b/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
@@ -72,6 +72,14 @@ from cellprofiler_library.opts.correctilluminationcalculate import (
     SmoothingFilterSize,
     SplineBackgroundMode
 )
+from cellprofiler_library.modules._correctilluminationcalculate import (
+    apply_smoothing, 
+    apply_dilation, 
+    get_smoothing_filter_size, 
+    preprocess_image_for_averaging, 
+    smooth_plane,
+    apply_scaling
+)
 
 EA_ALL = "All"
 
@@ -886,30 +894,7 @@ fewer iterations, but less accuracy.
         returns another instance of cpimage.Image
         """
         if self.dilate_objects.value:
-            #
-            # This filter is designed to spread the boundaries of cells
-            # and this "dilates" the cells
-            #
-            kernel = centrosome.smooth.circular_gaussian_kernel(
-                self.object_dilation_radius.value, self.object_dilation_radius.value * 3
-            )
-
-            def fn(image):
-                return scipy.ndimage.convolve(image, kernel, mode="constant", cval=0)
-
-            if image.pixel_data.ndim == 2:
-                dilated_pixels = centrosome.smooth.smooth_with_function_and_mask(
-                    image.pixel_data, fn, image.mask
-                )
-            else:
-                dilated_pixels = numpy.dstack(
-                    [
-                        centrosome.smooth.smooth_with_function_and_mask(
-                            x, fn, image.mask
-                        )
-                        for x in image.pixel_data.transpose(2, 0, 1)
-                    ]
-                )
+            dilated_pixels = apply_dilation(image, self.object_dilation_radius.value)
             return Image(dilated_pixels, parent_image=orig_image)
         else:
             return image
@@ -918,51 +903,27 @@ fewer iterations, but less accuracy.
         """Return the smoothing filter size based on the settings and image size
 
         """
-        if self.automatic_object_width == SmoothingFilterSize.MANUALLY.value:
-            # Convert from full-width at half-maximum to standard deviation
-            # (or so says CPsmooth.m)
-            return self.size_of_smoothing_filter.value
-        elif self.automatic_object_width == SmoothingFilterSize.OBJECT_SIZE.value:
-            return self.object_width.value * 2.35 / 3.5
-        elif self.automatic_object_width == SmoothingFilterSize.AUTOMATIC.value:
-            return min(30, float(numpy.max(image_shape)) / 40.0)
+        return get_smoothing_filter_size(
+            self.automatic_object_width.value,
+            self.size_of_smoothing_filter.value,
+            self.object_width.value,
+            image_shape
+        )
 
     def preprocess_image_for_averaging(self, orig_image):
         """Create a version of the image appropriate for averaging
 
         """
-        pixels = orig_image.pixel_data
-        if self.intensity_choice == IntensityChoice.REGULAR.value or self.smoothing_method == SmoothingMethod.SPLINES.value:
-            if orig_image.has_mask:
-                if pixels.ndim == 2:
-                    pixels[~orig_image.mask] = 0
-                else:
-                    pixels[~orig_image.mask, :] = 0
-                avg_image = Image(pixels, parent_image=orig_image)
-            else:
-                avg_image = orig_image
+        if (self.intensity_choice == IntensityChoice.REGULAR.value or self.smoothing_method == SmoothingMethod.SPLINES.value) and (not orig_image.has_mask):
+            avg_image = orig_image
         else:
-            # For background, we create a labels image using the block
-            # size and find the minimum within each block.
-            labels, indexes = centrosome.cpmorphology.block(
-                pixels.shape[:2], (self.block_size.value, self.block_size.value)
+            _avg_image = preprocess_image_for_averaging(
+                orig_image,
+                self.intensity_choice.value,
+                self.smoothing_method.value,
+                self.block_size.value
             )
-            if orig_image.has_mask:
-                labels[~orig_image.mask] = -1
-
-            min_block = numpy.zeros(pixels.shape)
-            if pixels.ndim == 2:
-                minima = centrosome.cpmorphology.fixup_scipy_ndimage_result(
-                    scipy.ndimage.minimum(pixels, labels, indexes)
-                )
-                min_block[labels != -1] = minima[labels[labels != -1]]
-            else:
-                for i in range(pixels.shape[2]):
-                    minima = centrosome.cpmorphology.fixup_scipy_ndimage_result(
-                        scipy.ndimage.minimum(pixels[:, :, i], labels, indexes)
-                    )
-                    min_block[labels != -1, i] = minima[labels[labels != -1]]
-            avg_image = Image(min_block, parent_image=orig_image)
+            avg_image = Image(_avg_image, parent_image=orig_image)
         return avg_image
 
     def apply_smoothing(self, image, orig_image=None):
@@ -975,103 +936,121 @@ fewer iterations, but less accuracy.
         if self.smoothing_method == SmoothingMethod.NONE.value:
             return image
 
-        pixel_data = image.pixel_data
-        if pixel_data.ndim == 3:
-            output_pixels = numpy.zeros(pixel_data.shape, pixel_data.dtype)
-            for i in range(pixel_data.shape[2]):
-                output_pixels[:, :, i] = self.smooth_plane(
-                    pixel_data[:, :, i], image.mask
-                )
-        else:
-            output_pixels = self.smooth_plane(pixel_data, image.mask)
+        # pixel_data = image.pixel_data
+        # if pixel_data.ndim == 3:
+        #     output_pixels = numpy.zeros(pixel_data.shape, pixel_data.dtype)
+        #     for i in range(pixel_data.shape[2]):
+        #         output_pixels[:, :, i] = self.smooth_plane(
+        #             pixel_data[:, :, i], image.mask
+        #         )
+        # else:
+        #     output_pixels = self.smooth_plane(pixel_data, image.mask)
+        output_pixels = apply_smoothing(
+            image_pixel_data=image.pixel_data,
+            image_mask=image.mask,
+            smoothing_method=self.smoothing_method.value,
+            # smooth filter size args
+            automatic_object_width=self.automatic_object_width.value,
+            size_of_smoothing_filter=self.size_of_smoothing_filter.value,
+            object_width=self.object_width.value,
+            image_shape=image.pixel_data.shape[:2],
+            # spline args
+            automatic_splines=self.automatic_splines.value,
+            spline_bg_mode=self.spline_bg_mode.value,
+            spline_points=self.spline_points.value,
+            spline_threshold=self.spline_threshold.value,
+            spline_convergence=self.spline_convergence.value,
+            spline_maximum_iterations=self.spline_maximum_iterations.value,
+            spline_rescale=self.spline_rescale.value,
+        )
         output_image = Image(output_pixels, parent_image=orig_image)
         return output_image
 
-    def smooth_plane(self, pixel_data, mask):
-        """Smooth one 2-d color plane of an image"""
+    # def smooth_plane(self, pixel_data, mask):
+    #     """Smooth one 2-d color plane of an image"""
 
-        sigma = self.smoothing_filter_size(pixel_data.shape) / 2.35
-        if self.smoothing_method == SmoothingMethod.FIT_POLYNOMIAL.value:
-            output_pixels = centrosome.smooth.fit_polynomial(pixel_data, mask)
-        elif self.smoothing_method == SmoothingMethod.GAUSSIAN_FILTER.value:
-            #
-            # Smoothing with the mask is good, even if there's no mask
-            # because the mechanism undoes the edge effects that are introduced
-            # by any choice of how to deal with border effects.
-            #
-            def fn(image):
-                return scipy.ndimage.gaussian_filter(
-                    image, sigma, mode="constant", cval=0
-                )
+    #     sigma = self.smoothing_filter_size(pixel_data.shape) / 2.35
+    #     if self.smoothing_method == SmoothingMethod.FIT_POLYNOMIAL.value:
+    #         output_pixels = centrosome.smooth.fit_polynomial(pixel_data, mask)
+    #     elif self.smoothing_method == SmoothingMethod.GAUSSIAN_FILTER.value:
+    #         #
+    #         # Smoothing with the mask is good, even if there's no mask
+    #         # because the mechanism undoes the edge effects that are introduced
+    #         # by any choice of how to deal with border effects.
+    #         #
+    #         def fn(image):
+    #             return scipy.ndimage.gaussian_filter(
+    #                 image, sigma, mode="constant", cval=0
+    #             )
 
-            output_pixels = centrosome.smooth.smooth_with_function_and_mask(
-                pixel_data, fn, mask
-            )
-        elif self.smoothing_method == SmoothingMethod.MEDIAN_FILTER.value:
-            filter_sigma = max(1, int(sigma + 0.5))
-            strel = centrosome.cpmorphology.strel_disk(filter_sigma)
-            rescaled_pixel_data = pixel_data * 65535
-            rescaled_pixel_data = rescaled_pixel_data.astype(numpy.uint16)
-            rescaled_pixel_data *= mask
-            output_pixels = skimage.filters.median(rescaled_pixel_data, strel, behavior="rank")
-        elif self.smoothing_method == SmoothingMethod.TO_AVERAGE.value:
-            mean = numpy.mean(pixel_data[mask])
-            output_pixels = numpy.ones(pixel_data.shape, pixel_data.dtype) * mean
-        elif self.smoothing_method == SmoothingMethod.SPLINES.value:
-            output_pixels = self.smooth_with_splines(pixel_data, mask)
-        elif self.smoothing_method == SmoothingMethod.CONVEX_HULL.value:
-            output_pixels = self.smooth_with_convex_hull(pixel_data, mask)
-        else:
-            raise ValueError(
-                "Unimplemented smoothing method: %s:" % self.smoothing_method.value
-            )
-        return output_pixels
+    #         output_pixels = centrosome.smooth.smooth_with_function_and_mask(
+    #             pixel_data, fn, mask
+    #         )
+    #     elif self.smoothing_method == SmoothingMethod.MEDIAN_FILTER.value:
+    #         filter_sigma = max(1, int(sigma + 0.5))
+    #         strel = centrosome.cpmorphology.strel_disk(filter_sigma)
+    #         rescaled_pixel_data = pixel_data * 65535
+    #         rescaled_pixel_data = rescaled_pixel_data.astype(numpy.uint16)
+    #         rescaled_pixel_data *= mask
+    #         output_pixels = skimage.filters.median(rescaled_pixel_data, strel, behavior="rank")
+    #     elif self.smoothing_method == SmoothingMethod.TO_AVERAGE.value:
+    #         mean = numpy.mean(pixel_data[mask])
+    #         output_pixels = numpy.ones(pixel_data.shape, pixel_data.dtype) * mean
+    #     elif self.smoothing_method == SmoothingMethod.SPLINES.value:
+    #         output_pixels = self.smooth_with_splines(pixel_data, mask)
+    #     elif self.smoothing_method == SmoothingMethod.CONVEX_HULL.value:
+    #         output_pixels = self.smooth_with_convex_hull(pixel_data, mask)
+    #     else:
+    #         raise ValueError(
+    #             "Unimplemented smoothing method: %s:" % self.smoothing_method.value
+    #         )
+    #     return output_pixels
 
-    def smooth_with_convex_hull(self, pixel_data, mask):
-        """Use the convex hull transform to smooth the image"""
-        #
-        # Apply an erosion, then the transform, then a dilation, heuristically
-        # to ignore little spikey noisy things.
-        #
-        image = centrosome.cpmorphology.grey_erosion(pixel_data, 2, mask)
-        image = centrosome.filter.convex_hull_transform(image, mask=mask)
-        image = centrosome.cpmorphology.grey_dilation(image, 2, mask)
-        return image
+    # def smooth_with_convex_hull(self, pixel_data, mask):
+    #     """Use the convex hull transform to smooth the image"""
+    #     #
+    #     # Apply an erosion, then the transform, then a dilation, heuristically
+    #     # to ignore little spikey noisy things.
+    #     #
+    #     image = centrosome.cpmorphology.grey_erosion(pixel_data, 2, mask)
+    #     image = centrosome.filter.convex_hull_transform(image, mask=mask)
+    #     image = centrosome.cpmorphology.grey_dilation(image, 2, mask)
+    #     return image
 
-    def smooth_with_splines(self, pixel_data, mask):
-        if self.automatic_splines:
-            # Make the image 200 pixels long on its shortest side
-            shortest_side = min(pixel_data.shape)
-            if shortest_side < 200:
-                scale = 1
-            else:
-                scale = float(shortest_side) / 200
-            result = centrosome.bg_compensate.backgr(pixel_data, mask, scale=scale)
-        else:
-            mode = self.spline_bg_mode.value
-            spline_points = self.spline_points.value
-            threshold = self.spline_threshold.value
-            convergence = self.spline_convergence.value
-            iterations = self.spline_maximum_iterations.value
-            rescale = self.spline_rescale.value
-            result = centrosome.bg_compensate.backgr(
-                pixel_data,
-                mask,
-                mode=mode,
-                thresh=threshold,
-                splinepoints=spline_points,
-                scale=rescale,
-                maxiter=iterations,
-                convergence=convergence,
-            )
-        #
-        # The result is a fit to the background intensity, but we
-        # want to normalize the intensity by subtraction, leaving
-        # the mean intensity alone.
-        #
-        mean_intensity = numpy.mean(result[mask])
-        result[mask] -= mean_intensity
-        return result
+    # def smooth_with_splines(self, pixel_data, mask):
+    #     if self.automatic_splines:
+    #         # Make the image 200 pixels long on its shortest side
+    #         shortest_side = min(pixel_data.shape)
+    #         if shortest_side < 200:
+    #             scale = 1
+    #         else:
+    #             scale = float(shortest_side) / 200
+    #         result = centrosome.bg_compensate.backgr(pixel_data, mask, scale=scale)
+    #     else:
+    #         mode = self.spline_bg_mode.value
+    #         spline_points = self.spline_points.value
+    #         threshold = self.spline_threshold.value
+    #         convergence = self.spline_convergence.value
+    #         iterations = self.spline_maximum_iterations.value
+    #         rescale = self.spline_rescale.value
+    #         result = centrosome.bg_compensate.backgr(
+    #             pixel_data,
+    #             mask,
+    #             mode=mode,
+    #             thresh=threshold,
+    #             splinepoints=spline_points,
+    #             scale=rescale,
+    #             maxiter=iterations,
+    #             convergence=convergence,
+    #         )
+    #     #
+    #     # The result is a fit to the background intensity, but we
+    #     # want to normalize the intensity by subtraction, leaving
+    #     # the mean intensity alone.
+    #     #
+    #     mean_intensity = numpy.mean(result[mask])
+    #     result[mask] -= mean_intensity
+    #     return result
 
     def apply_scaling(self, image, orig_image=None):
         """Return an image that is rescaled according to the settings
@@ -1082,32 +1061,33 @@ fewer iterations, but less accuracy.
         if self.rescale_option == "No":
             return image
 
-        def scaling_fn_2d(pixel_data):
-            if image.has_mask:
-                sorted_pixel_data = pixel_data[(pixel_data > 0) & image.mask]
-            else:
-                sorted_pixel_data = pixel_data[pixel_data > 0]
-            if sorted_pixel_data.shape[0] == 0:
-                return pixel_data
-            sorted_pixel_data.sort()
-            if self.rescale_option == "Yes":
-                idx = int(sorted_pixel_data.shape[0] * ROBUST_FACTOR)
-                robust_minimum = sorted_pixel_data[idx]
-                pixel_data = pixel_data.copy()
-                pixel_data[pixel_data < robust_minimum] = robust_minimum
-            elif self.rescale_option == RescaleIlluminationFunction.MEDIAN.value:
-                idx = int(sorted_pixel_data.shape[0] / 2)
-                robust_minimum = sorted_pixel_data[idx]
-            if robust_minimum == 0:
-                return pixel_data
-            return pixel_data / robust_minimum
+        # def scaling_fn_2d(pixel_data):
+        #     if image.has_mask:
+        #         sorted_pixel_data = pixel_data[(pixel_data > 0) & image.mask]
+        #     else:
+        #         sorted_pixel_data = pixel_data[pixel_data > 0]
+        #     if sorted_pixel_data.shape[0] == 0:
+        #         return pixel_data
+        #     sorted_pixel_data.sort()
+        #     if self.rescale_option == "Yes":
+        #         idx = int(sorted_pixel_data.shape[0] * ROBUST_FACTOR)
+        #         robust_minimum = sorted_pixel_data[idx]
+        #         pixel_data = pixel_data.copy()
+        #         pixel_data[pixel_data < robust_minimum] = robust_minimum
+        #     elif self.rescale_option == RescaleIlluminationFunction.MEDIAN.value:
+        #         idx = int(sorted_pixel_data.shape[0] / 2)
+        #         robust_minimum = sorted_pixel_data[idx]
+        #     if robust_minimum == 0:
+        #         return pixel_data
+        #     return pixel_data / robust_minimum
 
-        if image.pixel_data.ndim == 2:
-            output_pixels = scaling_fn_2d(image.pixel_data)
-        else:
-            output_pixels = numpy.dstack(
-                [scaling_fn_2d(x) for x in image.pixel_data.transpose(2, 0, 1)]
-            )
+        # if image.pixel_data.ndim == 2:
+        #     output_pixels = scaling_fn_2d(image.pixel_data)
+        # else:
+        #     output_pixels = numpy.dstack(
+        #         [scaling_fn_2d(x) for x in image.pixel_data.transpose(2, 0, 1)]
+        #     )
+        output_pixels = apply_scaling(image, self.rescale_option.value, orig_image)
         output_image = Image(output_pixels, parent_image=orig_image)
         return output_image
 

--- a/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
+++ b/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
@@ -707,12 +707,14 @@ fewer iterations, but less accuracy.
         ]
 
     def prepare_group(self, workspace, grouping, image_numbers):
+        if self.each_or_all == CalculateFunctionTarget.EACH.value or len(image_numbers) == 0:
+            return True
+
         image_set_list = workspace.image_set_list
-        pipeline = workspace.pipeline
-        assert isinstance(pipeline, Pipeline)
-        m = workspace.measurements
-        assert isinstance(m, Measurements)
-        if self.each_or_all != CalculateFunctionTarget.EACH.value and len(image_numbers) > 0:
+        output_image_provider = CorrectIlluminationImageProvider.create(
+            self.illumination_image_name.value, self
+        )
+        if self.each_or_all == CalculateFunctionTarget.ALL_FIRST.value:
             title = "#%d: CorrectIlluminationCalculate for %s" % (
                 self.module_num,
                 self.image_name,
@@ -721,31 +723,29 @@ fewer iterations, but less accuracy.
                 "CorrectIlluminationCalculate is averaging %d images while "
                 "preparing for run" % (len(image_numbers))
             )
-            output_image_provider = CorrectIlluminationImageProvider.create(
-                self.illumination_image_name.value, self
+            pipeline = workspace.pipeline
+            assert isinstance(pipeline, Pipeline)
+            #
+            # Find the module that provides the image we need
+            #
+            md = workspace.pipeline.get_provider_dictionary(
+                self.image_name.group, self
             )
-            d = self.get_dictionary(image_set_list)[OUTPUT_IMAGE] = {}
-            if self.each_or_all == CalculateFunctionTarget.ALL_FIRST.value:
-                #
-                # Find the module that provides the image we need
-                #
-                md = workspace.pipeline.get_provider_dictionary(
-                    self.image_name.group, self
-                )
-                src_module, src_setting = md[self.image_name.value][-1]
-                modules = list(pipeline.modules())
-                idx = modules.index(src_module)
-                last_module = modules[idx + 1]
-                for w in pipeline.run_group_with_yield(
-                    workspace, grouping, image_numbers, last_module, title, message
-                ):
-                    image = w.image_set.get_image(self.image_name.value, cache=False)
-                    if not output_image_provider.has_image:
-                        output_image_provider.set_image(image)
-                    else:
-                        output_image_provider.accumulate_image(image)
-                    w.image_set.clear_cache()
-            output_image_provider.save_state(d)
+            src_module, src_setting = md[self.image_name.value][-1]
+            modules = list(pipeline.modules())
+            idx = modules.index(src_module)
+            last_module = modules[idx + 1]
+            for w in pipeline.run_group_with_yield(
+                workspace, grouping, image_numbers, last_module, title, message
+            ):
+                image = w.image_set.get_image(self.image_name.value, cache=False)
+                if not output_image_provider.has_image:
+                    output_image_provider.set_image(image)
+                else:
+                    output_image_provider.accumulate_image(image)
+                w.image_set.clear_cache()
+        d = self.get_dictionary(image_set_list)[OUTPUT_IMAGE] = {}
+        output_image_provider.save_state(d)
 
         return True
 

--- a/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
+++ b/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
@@ -46,11 +46,8 @@ References
 import numpy
 from cellprofiler_core.image import AbstractImage
 from cellprofiler_core.image import Image
-from cellprofiler_core.measurement import Measurements
 from cellprofiler_core.module import Module
-from cellprofiler_core.pipeline import Pipeline
 from cellprofiler_core.setting import Binary
-from cellprofiler_core.setting import ValidationError
 from cellprofiler_core.setting.choice import Choice
 from cellprofiler_core.setting.subscriber import ImageSubscriber
 from cellprofiler_core.setting.text import Float
@@ -76,13 +73,11 @@ from cellprofiler_library.modules._correctilluminationcalculate import (
     calculate_average_from_state,
 )
 
-EA_ALL = "All"
-
 OUTPUT_IMAGE = "OutputImage"
 
 class CorrectIlluminationCalculate(Module):
     module_name = "CorrectIlluminationCalculate"
-    variable_revision_number = 2
+    variable_revision_number = 3
     category = "Image Processing"
 
     def create_settings(self):
@@ -140,7 +135,7 @@ the image beforehand solves this problem.
 """.format(
                 **{
                     "IC_REGULAR": IntensityChoice.REGULAR.value,
-                    "EA_ALL": EA_ALL,
+                    "EA_ALL": CalculateFunctionTarget.ALL.value,
                     "EA_EACH": CalculateFunctionTarget.EACH.value,
                     "SM_NONE": SmoothingMethod.NONE.value,
                     "IC_BACKGROUND": IntensityChoice.BACKGROUND.value,
@@ -226,7 +221,7 @@ are all equal to or greater than 1. You have the following options:
 
         self.each_or_all = Choice(
             "Calculate function for each image individually, or based on all images?",
-            [CalculateFunctionTarget.EACH.value, CalculateFunctionTarget.ALL_FIRST.value, CalculateFunctionTarget.ALL_ACROSS.value],
+            [CalculateFunctionTarget.EACH.value, CalculateFunctionTarget.ALL.value],
             doc="""\
 Calculate a separate function for each image, or one for all the
 images? You can calculate the illumination function using just the
@@ -236,19 +231,7 @@ illumination function can be calculated in one of the three ways:
 
 -  *{EA_EACH}:* Calculate an illumination function for each image
    individually.
--  *{EA_ALL_FIRST}:* Calculate an illumination function based on all
-   of the images in a group, performing the calculation before
-   proceeding to the next module. This means that the illumination
-   function will be created in the first cycle (making the first cycle
-   longer than subsequent cycles), and lets you use the function in a
-   subsequent **CorrectIlluminationApply** module in the same
-   pipeline, but also means that you will not have the ability to filter
-   out images (e.g., by using **FlagImage**). The input images need to
-   be assembled using the **Input** modules; using images produced by
-   other modules will yield an error. Thus, typically,
-   **CorrectIlluminationCalculate** will be the first module after the
-   input modules.
--  *{EA_ALL_ACROSS}:* Calculate an illumination function across all
+-  *{EA_ALL}:* Calculate an illumination function across all
    cycles in each group. This option takes any image as input; however,
    the illumination function will not be completed until the end of the
    last cycle in the group. You can use **SaveImages** to save the
@@ -259,8 +242,7 @@ illumination function can be calculated in one of the three ways:
 """.format(
                 **{
                     "EA_EACH": CalculateFunctionTarget.EACH.value, 
-                    "EA_ALL_FIRST": CalculateFunctionTarget.ALL_FIRST.value, 
-                    "EA_ALL_ACROSS": CalculateFunctionTarget.ALL_ACROSS.value
+                    "EA_ALL": CalculateFunctionTarget.ALL.value
                    }
 ),
         )
@@ -714,87 +696,47 @@ fewer iterations, but less accuracy.
         output_image_provider = CorrectIlluminationImageProvider.create(
             self.illumination_image_name.value, self
         )
-        if self.each_or_all == CalculateFunctionTarget.ALL_FIRST.value:
-            title = "#%d: CorrectIlluminationCalculate for %s" % (
-                self.module_num,
-                self.image_name,
-            )
-            message = (
-                "CorrectIlluminationCalculate is averaging %d images while "
-                "preparing for run" % (len(image_numbers))
-            )
-            pipeline = workspace.pipeline
-            assert isinstance(pipeline, Pipeline)
-            #
-            # Find the module that provides the image we need
-            #
-            md = workspace.pipeline.get_provider_dictionary(
-                self.image_name.group, self
-            )
-            src_module, src_setting = md[self.image_name.value][-1]
-            modules = list(pipeline.modules())
-            idx = modules.index(src_module)
-            last_module = modules[idx + 1]
-            for w in pipeline.run_group_with_yield(
-                workspace, grouping, image_numbers, last_module, title, message
-            ):
-                image = w.image_set.get_image(self.image_name.value, cache=False)
-                if not output_image_provider.has_image:
-                    output_image_provider.set_image(image)
-                else:
-                    output_image_provider.accumulate_image(image)
-                w.image_set.clear_cache()
         d = self.get_dictionary(image_set_list)[OUTPUT_IMAGE] = {}
         output_image_provider.save_state(d)
 
         return True
 
     def run(self, workspace):
-        if self.each_or_all != CalculateFunctionTarget.EACH.value:
+        if self.each_or_all == CalculateFunctionTarget.ALL.value:
+            orig_image = workspace.image_set.get_image(self.image_name.value)
             d = self.get_dictionary(workspace.image_set_list)[OUTPUT_IMAGE]
             output_image_provider = CorrectIlluminationImageProvider.restore_from_state(d)
-            if self.each_or_all == CalculateFunctionTarget.ALL_ACROSS.value:
-                #
-                # We are accumulating a pipeline image. Add this image set's
-                # image to the output image provider.
-                #
-                orig_image = workspace.image_set.get_image(self.image_name.value)
-                if not output_image_provider.has_image:
-                    output_image_provider.set_image(orig_image)
-                else:
-                    output_image_provider.accumulate_image(orig_image)
-                output_image_provider.save_state(d)
 
-            # fetch images for display
-            if (
-                self.show_window
-                or self.save_average_image
-                or self.save_dilated_image
-                or self.each_or_all == CalculateFunctionTarget.ALL_FIRST.value
-            ):
-                avg_image = output_image_provider.provide_avg_image()
-                dilated_image = output_image_provider.provide_dilated_image()
-                workspace.image_set.add_provider(output_image_provider)
-                output_image = output_image_provider.provide_image(workspace.image_set)
+            if not output_image_provider.has_image:
+                output_image_provider.set_image(orig_image)
             else:
-                workspace.image_set.add_provider(output_image_provider)
-        else:
+                output_image_provider.accumulate_image(orig_image)
+            output_image_provider.save_state(d)
+
+            if self.show_window:
+                output_image = output_image_provider.provide_image(workspace.image_set)
+
+            workspace.image_set.add_provider(output_image_provider)
+        else: # CalculateFunctionTarget.EACH.value
             orig_image = workspace.image_set.get_image(self.image_name.value)
             output_image_provider = CorrectIlluminationImageProvider.create(
                 self.illumination_image_name.value, self
             )
             output_image_provider.set_image(orig_image)
-            avg_image = output_image_provider.provide_avg_image()
-            dilated_image = output_image_provider.provide_dilated_image()
+
             output_image = output_image_provider.provide_image(workspace.image_set)
             # for illumination correction, we want the smoothed function to extend beyond the mask.
             output_image.mask = numpy.ones(output_image.pixel_data.shape[:2], bool)
             workspace.image_set.add(self.illumination_image_name.value, output_image)
 
-        if self.save_average_image.value:
-            workspace.image_set.add(self.average_image_name.value, avg_image)
-        if self.save_dilated_image.value:
-            workspace.image_set.add(self.dilated_image_name.value, dilated_image)
+        if self.show_window or self.save_average_image:
+            avg_image = output_image_provider.provide_avg_image()
+            if self.save_average_image.value:
+                workspace.image_set.add(self.average_image_name.value, avg_image)
+        if self.show_window or self.save_dilated_image:
+            dilated_image = output_image_provider.provide_dilated_image()
+            if self.save_dilated_image.value:
+                workspace.image_set.add(self.dilated_image_name.value, dilated_image)
         if self.show_window:
             # store images for potential display
             workspace.display_data.avg_image = avg_image.pixel_data
@@ -817,7 +759,7 @@ fewer iterations, but less accuracy.
             d = self.get_dictionary(workspace.image_set_list)[OUTPUT_IMAGE]
             output_image_provider = CorrectIlluminationImageProvider.restore_from_state(d)
             assert isinstance(output_image_provider, CorrectIlluminationImageProvider)
-            if not self.illumination_image_name.value in image_set.names:
+            if self.illumination_image_name.value not in image_set.names:
                 workspace.image_set.add_provider(output_image_provider)
             if (
                 self.save_average_image
@@ -892,31 +834,12 @@ fewer iterations, but less accuracy.
         )
 
     def validate_module(self, pipeline):
-        """Produce error if 'All:First' is selected and input image is not provided by the file image provider."""
-        if (
-            not pipeline.is_image_from_file(self.image_name.value)
-            and self.each_or_all == CalculateFunctionTarget.ALL_FIRST.value
-        ):
-            raise ValidationError(
-                "All: First cycle requires that the input image be provided by the Input modules, or LoadImages/LoadData.",
-                self.each_or_all,
-            )
-
-        """Modify the image provider attributes based on other setttings"""
+        """Modify the image provider attributes based setttings"""
         d = self.illumination_image_name.provided_attributes
-        if self.each_or_all == CalculateFunctionTarget.ALL_ACROSS.value:
+        if self.each_or_all == CalculateFunctionTarget.ALL.value:
             d["available_on_last"] = True
         elif "available_on_last" in d:
             del d["available_on_last"]
-
-    def validate_module_warnings(self, pipeline):
-        """Warn user re: Test mode """
-        if self.each_or_all == CalculateFunctionTarget.ALL_FIRST.value:
-            raise ValidationError(
-                "Pre-calculation of the illumination function is time-intensive, especially for Test Mode. The analysis will proceed, but consider using '%s' instead."
-                % CalculateFunctionTarget.ALL_ACROSS.value,
-                self.each_or_all,
-            )
 
     def upgrade_settings(self, setting_values, variable_revision_number, module_name):
         """Adjust the setting values of old versions
@@ -942,21 +865,12 @@ fewer iterations, but less accuracy.
             ]  # spline convergence
             variable_revision_number = 2
 
+        if variable_revision_number == 2:
+            if setting_values[7] in ["All: First cycle", "All: Across cycles"]:
+                setting_values[7] = CalculateFunctionTarget.ALL.value
+            variable_revision_number = 3
+
         return setting_values, variable_revision_number
-
-    def post_pipeline_load(self, pipeline):
-        """After loading, set each_or_all appropriately
-
-        This function handles the legacy EA_ALL which guessed the user's
-        intent: processing before the first cycle or not. We look for
-        the image provider and see if it is a file image provider.
-        """
-        if self.each_or_all == EA_ALL:
-            if pipeline.is_image_from_file(self.image_name.value):
-                self.each_or_all.value = CalculateFunctionTarget.ALL_FIRST.value
-            else:
-                self.each_or_all.value = CalculateFunctionTarget.ALL_ACROSS.value
-
 
 # ============================================================
 # Stage providers — internal pipeline steps used by

--- a/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
+++ b/src/frontend/cellprofiler/modules/correctilluminationcalculate.py
@@ -63,15 +63,7 @@ from cellprofiler_library.opts.correctilluminationcalculate import (
     SplineBackgroundMode,
 )
 from cellprofiler_library.functions.image_processing import get_smoothing_filter_size
-from cellprofiler_library.modules._correctilluminationcalculate import (
-    apply_smoothing,
-    apply_dilation,
-    apply_scaling,
-    preprocess_image_for_averaging,
-    initialize_illumination_accumulation,
-    accumulate_illumination_image,
-    calculate_average_from_state,
-)
+from cellprofiler_library.modules._correctilluminationcalculate import correctilluminationcalculate
 
 OUTPUT_IMAGE = "OutputImage"
 
@@ -872,183 +864,19 @@ fewer iterations, but less accuracy.
 
         return setting_values, variable_revision_number
 
-# ============================================================
-# Stage providers — internal pipeline steps used by
-# CorrectIlluminationCalculateProvider.  Each class encapsulates
-# exactly one transformation stage and lazily caches its output.
-# They are never added to the image set directly.
-# ============================================================
-
-class _AverageProvider:
-    """Computes the averaged illumination image from the accumulated state.
-
-    Holds a reference to the shared library_state dict.  The dict is
-    always mutated in place by the composite, so this reference never
-    goes stale across save/restore cycles.
-    """
-
-    def __init__(self, library_state):
-        self._library_state = library_state
-        self._cached = None
-
-    def provide_image(self, image_set):
-        if self._cached is None:
-            avg_pixel_data, avg_mask = calculate_average_from_state(self._library_state)
-            self._cached = Image(avg_pixel_data, avg_mask)
-        return self._cached
-
-    def invalidate(self):
-        self._cached = None
-
-
-class _DilationProvider:
-    """Applies optional Gaussian dilation to the averaged image.
-
-    Receives the _AverageProvider as its upstream source.  When
-    dilate_objects is False this stage is a transparent pass-through.
-    """
-
-    def __init__(self, avg_provider, dilate_objects, object_dilation_radius):
-        self._avg = avg_provider
-        self.dilate_objects = dilate_objects
-        self.object_dilation_radius = object_dilation_radius
-        self._cached = None
-
-    def provide_image(self, image_set):
-        if self._cached is None:
-            avg_image = self._avg.provide_image(image_set)
-            if self.dilate_objects:
-                dilated_pixels = apply_dilation(
-                    avg_image.pixel_data,
-                    avg_image.mask,
-                    self.object_dilation_radius,
-                )
-                self._cached = Image(dilated_pixels, parent_image=avg_image)
-            else:
-                self._cached = avg_image
-        return self._cached
-
-    def invalidate(self):
-        self._cached = None
-
-
-class _SmoothingProvider:
-    """Applies optional smoothing to the dilated image.
-
-    Receives the _DilationProvider as its upstream source (which in turn
-    receives the _AverageProvider).  When the smoothing method is NONE
-    this stage is a transparent pass-through.
-    """
-
-    def __init__(
-        self,
-        dilated_provider,
-        smoothing_method,
-        automatic_object_width,
-        size_of_smoothing_filter,
-        object_width,
-        automatic_splines,
-        spline_bg_mode,
-        spline_points,
-        spline_threshold,
-        spline_convergence,
-        spline_maximum_iterations,
-        spline_rescale,
-    ):
-        self._dilated = dilated_provider
-        self.smoothing_method = smoothing_method
-        self.automatic_object_width = automatic_object_width
-        self.size_of_smoothing_filter = size_of_smoothing_filter
-        self.object_width = object_width
-        self.automatic_splines = automatic_splines
-        self.spline_bg_mode = spline_bg_mode
-        self.spline_points = spline_points
-        self.spline_threshold = spline_threshold
-        self.spline_convergence = spline_convergence
-        self.spline_maximum_iterations = spline_maximum_iterations
-        self.spline_rescale = spline_rescale
-        self._cached = None
-
-    def provide_image(self, image_set):
-        if self._cached is None:
-            dilated_image = self._dilated.provide_image(image_set)
-            if self.smoothing_method != SmoothingMethod.NONE.value:
-                smoothed_pixels = apply_smoothing(
-                    image_pixel_data=dilated_image.pixel_data,
-                    image_mask=dilated_image.mask if dilated_image.has_mask else None,
-                    smoothing_method=self.smoothing_method,
-                    automatic_object_width=self.automatic_object_width,
-                    size_of_smoothing_filter=self.size_of_smoothing_filter,
-                    object_width=self.object_width,
-                    image_shape=dilated_image.pixel_data.shape[:2],
-                    automatic_splines=self.automatic_splines,
-                    spline_bg_mode=self.spline_bg_mode,
-                    spline_points=self.spline_points,
-                    spline_threshold=self.spline_threshold,
-                    spline_convergence=self.spline_convergence,
-                    spline_maximum_iterations=self.spline_maximum_iterations,
-                    spline_rescale=self.spline_rescale,
-                )
-                self._cached = Image(smoothed_pixels, parent_image=dilated_image)
-            else:
-                self._cached = dilated_image
-        return self._cached
-
-    def invalidate(self):
-        self._cached = None
-
-
-class _ScalingProvider:
-    """Applies optional rescaling to the smoothed image.
-
-    Receives the _SmoothingProvider as its upstream source.  When
-    rescale_option is NO this stage is a transparent pass-through.
-    """
-
-    def __init__(self, smoothed_provider, rescale_option):
-        self._smoothed = smoothed_provider
-        self.rescale_option = rescale_option
-        self._cached = None
-
-    def provide_image(self, image_set):
-        if self._cached is None:
-            smoothed_image = self._smoothed.provide_image(image_set)
-            if self.rescale_option != RescaleIlluminationFunction.NO.value:
-                output_pixels = apply_scaling(
-                    image_pixel_data=smoothed_image.pixel_data,
-                    image_mask=smoothed_image.mask if smoothed_image.has_mask else None,
-                    rescale_option=self.rescale_option,
-                )
-                self._cached = Image(output_pixels, parent_image=smoothed_image)
-            else:
-                self._cached = smoothed_image
-        return self._cached
-
-    def invalidate(self):
-        self._cached = None
-
-
 class CorrectIlluminationImageProvider(AbstractImage):
-    """Composite provider for the illumination correction pipeline.
+    """Provider wrapping the single library entry point, correctilluminationcalculate().
 
-    Wires four internal stage providers into a linear pipeline:
-
-        _AverageProvider
-            → _DilationProvider
-                → _SmoothingProvider
-                    → _ScalingProvider
-
-    Each stage is independently lazy-cached; requesting only the averaged
-    image does not trigger smoothing or scaling.  The composite coordinates
-    image accumulation and cache invalidation across all stages.
-
-    The library_state dict is always mutated in place so that
-    _AverageProvider's reference to it remains valid across
-    save_state / restore_from_state cycles.
+    Holds a library_accumulator callback object (an IlluminationAccumulator):
+    set_image()/accumulate_image() drive it via .accumulate(), and image
+    access (provide_image / provide_avg_image / provide_dilated_image) all
+    read from one cached call to .finalize(), which runs the full
+    average -> dilate -> smooth -> rescale pipeline in the library and
+    returns every image this provider can hand out.
     """
 
     D_NAME = "name"
-    D_LIBRARY_STATE = "library_state"
+    D_LIBRARY_STATE = "library_accumulator"
     D_INTENSITY_CHOICE = "intensity_choice"
     D_DILATE_OBJECTS = "dilate_objects"
     D_OBJECT_DILATION_RADIUS = "object_dilation_radius"
@@ -1104,45 +932,35 @@ class CorrectIlluminationImageProvider(AbstractImage):
         self.spline_convergence = spline_convergence
         self.spline_maximum_iterations = spline_maximum_iterations
         self.spline_rescale = spline_rescale
-        # library_state is always mutated in place so _AverageProvider's
-        # reference to it stays valid across save_state / restore_from_state.
-        self.library_state = {}
-        self._build_pipeline()
+        self.library_accumulator = None
+        self._cached_images = None
 
     # ------------------------------------------------------------------
-    # Pipeline construction and cache management
+    # Cache management
     # ------------------------------------------------------------------
 
-    def _build_pipeline(self):
-        """Wire the stage providers into a linear pipeline.
+    def _finalize(self):
+        """Run (and cache) the library's full average/dilate/smooth/rescale pipeline.
 
-        _AverageProvider receives a direct reference to self.library_state;
-        all other stages receive a reference to their upstream provider.
+        Wraps the three pixel arrays as Image objects once and caches those
+        (not just the raw arrays), so repeated calls return the same Image
+        identity — ImageSet.get_image() does no caching of its own, so this
+        is the only place that happens.
+
+        Returns:
+            (output_image, dilated_image, avg_image).
         """
-        self._avg = _AverageProvider(self.library_state)
-        self._dilated = _DilationProvider(
-            self._avg, self.dilate_objects, self.object_dilation_radius
-        )
-        self._smoothed = _SmoothingProvider(
-            self._dilated,
-            self.smoothing_method,
-            self.automatic_object_width,
-            self.size_of_smoothing_filter,
-            self.object_width,
-            self.automatic_splines,
-            self.spline_bg_mode,
-            self.spline_points,
-            self.spline_threshold,
-            self.spline_convergence,
-            self.spline_maximum_iterations,
-            self.spline_rescale,
-        )
-        self._scaling = _ScalingProvider(self._smoothed, self.rescale_option)
+        if self._cached_images is None:
+            output_pixel_data, dilated_pixel_data, avg_pixel_data, mask = self.library_accumulator.finalize()
+            self._cached_images = (
+                Image(output_pixel_data, mask),
+                Image(dilated_pixel_data, mask),
+                Image(avg_pixel_data, mask),
+            )
+        return self._cached_images
 
-    def _invalidate_pipeline(self):
-        """Clear each stage's cached image."""
-        for stage in (self._avg, self._dilated, self._smoothed, self._scaling):
-            stage.invalidate()
+    def _invalidate_cache(self):
+        self._cached_images = None
 
     # ------------------------------------------------------------------
     # Factory and serialization
@@ -1191,7 +1009,7 @@ class CorrectIlluminationImageProvider(AbstractImage):
         """
         P = CorrectIlluminationImageProvider
         d[P.D_NAME] = self._name
-        d[P.D_LIBRARY_STATE] = self.library_state
+        d[P.D_LIBRARY_STATE] = self.library_accumulator
         d[P.D_INTENSITY_CHOICE] = self.intensity_choice
         d[P.D_DILATE_OBJECTS] = self.dilate_objects
         d[P.D_OBJECT_DILATION_RADIUS] = self.object_dilation_radius
@@ -1239,9 +1057,7 @@ class CorrectIlluminationImageProvider(AbstractImage):
             spline_maximum_iterations=d[P.D_SPLINE_MAXIMUM_ITERATIONS],
             spline_rescale=d[P.D_SPLINE_RESCALE],
         )
-        # Restore accumulation state in place so _AverageProvider's
-        # reference (established in _build_pipeline) remains valid.
-        provider.library_state.update(d.get(P.D_LIBRARY_STATE, {}))
+        provider.library_accumulator = d.get(P.D_LIBRARY_STATE, None)
         return provider
 
     # ------------------------------------------------------------------
@@ -1250,13 +1066,13 @@ class CorrectIlluminationImageProvider(AbstractImage):
 
     def reset(self):
         """Reset accumulation at the start of a group."""
-        self.library_state.clear()
-        self._invalidate_pipeline()
+        self.library_accumulator = None
+        self._invalidate_cache()
 
     @property
     def has_image(self):
         """True when at least one image has been accumulated."""
-        return len(self.library_state) > 0
+        return self.library_accumulator is not None
 
     def set_image(self, image):
         """Initialize accumulation from the first image.
@@ -1265,18 +1081,27 @@ class CorrectIlluminationImageProvider(AbstractImage):
             image: A cellprofiler_core.image.Image instance.
         """
         mask = image.mask if image.has_mask else None
-        preprocessed = preprocess_image_for_averaging(
+        self.library_accumulator = correctilluminationcalculate(
             image.pixel_data,
             mask,
             self.intensity_choice,
             self.smoothing_method,
             self.block_size,
+            self.dilate_objects,
+            self.object_dilation_radius,
+            self.automatic_object_width,
+            self.size_of_smoothing_filter,
+            self.object_width,
+            self.automatic_splines,
+            self.spline_bg_mode,
+            self.spline_points,
+            self.spline_threshold,
+            self.spline_convergence,
+            self.spline_maximum_iterations,
+            self.spline_rescale,
+            self.rescale_option,
         )
-        new_state = initialize_illumination_accumulation(preprocessed, mask)
-        # Mutate in place to keep _AverageProvider's reference valid.
-        self.library_state.clear()
-        self.library_state.update(new_state)
-        self._invalidate_pipeline()
+        self._invalidate_cache()
 
     def accumulate_image(self, image):
         """Accumulate a subsequent image into the running state.
@@ -1285,31 +1110,27 @@ class CorrectIlluminationImageProvider(AbstractImage):
             image: A cellprofiler_core.image.Image instance.
         """
         mask = image.mask if image.has_mask else None
-        preprocessed = preprocess_image_for_averaging(
-            image.pixel_data,
-            mask,
-            self.intensity_choice,
-            self.smoothing_method,
-            self.block_size,
-        )
-        accumulate_illumination_image(preprocessed, mask, self.library_state)
-        self._invalidate_pipeline()
+        self.library_accumulator = self.library_accumulator.accumulate(image.pixel_data, mask)
+        self._invalidate_cache()
 
     # ------------------------------------------------------------------
-    # Image access — delegates to stage providers
+    # Image access — all backed by one cached call to .finalize()
     # ------------------------------------------------------------------
 
     def provide_avg_image(self):
         """Return the averaged image (before dilation and smoothing)."""
-        return self._avg.provide_image(None)
+        _, _, avg_image = self._finalize()
+        return avg_image
 
     def provide_dilated_image(self):
         """Return the dilated image (after dilation, before smoothing)."""
-        return self._dilated.provide_image(None)
+        _, dilated_image, _ = self._finalize()
+        return dilated_image
 
     def provide_image(self, image_set):
         """Return the final (scaled) illumination correction image."""
-        return self._scaling.provide_image(image_set)
+        output_image, _, _ = self._finalize()
+        return output_image
 
     def get_name(self):
         """Return the name of the output illumination image."""

--- a/src/subpackages/core/cellprofiler_core/module/_module.py
+++ b/src/subpackages/core/cellprofiler_core/module/_module.py
@@ -898,11 +898,11 @@ class Module:
 
     def is_image_from_file(self, image_name):
         """Return True if this module loads this image name from a file."""
-        from ..setting.subscriber import FileImageSubscriber
+        from ..setting.text import FileImageName
 
         for setting in self.settings():
             if (
-                    isinstance(setting, FileImageSubscriber, )
+                    isinstance(setting, FileImageName, )
                     and setting.value == image_name
             ):
                 return True

--- a/src/subpackages/library/cellprofiler_library/functions/image_processing.py
+++ b/src/subpackages/library/cellprofiler_library/functions/image_processing.py
@@ -12,6 +12,9 @@ import skimage.exposure
 import centrosome
 import centrosome.threshold
 import centrosome.filter
+import centrosome.cpmorphology
+import centrosome.bg_compensate
+import centrosome.smooth
 import scipy
 import scipy.interpolate
 import matplotlib
@@ -47,6 +50,11 @@ from cellprofiler_library.opts.imagemath import Operator
 from cellprofiler_library.opts.flipandrotate import RotationCoordinateAlignmnet
 from cellprofiler_library.opts.enhanceedges import EdgeDirection
 from cellprofiler_library.opts.rescaleintensity import MaximumIntensityMethod, MinimumIntensityMethod
+from cellprofiler_library.opts.correctilluminationcalculate import (
+    SmoothingFilterSize,
+    SmoothingMethod,
+    SplineBackgroundMode,
+)
 invert = cast(Callable[[ImageAny], ImageAny], _invert)
 isscalar = cast(Callable[[Optional[ImageAny]], bool], _isscalar)
 
@@ -3105,5 +3113,189 @@ def apply_target_mask(x_data: ImageAny, masking_image: Union[ImageAny,ObjectSegm
     return x_data
 
 
+###############################################################################
+# CorrectIlluminationCalculate
+###############################################################################
+
+def smooth_plane(
+        pixel_data: Image2D, 
+        mask: Image2DMask,
+        smoothing_method: SmoothingMethod,
+        automatic_object_width,
+        size_of_smoothing_filter,
+        object_width,
+        image_shape,
+        automatic_splines: Optional[bool],
+        spline_bg_mode: Optional[SplineBackgroundMode], 
+        spline_points: Optional[int],
+        spline_threshold: Optional[float],
+        spline_convergence: Optional[float],
+        spline_maximum_iterations: Optional[int],
+        spline_rescale: Optional[float],
+    ):
+    """Smooth one 2-d color plane of an image"""
+    smoothing_dispatcher = {
+        SmoothingMethod.FIT_POLYNOMIAL.value: smooth_with_polynomial,
+        SmoothingMethod.GAUSSIAN_FILTER.value: smooth_with_gaussian,
+        SmoothingMethod.MEDIAN_FILTER.value: smooth_with_median,
+        SmoothingMethod.TO_AVERAGE.value: smooth_to_average,
+        SmoothingMethod.SPLINES.value: smooth_with_splines,
+        SmoothingMethod.CONVEX_HULL.value: smooth_with_convex_hull,
+    }
+    if smoothing_method not in smoothing_dispatcher:
+        raise ValueError(
+            "Unimplemented smoothing method: %s:" % smoothing_method.value
+        )
+    output_pixels = smoothing_dispatcher[smoothing_method](
+        pixel_data, 
+        mask, 
+        automatic_object_width,
+        size_of_smoothing_filter,
+        object_width,
+        image_shape,
+        automatic_splines,
+        spline_bg_mode,
+        spline_points,
+        spline_threshold,
+        spline_convergence,
+        spline_maximum_iterations,
+        spline_rescale,
+    )
+    return output_pixels
+
+    # if smoothing_method == SmoothingMethod.FIT_POLYNOMIAL.value:
+    #     output_pixels = smooth_with_polynomial(pixel_data, mask)
+    # elif smoothing_method == SmoothingMethod.GAUSSIAN_FILTER.value:
+    #     output_pixels = smooth_with_gaussian(pixel_data, mask, sigma)
+    # elif smoothing_method == SmoothingMethod.MEDIAN_FILTER.value:
+    #     output_pixels = smooth_with_median(pixel_data, mask, sigma)
+    # elif smoothing_method == SmoothingMethod.TO_AVERAGE.value:
+    #     output_pixels = smooth_to_average(pixel_data, mask)
+    # elif smoothing_method == SmoothingMethod.SPLINES.value:
+    #     output_pixels = smooth_with_splines(
+    #         pixel_data = pixel_data, 
+    #         mask = mask,
+    #         automatic_splines = automatic_splines,
+    #         spline_bg_mode = spline_bg_mode,
+    #         spline_points = spline_points,
+    #         spline_threshold = spline_threshold,
+    #         spline_convergence = spline_convergence,
+    #         spline_maximum_iterations = spline_maximum_iterations,
+    #         spline_rescale = spline_rescale,
+    #     )
+    # elif smoothing_method == SmoothingMethod.CONVEX_HULL.value:
+    #     output_pixels = smooth_with_convex_hull(pixel_data, mask)
+    # else:
+    #     raise ValueError(
+    #         "Unimplemented smoothing method: %s:" % smoothing_method.value
+    #     )
+    # return output_pixels
+
+
+
+def smooth_with_polynomial(pixel_data, mask, *args, **kwargs):
+    return centrosome.smooth.fit_polynomial(pixel_data, mask)
+
+def smooth_with_gaussian(pixel_data, mask, sigma, *args, **kwargs):
+    #
+    # Smoothing with the mask is good, even if there's no mask
+    # because the mechanism undoes the edge effects that are introduced
+    # by any choice of how to deal with border effects.
+    #
+    assert sigma is not None, "sigma must be provided for Gaussian smoothing"
+    def fn(image):
+        return scipy.ndimage.gaussian_filter(
+            image, sigma, mode="constant", cval=0
+        )
+
+    output_pixels = centrosome.smooth.smooth_with_function_and_mask(
+        pixel_data, fn, mask
+    )
+    return output_pixels
+
+def smooth_with_median(pixel_data, mask, sigma, *args, **kwargs):
+    assert sigma is not None, "sigma must be provided for median smoothing"
+    filter_sigma = max(1, int(sigma + 0.5))
+    strel = centrosome.cpmorphology.strel_disk(filter_sigma)
+    rescaled_pixel_data = pixel_data * 65535
+    rescaled_pixel_data = rescaled_pixel_data.astype(numpy.uint16)
+    rescaled_pixel_data *= mask
+    output_pixels = skimage.filters.median(rescaled_pixel_data, strel, behavior="rank")
+    return output_pixels
+
+def smooth_to_average(pixel_data, mask, *args, **kwargs):
+    mean = numpy.mean(pixel_data[mask])
+    output_pixels = numpy.ones(pixel_data.shape, pixel_data.dtype) * mean
+    return output_pixels
+
+def smooth_with_convex_hull(pixel_data, mask, *args, **kwargs):
+    """Use the convex hull transform to smooth the image"""
+    #
+    # Apply an erosion, then the transform, then a dilation, heuristically
+    # to ignore little spikey noisy things.
+    #
+    image = centrosome.cpmorphology.grey_erosion(pixel_data, 2, mask)
+    image = centrosome.filter.convex_hull_transform(image, mask=mask)
+    image = centrosome.cpmorphology.grey_dilation(image, 2, mask)
+    return image
+
+
+def smooth_with_splines(
+        pixel_data: Image2D, 
+        mask: Image2DMask,
+        automatic_splines: bool,
+        spline_bg_mode: Optional[SplineBackgroundMode],
+        spline_points: Optional[int],
+        spline_threshold: Optional[float],
+        spline_convergence: Optional[float],
+        spline_maximum_iterations: Optional[int],
+        spline_rescale: Optional[float],
+        *args,
+        **kwargs,
+    ):
+    assert automatic_splines is not None, "automatic_splines must be provided for spline smoothing"
+    if automatic_splines:
+        # Make the image 200 pixels long on its shortest side
+        shortest_side = min(pixel_data.shape)
+        if shortest_side < 200:
+            scale = 1
+        else:
+            scale = float(shortest_side) / 200
+        result = centrosome.bg_compensate.backgr(pixel_data, mask, scale=scale) # type: ignore # scale can be a float
+    else:
+        assert spline_bg_mode is not None, "spline_bg_mode must be provided for spline smoothing"
+        assert spline_points is not None, "spline_points must be provided for spline smoothing"
+        assert spline_threshold is not None, "spline_threshold must be provided for spline smoothing"
+        assert spline_convergence is not None, "spline_convergence must be provided for spline smoothing"
+        assert spline_maximum_iterations is not None, "spline_maximum_iterations must be provided for spline smoothing"
+        assert spline_rescale is not None, "spline_rescale must be provided for spline smoothing"
+        mode = spline_bg_mode
+        spline_points = spline_points
+        threshold = spline_threshold
+        convergence = spline_convergence
+        iterations = spline_maximum_iterations
+        rescale = spline_rescale
+        result = centrosome.bg_compensate.backgr(
+            pixel_data,
+            mask,
+            mode=mode,
+            thresh=threshold, # type: ignore # threshold can be a float
+            splinepoints=spline_points,
+            scale=rescale, # type: ignore # scale can be a float
+            maxiter=iterations,
+            convergence=convergence,
+        )
+    #
+    # The result is a fit to the background intensity, but we
+    # want to normalize the intensity by subtraction, leaving
+    # the mean intensity alone.
+    #
+    if mask is not None:
+        mean_intensity = numpy.mean(result[mask])
+        result[mask] -= mean_intensity
+    else:
+        mean_intensity = numpy.mean(result)
+        result -= mean_intensity
+    return result
 
 

--- a/src/subpackages/library/cellprofiler_library/functions/image_processing.py
+++ b/src/subpackages/library/cellprofiler_library/functions/image_processing.py
@@ -3117,14 +3117,39 @@ def apply_target_mask(x_data: ImageAny, masking_image: Union[ImageAny,ObjectSegm
 # CorrectIlluminationCalculate
 ###############################################################################
 
+
+def get_smoothing_filter_size(
+        automatic_object_width: SmoothingFilterSize, 
+        smoothing_filter_size: Optional[int], # default to 10
+        object_width: Optional[int], # default to 10 
+        image_shape: Optional[Tuple[int, ...]]
+    ) -> float:
+    """Return the smoothing filter size based on the settings and image size"""
+    filter_size = None
+    if automatic_object_width == SmoothingFilterSize.MANUALLY.value:
+        assert smoothing_filter_size is not None, "Manual smoothing filter size must be provided"
+        # Convert from full-width at half-maximum to standard deviation
+        # (or so says CPsmooth.m)
+        filter_size = smoothing_filter_size
+    elif automatic_object_width == SmoothingFilterSize.OBJECT_SIZE.value:
+        assert object_width is not None, "Object width must be provided"
+        filter_size =  object_width * 2.35 / 3.5
+    elif automatic_object_width == SmoothingFilterSize.AUTOMATIC.value:
+        assert image_shape is not None, "Image shape must be provided"
+        filter_size = min(30, float(numpy.max(image_shape)) / 40.0)
+    else:
+        raise ValueError(f"Unknown smoothing filter size: {automatic_object_width}")
+    return filter_size
+
+
 def smooth_plane(
         pixel_data: Image2D, 
         mask: Image2DMask,
         smoothing_method: SmoothingMethod,
-        automatic_object_width,
-        size_of_smoothing_filter,
-        object_width,
-        image_shape,
+        automatic_object_width: Optional[SmoothingFilterSize],
+        size_of_smoothing_filter: Optional[int],
+        object_width: Optional[int],
+        image_shape: Optional[Tuple[int, ...]],
         automatic_splines: Optional[bool],
         spline_bg_mode: Optional[SplineBackgroundMode], 
         spline_points: Optional[int],
@@ -3132,77 +3157,69 @@ def smooth_plane(
         spline_convergence: Optional[float],
         spline_maximum_iterations: Optional[int],
         spline_rescale: Optional[float],
-    ):
+    ) -> Image2D:
     """Smooth one 2-d color plane of an image"""
-    smoothing_dispatcher = {
-        SmoothingMethod.FIT_POLYNOMIAL.value: smooth_with_polynomial,
-        SmoothingMethod.GAUSSIAN_FILTER.value: smooth_with_gaussian,
-        SmoothingMethod.MEDIAN_FILTER.value: smooth_with_median,
-        SmoothingMethod.TO_AVERAGE.value: smooth_to_average,
-        SmoothingMethod.SPLINES.value: smooth_with_splines,
-        SmoothingMethod.CONVEX_HULL.value: smooth_with_convex_hull,
-    }
-    if smoothing_method not in smoothing_dispatcher:
+    if smoothing_method == SmoothingMethod.FIT_POLYNOMIAL.value:
+        output_pixels = smooth_with_polynomial(pixel_data, mask)
+    elif smoothing_method == SmoothingMethod.GAUSSIAN_FILTER.value:
+        sigma = _get_sigma(automatic_object_width, size_of_smoothing_filter, object_width, image_shape)
+        output_pixels = smooth_with_gaussian(pixel_data, mask, sigma)
+    elif smoothing_method == SmoothingMethod.MEDIAN_FILTER.value:
+        sigma = _get_sigma(automatic_object_width, size_of_smoothing_filter, object_width, image_shape)
+        output_pixels = smooth_with_median(pixel_data, mask, sigma)
+    elif smoothing_method == SmoothingMethod.TO_AVERAGE.value:
+        output_pixels = smooth_to_average(pixel_data, mask)
+    elif smoothing_method == SmoothingMethod.SPLINES.value:
+        assert automatic_splines is not None, "automatic_splines must be provided for spline smoothing"
+        output_pixels = smooth_with_splines(
+            pixel_data = pixel_data, 
+            mask = mask,
+            automatic_splines = automatic_splines,
+            spline_bg_mode = spline_bg_mode,
+            spline_points = spline_points,
+            spline_threshold = spline_threshold,
+            spline_convergence = spline_convergence,
+            spline_maximum_iterations = spline_maximum_iterations,
+            spline_rescale = spline_rescale,
+        )
+    elif smoothing_method == SmoothingMethod.CONVEX_HULL.value:
+        output_pixels = smooth_with_convex_hull(pixel_data, mask)
+    else:
         raise ValueError(
             "Unimplemented smoothing method: %s:" % smoothing_method.value
         )
-    output_pixels = smoothing_dispatcher[smoothing_method](
-        pixel_data, 
-        mask, 
-        automatic_object_width,
-        size_of_smoothing_filter,
-        object_width,
-        image_shape,
-        automatic_splines,
-        spline_bg_mode,
-        spline_points,
-        spline_threshold,
-        spline_convergence,
-        spline_maximum_iterations,
-        spline_rescale,
-    )
     return output_pixels
 
-    # if smoothing_method == SmoothingMethod.FIT_POLYNOMIAL.value:
-    #     output_pixels = smooth_with_polynomial(pixel_data, mask)
-    # elif smoothing_method == SmoothingMethod.GAUSSIAN_FILTER.value:
-    #     output_pixels = smooth_with_gaussian(pixel_data, mask, sigma)
-    # elif smoothing_method == SmoothingMethod.MEDIAN_FILTER.value:
-    #     output_pixels = smooth_with_median(pixel_data, mask, sigma)
-    # elif smoothing_method == SmoothingMethod.TO_AVERAGE.value:
-    #     output_pixels = smooth_to_average(pixel_data, mask)
-    # elif smoothing_method == SmoothingMethod.SPLINES.value:
-    #     output_pixels = smooth_with_splines(
-    #         pixel_data = pixel_data, 
-    #         mask = mask,
-    #         automatic_splines = automatic_splines,
-    #         spline_bg_mode = spline_bg_mode,
-    #         spline_points = spline_points,
-    #         spline_threshold = spline_threshold,
-    #         spline_convergence = spline_convergence,
-    #         spline_maximum_iterations = spline_maximum_iterations,
-    #         spline_rescale = spline_rescale,
-    #     )
-    # elif smoothing_method == SmoothingMethod.CONVEX_HULL.value:
-    #     output_pixels = smooth_with_convex_hull(pixel_data, mask)
-    # else:
-    #     raise ValueError(
-    #         "Unimplemented smoothing method: %s:" % smoothing_method.value
-    #     )
-    # return output_pixels
+def _get_sigma(
+        automatic_object_width: Optional[SmoothingFilterSize],
+        size_of_smoothing_filter: Optional[int],
+        object_width: Optional[int],
+        image_shape: Optional[Tuple[int, ...]],
+    ) -> float:
+    assert automatic_object_width is not None, "automatic_object_width must be provided for Gaussian or Median smoothing"
+    assert size_of_smoothing_filter is not None, "size_of_smoothing_filter must be provided for Gaussian or Median smoothing"
+    assert object_width is not None, "object_width must be provided for Gaussian or Median smoothing"
+    assert image_shape is not None, "image_shape must be provided for Gaussian or Median smoothing"
+    sigma = get_smoothing_filter_size(automatic_object_width, size_of_smoothing_filter, object_width, image_shape) / 2.35 # What's up with 2.35?
+    return sigma
 
 
-
-def smooth_with_polynomial(pixel_data, mask, *args, **kwargs):
+def smooth_with_polynomial(
+        pixel_data: Image2D, 
+        mask: Image2DMask
+    ) -> Image2D:
     return centrosome.smooth.fit_polynomial(pixel_data, mask)
 
-def smooth_with_gaussian(pixel_data, mask, sigma, *args, **kwargs):
+def smooth_with_gaussian(
+        pixel_data: Image2D,
+        mask: Image2DMask,
+        sigma: float
+    ) -> Image2D:
     #
     # Smoothing with the mask is good, even if there's no mask
     # because the mechanism undoes the edge effects that are introduced
     # by any choice of how to deal with border effects.
     #
-    assert sigma is not None, "sigma must be provided for Gaussian smoothing"
     def fn(image):
         return scipy.ndimage.gaussian_filter(
             image, sigma, mode="constant", cval=0
@@ -3213,8 +3230,11 @@ def smooth_with_gaussian(pixel_data, mask, sigma, *args, **kwargs):
     )
     return output_pixels
 
-def smooth_with_median(pixel_data, mask, sigma, *args, **kwargs):
-    assert sigma is not None, "sigma must be provided for median smoothing"
+def smooth_with_median(
+        pixel_data: Image2D, 
+        mask: Image2DMask,
+        sigma: float
+    ) -> Image2D:
     filter_sigma = max(1, int(sigma + 0.5))
     strel = centrosome.cpmorphology.strel_disk(filter_sigma)
     rescaled_pixel_data = pixel_data * 65535
@@ -3223,12 +3243,18 @@ def smooth_with_median(pixel_data, mask, sigma, *args, **kwargs):
     output_pixels = skimage.filters.median(rescaled_pixel_data, strel, behavior="rank")
     return output_pixels
 
-def smooth_to_average(pixel_data, mask, *args, **kwargs):
+def smooth_to_average(
+        pixel_data: Image2D, 
+        mask: Image2DMask
+    ) -> Image2D:
     mean = numpy.mean(pixel_data[mask])
     output_pixels = numpy.ones(pixel_data.shape, pixel_data.dtype) * mean
     return output_pixels
 
-def smooth_with_convex_hull(pixel_data, mask, *args, **kwargs):
+def smooth_with_convex_hull(
+        pixel_data: Image2D, 
+        mask: Image2DMask
+    ) -> Image2D:
     """Use the convex hull transform to smooth the image"""
     #
     # Apply an erosion, then the transform, then a dilation, heuristically
@@ -3250,9 +3276,7 @@ def smooth_with_splines(
         spline_convergence: Optional[float],
         spline_maximum_iterations: Optional[int],
         spline_rescale: Optional[float],
-        *args,
-        **kwargs,
-    ):
+    ) -> Image2D:
     assert automatic_splines is not None, "automatic_splines must be provided for spline smoothing"
     if automatic_splines:
         # Make the image 200 pixels long on its shortest side

--- a/src/subpackages/library/cellprofiler_library/functions/image_processing.py
+++ b/src/subpackages/library/cellprofiler_library/functions/image_processing.py
@@ -3118,14 +3118,39 @@ def apply_target_mask(x_data: ImageAny, masking_image: Union[ImageAny,ObjectSegm
 # CorrectIlluminationCalculate
 ###############################################################################
 
+
+def get_smoothing_filter_size(
+        automatic_object_width: SmoothingFilterSize, 
+        smoothing_filter_size: Optional[int], # default to 10
+        object_width: Optional[int], # default to 10 
+        image_shape: Optional[Tuple[int, ...]]
+    ) -> float:
+    """Return the smoothing filter size based on the settings and image size"""
+    filter_size = None
+    if automatic_object_width == SmoothingFilterSize.MANUALLY.value:
+        assert smoothing_filter_size is not None, "Manual smoothing filter size must be provided"
+        # Convert from full-width at half-maximum to standard deviation
+        # (or so says CPsmooth.m)
+        filter_size = smoothing_filter_size
+    elif automatic_object_width == SmoothingFilterSize.OBJECT_SIZE.value:
+        assert object_width is not None, "Object width must be provided"
+        filter_size =  object_width * 2.35 / 3.5
+    elif automatic_object_width == SmoothingFilterSize.AUTOMATIC.value:
+        assert image_shape is not None, "Image shape must be provided"
+        filter_size = min(30, float(numpy.max(image_shape)) / 40.0)
+    else:
+        raise ValueError(f"Unknown smoothing filter size: {automatic_object_width}")
+    return filter_size
+
+
 def smooth_plane(
         pixel_data: Image2D, 
         mask: Image2DMask,
         smoothing_method: SmoothingMethod,
-        automatic_object_width,
-        size_of_smoothing_filter,
-        object_width,
-        image_shape,
+        automatic_object_width: Optional[SmoothingFilterSize],
+        size_of_smoothing_filter: Optional[int],
+        object_width: Optional[int],
+        image_shape: Optional[Tuple[int, ...]],
         automatic_splines: Optional[bool],
         spline_bg_mode: Optional[SplineBackgroundMode], 
         spline_points: Optional[int],
@@ -3133,77 +3158,69 @@ def smooth_plane(
         spline_convergence: Optional[float],
         spline_maximum_iterations: Optional[int],
         spline_rescale: Optional[float],
-    ):
+    ) -> Image2D:
     """Smooth one 2-d color plane of an image"""
-    smoothing_dispatcher = {
-        SmoothingMethod.FIT_POLYNOMIAL.value: smooth_with_polynomial,
-        SmoothingMethod.GAUSSIAN_FILTER.value: smooth_with_gaussian,
-        SmoothingMethod.MEDIAN_FILTER.value: smooth_with_median,
-        SmoothingMethod.TO_AVERAGE.value: smooth_to_average,
-        SmoothingMethod.SPLINES.value: smooth_with_splines,
-        SmoothingMethod.CONVEX_HULL.value: smooth_with_convex_hull,
-    }
-    if smoothing_method not in smoothing_dispatcher:
+    if smoothing_method == SmoothingMethod.FIT_POLYNOMIAL.value:
+        output_pixels = smooth_with_polynomial(pixel_data, mask)
+    elif smoothing_method == SmoothingMethod.GAUSSIAN_FILTER.value:
+        sigma = _get_sigma(automatic_object_width, size_of_smoothing_filter, object_width, image_shape)
+        output_pixels = smooth_with_gaussian(pixel_data, mask, sigma)
+    elif smoothing_method == SmoothingMethod.MEDIAN_FILTER.value:
+        sigma = _get_sigma(automatic_object_width, size_of_smoothing_filter, object_width, image_shape)
+        output_pixels = smooth_with_median(pixel_data, mask, sigma)
+    elif smoothing_method == SmoothingMethod.TO_AVERAGE.value:
+        output_pixels = smooth_to_average(pixel_data, mask)
+    elif smoothing_method == SmoothingMethod.SPLINES.value:
+        assert automatic_splines is not None, "automatic_splines must be provided for spline smoothing"
+        output_pixels = smooth_with_splines(
+            pixel_data = pixel_data, 
+            mask = mask,
+            automatic_splines = automatic_splines,
+            spline_bg_mode = spline_bg_mode,
+            spline_points = spline_points,
+            spline_threshold = spline_threshold,
+            spline_convergence = spline_convergence,
+            spline_maximum_iterations = spline_maximum_iterations,
+            spline_rescale = spline_rescale,
+        )
+    elif smoothing_method == SmoothingMethod.CONVEX_HULL.value:
+        output_pixels = smooth_with_convex_hull(pixel_data, mask)
+    else:
         raise ValueError(
             "Unimplemented smoothing method: %s:" % smoothing_method.value
         )
-    output_pixels = smoothing_dispatcher[smoothing_method](
-        pixel_data, 
-        mask, 
-        automatic_object_width,
-        size_of_smoothing_filter,
-        object_width,
-        image_shape,
-        automatic_splines,
-        spline_bg_mode,
-        spline_points,
-        spline_threshold,
-        spline_convergence,
-        spline_maximum_iterations,
-        spline_rescale,
-    )
     return output_pixels
 
-    # if smoothing_method == SmoothingMethod.FIT_POLYNOMIAL.value:
-    #     output_pixels = smooth_with_polynomial(pixel_data, mask)
-    # elif smoothing_method == SmoothingMethod.GAUSSIAN_FILTER.value:
-    #     output_pixels = smooth_with_gaussian(pixel_data, mask, sigma)
-    # elif smoothing_method == SmoothingMethod.MEDIAN_FILTER.value:
-    #     output_pixels = smooth_with_median(pixel_data, mask, sigma)
-    # elif smoothing_method == SmoothingMethod.TO_AVERAGE.value:
-    #     output_pixels = smooth_to_average(pixel_data, mask)
-    # elif smoothing_method == SmoothingMethod.SPLINES.value:
-    #     output_pixels = smooth_with_splines(
-    #         pixel_data = pixel_data, 
-    #         mask = mask,
-    #         automatic_splines = automatic_splines,
-    #         spline_bg_mode = spline_bg_mode,
-    #         spline_points = spline_points,
-    #         spline_threshold = spline_threshold,
-    #         spline_convergence = spline_convergence,
-    #         spline_maximum_iterations = spline_maximum_iterations,
-    #         spline_rescale = spline_rescale,
-    #     )
-    # elif smoothing_method == SmoothingMethod.CONVEX_HULL.value:
-    #     output_pixels = smooth_with_convex_hull(pixel_data, mask)
-    # else:
-    #     raise ValueError(
-    #         "Unimplemented smoothing method: %s:" % smoothing_method.value
-    #     )
-    # return output_pixels
+def _get_sigma(
+        automatic_object_width: Optional[SmoothingFilterSize],
+        size_of_smoothing_filter: Optional[int],
+        object_width: Optional[int],
+        image_shape: Optional[Tuple[int, ...]],
+    ) -> float:
+    assert automatic_object_width is not None, "automatic_object_width must be provided for Gaussian or Median smoothing"
+    assert size_of_smoothing_filter is not None, "size_of_smoothing_filter must be provided for Gaussian or Median smoothing"
+    assert object_width is not None, "object_width must be provided for Gaussian or Median smoothing"
+    assert image_shape is not None, "image_shape must be provided for Gaussian or Median smoothing"
+    sigma = get_smoothing_filter_size(automatic_object_width, size_of_smoothing_filter, object_width, image_shape) / 2.35 # What's up with 2.35?
+    return sigma
 
 
-
-def smooth_with_polynomial(pixel_data, mask, *args, **kwargs):
+def smooth_with_polynomial(
+        pixel_data: Image2D, 
+        mask: Image2DMask
+    ) -> Image2D:
     return centrosome.smooth.fit_polynomial(pixel_data, mask)
 
-def smooth_with_gaussian(pixel_data, mask, sigma, *args, **kwargs):
+def smooth_with_gaussian(
+        pixel_data: Image2D,
+        mask: Image2DMask,
+        sigma: float
+    ) -> Image2D:
     #
     # Smoothing with the mask is good, even if there's no mask
     # because the mechanism undoes the edge effects that are introduced
     # by any choice of how to deal with border effects.
     #
-    assert sigma is not None, "sigma must be provided for Gaussian smoothing"
     def fn(image):
         return scipy.ndimage.gaussian_filter(
             image, sigma, mode="constant", cval=0
@@ -3214,8 +3231,11 @@ def smooth_with_gaussian(pixel_data, mask, sigma, *args, **kwargs):
     )
     return output_pixels
 
-def smooth_with_median(pixel_data, mask, sigma, *args, **kwargs):
-    assert sigma is not None, "sigma must be provided for median smoothing"
+def smooth_with_median(
+        pixel_data: Image2D, 
+        mask: Image2DMask,
+        sigma: float
+    ) -> Image2D:
     filter_sigma = max(1, int(sigma + 0.5))
     strel = centrosome.cpmorphology.strel_disk(filter_sigma)
     rescaled_pixel_data = pixel_data * 65535
@@ -3224,12 +3244,18 @@ def smooth_with_median(pixel_data, mask, sigma, *args, **kwargs):
     output_pixels = skimage.filters.median(rescaled_pixel_data, strel, behavior="rank")
     return output_pixels
 
-def smooth_to_average(pixel_data, mask, *args, **kwargs):
+def smooth_to_average(
+        pixel_data: Image2D, 
+        mask: Image2DMask
+    ) -> Image2D:
     mean = numpy.mean(pixel_data[mask])
     output_pixels = numpy.ones(pixel_data.shape, pixel_data.dtype) * mean
     return output_pixels
 
-def smooth_with_convex_hull(pixel_data, mask, *args, **kwargs):
+def smooth_with_convex_hull(
+        pixel_data: Image2D, 
+        mask: Image2DMask
+    ) -> Image2D:
     """Use the convex hull transform to smooth the image"""
     #
     # Apply an erosion, then the transform, then a dilation, heuristically
@@ -3251,9 +3277,7 @@ def smooth_with_splines(
         spline_convergence: Optional[float],
         spline_maximum_iterations: Optional[int],
         spline_rescale: Optional[float],
-        *args,
-        **kwargs,
-    ):
+    ) -> Image2D:
     assert automatic_splines is not None, "automatic_splines must be provided for spline smoothing"
     if automatic_splines:
         # Make the image 200 pixels long on its shortest side

--- a/src/subpackages/library/cellprofiler_library/functions/image_processing.py
+++ b/src/subpackages/library/cellprofiler_library/functions/image_processing.py
@@ -12,6 +12,9 @@ import skimage.exposure
 import centrosome
 import centrosome.threshold
 import centrosome.filter
+import centrosome.cpmorphology
+import centrosome.bg_compensate
+import centrosome.smooth
 import scipy
 import scipy.interpolate
 import scipy.sparse
@@ -45,6 +48,11 @@ from cellprofiler_library.opts.imagemath import Operator
 from cellprofiler_library.opts.flipandrotate import RotationCoordinateAlignmnet
 from cellprofiler_library.opts.enhanceedges import EdgeDirection
 from cellprofiler_library.opts.rescaleintensity import MaximumIntensityMethod, MinimumIntensityMethod
+from cellprofiler_library.opts.correctilluminationcalculate import (
+    SmoothingFilterSize,
+    SmoothingMethod,
+    SplineBackgroundMode,
+)
 invert = cast(Callable[[ImageAny], ImageAny], _invert)
 isscalar = cast(Callable[[Optional[ImageAny]], bool], _isscalar)
 
@@ -3105,3 +3113,188 @@ def apply_target_mask(x_data: ImageAny, masking_image: Union[ImageAny,ObjectSegm
     mask = masking_image.astype(bool)
     x_data[~mask] = 0
     return x_data
+
+###############################################################################
+# CorrectIlluminationCalculate
+###############################################################################
+
+def smooth_plane(
+        pixel_data: Image2D, 
+        mask: Image2DMask,
+        smoothing_method: SmoothingMethod,
+        automatic_object_width,
+        size_of_smoothing_filter,
+        object_width,
+        image_shape,
+        automatic_splines: Optional[bool],
+        spline_bg_mode: Optional[SplineBackgroundMode], 
+        spline_points: Optional[int],
+        spline_threshold: Optional[float],
+        spline_convergence: Optional[float],
+        spline_maximum_iterations: Optional[int],
+        spline_rescale: Optional[float],
+    ):
+    """Smooth one 2-d color plane of an image"""
+    smoothing_dispatcher = {
+        SmoothingMethod.FIT_POLYNOMIAL.value: smooth_with_polynomial,
+        SmoothingMethod.GAUSSIAN_FILTER.value: smooth_with_gaussian,
+        SmoothingMethod.MEDIAN_FILTER.value: smooth_with_median,
+        SmoothingMethod.TO_AVERAGE.value: smooth_to_average,
+        SmoothingMethod.SPLINES.value: smooth_with_splines,
+        SmoothingMethod.CONVEX_HULL.value: smooth_with_convex_hull,
+    }
+    if smoothing_method not in smoothing_dispatcher:
+        raise ValueError(
+            "Unimplemented smoothing method: %s:" % smoothing_method.value
+        )
+    output_pixels = smoothing_dispatcher[smoothing_method](
+        pixel_data, 
+        mask, 
+        automatic_object_width,
+        size_of_smoothing_filter,
+        object_width,
+        image_shape,
+        automatic_splines,
+        spline_bg_mode,
+        spline_points,
+        spline_threshold,
+        spline_convergence,
+        spline_maximum_iterations,
+        spline_rescale,
+    )
+    return output_pixels
+
+    # if smoothing_method == SmoothingMethod.FIT_POLYNOMIAL.value:
+    #     output_pixels = smooth_with_polynomial(pixel_data, mask)
+    # elif smoothing_method == SmoothingMethod.GAUSSIAN_FILTER.value:
+    #     output_pixels = smooth_with_gaussian(pixel_data, mask, sigma)
+    # elif smoothing_method == SmoothingMethod.MEDIAN_FILTER.value:
+    #     output_pixels = smooth_with_median(pixel_data, mask, sigma)
+    # elif smoothing_method == SmoothingMethod.TO_AVERAGE.value:
+    #     output_pixels = smooth_to_average(pixel_data, mask)
+    # elif smoothing_method == SmoothingMethod.SPLINES.value:
+    #     output_pixels = smooth_with_splines(
+    #         pixel_data = pixel_data, 
+    #         mask = mask,
+    #         automatic_splines = automatic_splines,
+    #         spline_bg_mode = spline_bg_mode,
+    #         spline_points = spline_points,
+    #         spline_threshold = spline_threshold,
+    #         spline_convergence = spline_convergence,
+    #         spline_maximum_iterations = spline_maximum_iterations,
+    #         spline_rescale = spline_rescale,
+    #     )
+    # elif smoothing_method == SmoothingMethod.CONVEX_HULL.value:
+    #     output_pixels = smooth_with_convex_hull(pixel_data, mask)
+    # else:
+    #     raise ValueError(
+    #         "Unimplemented smoothing method: %s:" % smoothing_method.value
+    #     )
+    # return output_pixels
+
+
+
+def smooth_with_polynomial(pixel_data, mask, *args, **kwargs):
+    return centrosome.smooth.fit_polynomial(pixel_data, mask)
+
+def smooth_with_gaussian(pixel_data, mask, sigma, *args, **kwargs):
+    #
+    # Smoothing with the mask is good, even if there's no mask
+    # because the mechanism undoes the edge effects that are introduced
+    # by any choice of how to deal with border effects.
+    #
+    assert sigma is not None, "sigma must be provided for Gaussian smoothing"
+    def fn(image):
+        return scipy.ndimage.gaussian_filter(
+            image, sigma, mode="constant", cval=0
+        )
+
+    output_pixels = centrosome.smooth.smooth_with_function_and_mask(
+        pixel_data, fn, mask
+    )
+    return output_pixels
+
+def smooth_with_median(pixel_data, mask, sigma, *args, **kwargs):
+    assert sigma is not None, "sigma must be provided for median smoothing"
+    filter_sigma = max(1, int(sigma + 0.5))
+    strel = centrosome.cpmorphology.strel_disk(filter_sigma)
+    rescaled_pixel_data = pixel_data * 65535
+    rescaled_pixel_data = rescaled_pixel_data.astype(numpy.uint16)
+    rescaled_pixel_data *= mask
+    output_pixels = skimage.filters.median(rescaled_pixel_data, strel, behavior="rank")
+    return output_pixels
+
+def smooth_to_average(pixel_data, mask, *args, **kwargs):
+    mean = numpy.mean(pixel_data[mask])
+    output_pixels = numpy.ones(pixel_data.shape, pixel_data.dtype) * mean
+    return output_pixels
+
+def smooth_with_convex_hull(pixel_data, mask, *args, **kwargs):
+    """Use the convex hull transform to smooth the image"""
+    #
+    # Apply an erosion, then the transform, then a dilation, heuristically
+    # to ignore little spikey noisy things.
+    #
+    image = centrosome.cpmorphology.grey_erosion(pixel_data, 2, mask)
+    image = centrosome.filter.convex_hull_transform(image, mask=mask)
+    image = centrosome.cpmorphology.grey_dilation(image, 2, mask)
+    return image
+
+
+def smooth_with_splines(
+        pixel_data: Image2D, 
+        mask: Image2DMask,
+        automatic_splines: bool,
+        spline_bg_mode: Optional[SplineBackgroundMode],
+        spline_points: Optional[int],
+        spline_threshold: Optional[float],
+        spline_convergence: Optional[float],
+        spline_maximum_iterations: Optional[int],
+        spline_rescale: Optional[float],
+        *args,
+        **kwargs,
+    ):
+    assert automatic_splines is not None, "automatic_splines must be provided for spline smoothing"
+    if automatic_splines:
+        # Make the image 200 pixels long on its shortest side
+        shortest_side = min(pixel_data.shape)
+        if shortest_side < 200:
+            scale = 1
+        else:
+            scale = float(shortest_side) / 200
+        result = centrosome.bg_compensate.backgr(pixel_data, mask, scale=scale) # type: ignore # scale can be a float
+    else:
+        assert spline_bg_mode is not None, "spline_bg_mode must be provided for spline smoothing"
+        assert spline_points is not None, "spline_points must be provided for spline smoothing"
+        assert spline_threshold is not None, "spline_threshold must be provided for spline smoothing"
+        assert spline_convergence is not None, "spline_convergence must be provided for spline smoothing"
+        assert spline_maximum_iterations is not None, "spline_maximum_iterations must be provided for spline smoothing"
+        assert spline_rescale is not None, "spline_rescale must be provided for spline smoothing"
+        mode = spline_bg_mode
+        spline_points = spline_points
+        threshold = spline_threshold
+        convergence = spline_convergence
+        iterations = spline_maximum_iterations
+        rescale = spline_rescale
+        result = centrosome.bg_compensate.backgr(
+            pixel_data,
+            mask,
+            mode=mode,
+            thresh=threshold, # type: ignore # threshold can be a float
+            splinepoints=spline_points,
+            scale=rescale, # type: ignore # scale can be a float
+            maxiter=iterations,
+            convergence=convergence,
+        )
+    #
+    # The result is a fit to the background intensity, but we
+    # want to normalize the intensity by subtraction, leaving
+    # the mean intensity alone.
+    #
+    if mask is not None:
+        mean_intensity = numpy.mean(result[mask])
+        result[mask] -= mean_intensity
+    else:
+        mean_intensity = numpy.mean(result)
+        result -= mean_intensity
+    return result

--- a/src/subpackages/library/cellprofiler_library/functions/image_processing.py
+++ b/src/subpackages/library/cellprofiler_library/functions/image_processing.py
@@ -3232,7 +3232,7 @@ def smooth_with_gaussian(
     return output_pixels
 
 def smooth_with_median(
-        pixel_data: Image2D, 
+        pixel_data: Image2D,
         mask: Image2DMask,
         sigma: float
     ) -> Image2D:
@@ -3242,7 +3242,10 @@ def smooth_with_median(
     rescaled_pixel_data = rescaled_pixel_data.astype(numpy.uint16)
     rescaled_pixel_data *= mask
     output_pixels = skimage.filters.median(rescaled_pixel_data, strel, behavior="rank")
-    return output_pixels
+    # skimage's rank median preserves the uint16 dtype of its input; rescale
+    # back to the [0, 1]-ish float range the rest of the pipeline expects,
+    # matching the input's precision rather than widening it.
+    return (output_pixels / 65535.0).astype(pixel_data.dtype)
 
 def smooth_to_average(
         pixel_data: Image2D, 

--- a/src/subpackages/library/cellprofiler_library/modules/_correctilluminationcalculate.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_correctilluminationcalculate.py
@@ -78,9 +78,6 @@ def get_smoothing_filter_size(
         raise ValueError(f"Unknown smoothing filter size: {automatic_object_width}")
     return filter_size
 
-# intensity_choice = self.intensity_choice.value
-# smoothing_method = self.smoothing_method.value
-# block_size = self.block_size.value
 def preprocess_image_for_averaging(
         orig_image,
         intensity_choice: IntensityChoice,
@@ -124,8 +121,6 @@ def preprocess_image_for_averaging(
         avg_image = min_block
     return avg_image
 
-# image_pixel_data = image.pixel_data
-# image_mask = image.mask
 def apply_smoothing(
         image_pixel_data,
         image_mask,
@@ -151,8 +146,6 @@ def apply_smoothing(
     orig_image - the ancestor source image or None if ambiguous
     returns another instance of cpimage.Image
     """
-    # if self.smoothing_method == SmoothingMethod.NONE.value:
-    #     return image
     pixel_data = image_pixel_data
     if pixel_data.ndim == 3:
         output_pixels = numpy.zeros(pixel_data.shape, pixel_data.dtype)
@@ -190,7 +183,6 @@ def apply_smoothing(
             spline_maximum_iterations = spline_maximum_iterations,
             spline_rescale = spline_rescale,
         )
-    # output_image = Image(output_pixels, parent_image=orig_image)
     return output_pixels
 
 def smooth_plane(
@@ -269,13 +261,6 @@ def smooth_with_convex_hull(pixel_data, mask):
     image = centrosome.cpmorphology.grey_dilation(image, 2, mask)
     return image
 
-# automatic_splines = self.automatic_splines
-# spline_bg_mode = self.spline_bg_mode.value
-# spline_points = self.spline_points.value
-# spline_threshold = self.spline_threshold.value
-# spline_convergence = self.spline_convergence.value
-# spline_maximum_iterations = self.spline_maximum_iterations.value
-# spline_rescale = self.spline_rescale.value
 def smooth_with_splines(
         pixel_data, 
         mask,
@@ -327,8 +312,6 @@ def smooth_with_splines(
     result[mask] -= mean_intensity
     return result
 
-# rescale_option = self.rescale_option.value
-# image_mask = None if image.has_mask else image.mask
 def apply_scaling(
         image_pixel_data,
         image_mask, 

--- a/src/subpackages/library/cellprofiler_library/modules/_correctilluminationcalculate.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_correctilluminationcalculate.py
@@ -5,14 +5,15 @@ import numpy
 import skimage.filters
 import centrosome.bg_compensate
 import centrosome.filter
-from typing import Optional, Tuple
-
+from typing import Any, Dict, Optional, Tuple
+from cellprofiler_library.types import Image2D, Image2DMask
 from cellprofiler_library.opts.correctilluminationcalculate import (
     SmoothingFilterSize,
     IntensityChoice,
     SmoothingMethod,
     SplineBackgroundMode,
     RescaleIlluminationFunction,
+    StateKey,
 )
 
 
@@ -20,19 +21,22 @@ from cellprofiler_library.opts.correctilluminationcalculate import (
 ROBUST_FACTOR = 0.02  # For rescaling, take 2nd percentile value
 
 def apply_dilation(
-        image, 
-        object_dilation_radius,
-    ):
-    """Return an image that is dilated according to the settings
+        pixel_data: Image2D,
+        mask: Image2DMask,
+        object_dilation_radius: int,
+    ) -> Image2D:
+    """Return pixel data dilated with a circular Gaussian kernel.
 
-    image - an instance of cpimage.Image
+    This filter spreads the boundaries of cells, effectively "dilating" them.
 
-    returns another instance of cpimage.Image
+    Args:
+        pixel_data: 2-D or 3-D image array (H, W) or (H, W, C).
+        mask: Boolean mask array (H, W). True = valid pixel.
+        object_dilation_radius: Radius for the circular Gaussian kernel.
+
+    Returns:
+        Dilated pixel data array of the same shape as pixel_data.
     """
-    #
-    # This filter is designed to spread the boundaries of cells
-    # and this "dilates" the cells
-    #
     kernel = centrosome.smooth.circular_gaussian_kernel(
         object_dilation_radius, object_dilation_radius * 3
     )
@@ -40,17 +44,17 @@ def apply_dilation(
     def fn(image):
         return scipy.ndimage.convolve(image, kernel, mode="constant", cval=0)
 
-    if image.pixel_data.ndim == 2:
+    if pixel_data.ndim == 2:
         dilated_pixels = centrosome.smooth.smooth_with_function_and_mask(
-            image.pixel_data, fn, image.mask
+            pixel_data, fn, mask
         )
     else:
         dilated_pixels = numpy.dstack(
             [
                 centrosome.smooth.smooth_with_function_and_mask(
-                    x, fn, image.mask
+                    x, fn, mask
                 )
-                for x in image.pixel_data.transpose(2, 0, 1)
+                for x in pixel_data.transpose(2, 0, 1)
             ]
         )
     return dilated_pixels
@@ -79,47 +83,155 @@ def get_smoothing_filter_size(
     return filter_size
 
 def preprocess_image_for_averaging(
-        orig_image,
+        pixel_data: Image2D,
+        mask: Optional[Image2DMask],
         intensity_choice: IntensityChoice,
         smoothing_method: SmoothingMethod,
         block_size: int,
-    ):
-    """Create a version of the image appropriate for averaging
+    ) -> Image2D:
+    """Create a version of the image appropriate for averaging.
 
+    For Regular or Splines mode: zeros out masked pixels (if any) and
+    returns the result. For Background mode: finds the minimum pixel
+    intensity within blocks and returns a block-minimum image.
+
+    Args:
+        pixel_data: Image array (H, W) or (H, W, C).
+        has_mask: Whether a mask is present.
+        mask: Boolean mask array (H, W); True = valid. Required when
+            has_mask is True.
+        intensity_choice: Regular or Background illumination method.
+        smoothing_method: The smoothing method selected (affects whether
+            the Splines branch is used).
+        block_size: Side length in pixels of each background block
+            (Background mode only).
+
+    Returns:
+        Preprocessed image array suitable for accumulation.
     """
-    pixels = orig_image.pixel_data
     if intensity_choice == IntensityChoice.REGULAR.value or smoothing_method == SmoothingMethod.SPLINES.value:
-        if orig_image.has_mask:
+        if mask is not None:
+            pixels = pixel_data.copy()
             if pixels.ndim == 2:
-                pixels[~orig_image.mask] = 0
+                pixels[~mask] = 0
             else:
-                pixels[~orig_image.mask, :] = 0
-            avg_image = pixels
+                pixels[~mask, :] = 0
+            return pixels
         else:
-            avg_image = orig_image
+            return pixel_data
     else:
         # For background, we create a labels image using the block
         # size and find the minimum within each block.
         labels, indexes = centrosome.cpmorphology.block(
-            pixels.shape[:2], (block_size, block_size)
+            pixel_data.shape[:2], (block_size, block_size)
         )
-        if orig_image.has_mask:
-            labels[~orig_image.mask] = -1
+        if mask is not None:
+            labels[~mask] = -1
 
-        min_block = numpy.zeros(pixels.shape)
-        if pixels.ndim == 2:
+        min_block = numpy.zeros(pixel_data.shape)
+        if pixel_data.ndim == 2:
             minima = centrosome.cpmorphology.fixup_scipy_ndimage_result(
-                scipy.ndimage.minimum(pixels, labels, indexes)
+                scipy.ndimage.minimum(pixel_data, labels, indexes)
             )
             min_block[labels != -1] = minima[labels[labels != -1]]
         else:
-            for i in range(pixels.shape[2]):
+            for i in range(pixel_data.shape[2]):
                 minima = centrosome.cpmorphology.fixup_scipy_ndimage_result(
-                    scipy.ndimage.minimum(pixels[:, :, i], labels, indexes)
+                    scipy.ndimage.minimum(pixel_data[:, :, i], labels, indexes)
                 )
                 min_block[labels != -1, i] = minima[labels[labels != -1]]
-        avg_image = min_block
-    return avg_image
+        return min_block
+
+
+def initialize_illumination_accumulation(
+        preprocessed_pixel_data: numpy.ndarray,
+        mask: Optional[numpy.ndarray],
+) -> Dict[str, Any]:
+    """Initialize the illumination accumulation state from the first image.
+
+    Creates a zeroed image_sum and mask_count, then accumulates the
+    first (already preprocessed) image into them.
+
+    Args:
+        preprocessed_pixel_data: Output of preprocess_image_for_averaging
+            for the first image, shape (H, W) or (H, W, C).
+        has_mask: Whether the image has a mask.
+        mask: Boolean mask (H, W); True = valid. Required when has_mask
+            is True.
+
+    Returns:
+        Initial accumulation state dict with StateKey.IMAGE_SUM and
+        StateKey.MASK_COUNT entries.
+    """
+    state: Dict[str, Any] = {
+        StateKey.IMAGE_SUM.value: numpy.zeros(
+            preprocessed_pixel_data.shape, preprocessed_pixel_data.dtype
+        ),
+        StateKey.MASK_COUNT.value: numpy.zeros(
+            preprocessed_pixel_data.shape[:2], numpy.int32
+        ),
+    }
+    accumulate_illumination_image(preprocessed_pixel_data, mask, state)
+    return state
+
+
+def accumulate_illumination_image(
+        preprocessed_pixel_data: numpy.ndarray,
+        mask: Optional[numpy.ndarray],
+        state: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Accumulate a preprocessed image into the illumination state.
+
+    Args:
+        preprocessed_pixel_data: Output of preprocess_image_for_averaging,
+            shape (H, W) or (H, W, C).
+        has_mask: Whether the image has a mask.
+        mask: Boolean mask (H, W); True = valid. Required when has_mask
+            is True.
+        state: Existing accumulation state dict (mutated in place).
+
+    Returns:
+        The updated state dict (same object as input).
+    """
+    image_sum = state[StateKey.IMAGE_SUM.value]
+    mask_count = state[StateKey.MASK_COUNT.value]
+    if mask is not None:
+        if image_sum.ndim == 2:
+            image_sum[mask] += preprocessed_pixel_data[mask]
+        else:
+            image_sum[mask, :] += preprocessed_pixel_data[mask, :]
+        mask_count[mask] += 1
+    else:
+        image_sum += preprocessed_pixel_data
+        mask_count += 1
+    return state
+
+
+def calculate_average_from_state(
+        state: Dict[str, Any],
+) -> Tuple[numpy.ndarray, numpy.ndarray]:
+    """Compute the average illumination image from the accumulated state.
+
+    Args:
+        state: Accumulation state dict produced by
+            initialize_illumination_accumulation /
+            accumulate_illumination_image.
+
+    Returns:
+        Tuple of (avg_pixel_data, mask) where avg_pixel_data contains
+        the per-pixel mean values and mask is a boolean array
+        (True where at least one image contributed).
+    """
+    image_sum = state[StateKey.IMAGE_SUM.value]
+    mask_count = state[StateKey.MASK_COUNT.value]
+    pixel_data = numpy.zeros(image_sum.shape, image_sum.dtype)
+    mask = mask_count > 0
+    if pixel_data.ndim == 2:
+        pixel_data[mask] = image_sum[mask] / mask_count[mask]
+    else:
+        for i in range(pixel_data.shape[2]):
+            pixel_data[mask, i] = image_sum[mask, i] / mask_count[mask]
+    return pixel_data, mask
 
 def apply_smoothing(
         image_pixel_data,
@@ -193,7 +305,7 @@ def smooth_plane(
         size_of_smoothing_filter: Optional[int], # default to 10
         object_width: Optional[int], # default to 10 
         image_shape: Optional[Tuple[int, ...]],
-        automatic_splines: bool,
+        automatic_splines: Optional[bool],
         spline_bg_mode: Optional[SplineBackgroundMode], 
         spline_points: Optional[int],
         spline_threshold: Optional[float],
@@ -231,6 +343,7 @@ def smooth_plane(
         mean = numpy.mean(pixel_data[mask])
         output_pixels = numpy.ones(pixel_data.shape, pixel_data.dtype) * mean
     elif smoothing_method == SmoothingMethod.SPLINES.value:
+        assert automatic_splines is not None, "automatic_splines must be provided for spline smoothing"
         output_pixels = smooth_with_splines(
             pixel_data = pixel_data, 
             mask = mask,

--- a/src/subpackages/library/cellprofiler_library/modules/_correctilluminationcalculate.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_correctilluminationcalculate.py
@@ -12,8 +12,10 @@ from cellprofiler_library.opts.correctilluminationcalculate import (
     IntensityChoice,
     SmoothingMethod,
     SplineBackgroundMode,
-    RescaleIlluminationFunction
+    RescaleIlluminationFunction,
 )
+
+
 
 ROBUST_FACTOR = 0.02  # For rescaling, take 2nd percentile value
 
@@ -136,12 +138,12 @@ def apply_smoothing(
         image_shape: Optional[Tuple[int, ...]],
         # spline args
         automatic_splines: bool,
-        spline_bg_mode: SplineBackgroundMode,
-        spline_points: int,
-        spline_threshold: float,
-        spline_convergence: float,
-        spline_maximum_iterations: int,
-        spline_rescale: float,
+        spline_bg_mode: Optional[SplineBackgroundMode],
+        spline_points: Optional[int],
+        spline_threshold: Optional[float],
+        spline_convergence: Optional[float],
+        spline_maximum_iterations: Optional[int],
+        spline_rescale: Optional[float],
     ):
     """Return an image that is smoothed according to the settings
 
@@ -200,12 +202,12 @@ def smooth_plane(
         object_width: Optional[int], # default to 10 
         image_shape: Optional[Tuple[int, ...]],
         automatic_splines: bool,
-        spline_bg_mode: SplineBackgroundMode,
-        spline_points: int,
-        spline_threshold: float,
-        spline_convergence: float,
-        spline_maximum_iterations: int,
-        spline_rescale: float,
+        spline_bg_mode: Optional[SplineBackgroundMode], 
+        spline_points: Optional[int],
+        spline_threshold: Optional[float],
+        spline_convergence: Optional[float],
+        spline_maximum_iterations: Optional[int],
+        spline_rescale: Optional[float],
     ):
     """Smooth one 2-d color plane of an image"""
 
@@ -238,15 +240,15 @@ def smooth_plane(
         output_pixels = numpy.ones(pixel_data.shape, pixel_data.dtype) * mean
     elif smoothing_method == SmoothingMethod.SPLINES.value:
         output_pixels = smooth_with_splines(
-            pixel_data, 
-            mask,
-            automatic_splines,
-            spline_bg_mode,
-            spline_points,
-            spline_threshold,
-            spline_convergence,
-            spline_maximum_iterations,
-            spline_rescale,
+            pixel_data = pixel_data, 
+            mask = mask,
+            automatic_splines = automatic_splines,
+            spline_bg_mode = spline_bg_mode,
+            spline_points = spline_points,
+            spline_threshold = spline_threshold,
+            spline_convergence = spline_convergence,
+            spline_maximum_iterations = spline_maximum_iterations,
+            spline_rescale = spline_rescale,
         )
     elif smoothing_method == SmoothingMethod.CONVEX_HULL.value:
         output_pixels = smooth_with_convex_hull(pixel_data, mask)
@@ -278,13 +280,12 @@ def smooth_with_splines(
         pixel_data, 
         mask,
         automatic_splines: bool,
-        # centrosome.bg_compensate args
-        spline_bg_mode: SplineBackgroundMode,
-        spline_points: int,
-        spline_threshold: float,
-        spline_convergence: float,
-        spline_maximum_iterations: int,
-        spline_rescale: float,
+        spline_bg_mode: Optional[SplineBackgroundMode],
+        spline_points: Optional[int],
+        spline_threshold: Optional[float],
+        spline_convergence: Optional[float],
+        spline_maximum_iterations: Optional[int],
+        spline_rescale: Optional[float],
     ):
     if automatic_splines:
         # Make the image 200 pixels long on its shortest side
@@ -295,6 +296,12 @@ def smooth_with_splines(
             scale = float(shortest_side) / 200
         result = centrosome.bg_compensate.backgr(pixel_data, mask, scale=scale)
     else:
+        assert spline_bg_mode is not None, "spline_bg_mode must be provided for spline smoothing"
+        assert spline_points is not None, "spline_points must be provided for spline smoothing"
+        assert spline_threshold is not None, "spline_threshold must be provided for spline smoothing"
+        assert spline_convergence is not None, "spline_convergence must be provided for spline smoothing"
+        assert spline_maximum_iterations is not None, "spline_maximum_iterations must be provided for spline smoothing"
+        assert spline_rescale is not None, "spline_rescale must be provided for spline smoothing"
         mode = spline_bg_mode
         spline_points = spline_points
         threshold = spline_threshold
@@ -321,28 +328,29 @@ def smooth_with_splines(
     return result
 
 # rescale_option = self.rescale_option.value
+# image_mask = None if image.has_mask else image.mask
 def apply_scaling(
-        image, 
+        image_pixel_data,
+        image_mask, 
         rescale_option: RescaleIlluminationFunction,
-        orig_image=None
     ):
     """Return an image that is rescaled according to the settings
 
     image - an instance of cpimage.Image
     returns another instance of cpimage.Image
     """
-    if rescale_option == "No":
-        return image
+    if rescale_option == RescaleIlluminationFunction.NO.value:
+        return image_pixel_data
 
     def scaling_fn_2d(pixel_data):
-        if image.has_mask:
-            sorted_pixel_data = pixel_data[(pixel_data > 0) & image.mask]
+        if image_mask is not None:
+            sorted_pixel_data = pixel_data[(pixel_data > 0) & image_mask]
         else:
             sorted_pixel_data = pixel_data[pixel_data > 0]
         if sorted_pixel_data.shape[0] == 0:
             return pixel_data
         sorted_pixel_data.sort()
-        if rescale_option == "Yes":
+        if rescale_option == RescaleIlluminationFunction.YES.value:
             idx = int(sorted_pixel_data.shape[0] * ROBUST_FACTOR)
             robust_minimum = sorted_pixel_data[idx]
             pixel_data = pixel_data.copy()
@@ -350,14 +358,16 @@ def apply_scaling(
         elif rescale_option == RescaleIlluminationFunction.MEDIAN.value:
             idx = int(sorted_pixel_data.shape[0] / 2)
             robust_minimum = sorted_pixel_data[idx]
+        else: 
+            raise ValueError(f"Unknown rescale option: {rescale_option}")
         if robust_minimum == 0:
             return pixel_data
         return pixel_data / robust_minimum
 
-    if image.pixel_data.ndim == 2:
-        output_pixels = scaling_fn_2d(image.pixel_data)
+    if image_pixel_data.ndim == 2:
+        output_pixels = scaling_fn_2d(image_pixel_data)
     else:
         output_pixels = numpy.dstack(
-            [scaling_fn_2d(x) for x in image.pixel_data.transpose(2, 0, 1)]
+            [scaling_fn_2d(x) for x in image_pixel_data.transpose(2, 0, 1)]
         )
     return output_pixels

--- a/src/subpackages/library/cellprofiler_library/modules/_correctilluminationcalculate.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_correctilluminationcalculate.py
@@ -3,7 +3,7 @@ import centrosome.cpmorphology
 import scipy.ndimage
 import numpy
 from typing import Any, Dict, Optional, Tuple, Annotated
-from pydantic import validate_call, ConfigDict
+from pydantic import Field, validate_call, ConfigDict
 from cellprofiler_library.types import Image2D, Image2DMask
 from cellprofiler_library.opts.correctilluminationcalculate import (
     SmoothingFilterSize,
@@ -20,21 +20,21 @@ ROBUST_FACTOR = 0.02  # For rescaling, take 2nd percentile value
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def apply_dilation(
-        pixel_data: Image2D,
-        mask: Image2DMask,
-        object_dilation_radius: int,
+        pixel_data:             Annotated[Image2D, Field(description="Input image for dilation")],
+        mask:                   Annotated[Image2DMask, Field(description="Input image mask")],
+        object_dilation_radius: Annotated[int, Field(description="Radius for the circular Gaussian dilation kernel")],
     ) -> Image2D:
     """Return pixel data dilated with a circular Gaussian kernel.
 
     This filter spreads the boundaries of cells, effectively "dilating" them.
 
     Args:
-        pixel_data: 2-D or 3-D image array (H, W) or (H, W, C).
-        mask: Boolean mask array (H, W). True = valid pixel.
-        object_dilation_radius: Radius for the circular Gaussian kernel.
+        pixel_data: Input image for dilation.
+        mask: Input image mask.
+        object_dilation_radius: Radius for the circular Gaussian dilation kernel.
 
     Returns:
-        Dilated pixel data array of the same shape as pixel_data.
+        Dilated pixel data of same shape as input.
     """
     kernel = centrosome.smooth.circular_gaussian_kernel(
         object_dilation_radius, object_dilation_radius * 3
@@ -60,11 +60,11 @@ def apply_dilation(
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def preprocess_image_for_averaging(
-        pixel_data: Image2D,
-        mask: Optional[Image2DMask],
-        intensity_choice: IntensityChoice,
-        smoothing_method: SmoothingMethod,
-        block_size: int,
+        pixel_data:         Annotated[Image2D, Field(description="Input image for averaging")],
+        mask:               Annotated[Optional[Image2DMask], Field(description="Input image mask, or None if no mask")],
+        intensity_choice:   Annotated[IntensityChoice, Field(description="'Regular' uses per-pixel intensity; 'Background' finds block minima")],
+        smoothing_method:   Annotated[SmoothingMethod, Field(description="Smoothing method; Splines triggers the Regular code path")],
+        block_size:         Annotated[int, Field(description="Block side length in pixels for Background mode")],
     ) -> Image2D:
     """Create a version of the image appropriate for averaging.
 
@@ -73,18 +73,16 @@ def preprocess_image_for_averaging(
     intensity within blocks and returns a block-minimum image.
 
     Args:
-        pixel_data: Image array (H, W) or (H, W, C).
-        has_mask: Whether a mask is present.
-        mask: Boolean mask array (H, W); True = valid. Required when
-            has_mask is True.
-        intensity_choice: Regular or Background illumination method.
-        smoothing_method: The smoothing method selected (affects whether
-            the Splines branch is used).
-        block_size: Side length in pixels of each background block
-            (Background mode only).
+        pixel_data: Input image for averaging.
+        mask: Input image mask, or None if no mask.
+        intensity_choice: 'Regular' uses per-pixel intensity; 'Background'
+            finds block minima.
+        smoothing_method: Smoothing method; Splines triggers the Regular
+            code path.
+        block_size: Block side length in pixels for Background mode.
 
     Returns:
-        Preprocessed image array suitable for accumulation.
+        Preprocessed image suitable for accumulation.
     """
     if intensity_choice == IntensityChoice.REGULAR.value or smoothing_method == SmoothingMethod.SPLINES.value:
         if mask is not None:
@@ -120,8 +118,8 @@ def preprocess_image_for_averaging(
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def initialize_illumination_accumulation(
-        preprocessed_pixel_data: numpy.ndarray,
-        mask: Optional[numpy.ndarray],
+        preprocessed_pixel_data:    Annotated[numpy.ndarray, Field(description="Preprocessed image from preprocess_image_for_averaging, shape (H, W) or (H, W, C)")],
+        mask:                       Annotated[Optional[numpy.ndarray], Field(description="Input image mask, or None if no mask")],
 ) -> Dict[str, Any]:
     """Initialize the illumination accumulation state from the first image.
 
@@ -129,15 +127,12 @@ def initialize_illumination_accumulation(
     first (already preprocessed) image into them.
 
     Args:
-        preprocessed_pixel_data: Output of preprocess_image_for_averaging
-            for the first image, shape (H, W) or (H, W, C).
-        has_mask: Whether the image has a mask.
-        mask: Boolean mask (H, W); True = valid. Required when has_mask
-            is True.
+        preprocessed_pixel_data: Preprocessed image from
+            preprocess_image_for_averaging, shape (H, W) or (H, W, C).
+        mask: Input image mask, or None if no mask.
 
     Returns:
-        Initial accumulation state dict with StateKey.IMAGE_SUM and
-        StateKey.MASK_COUNT entries.
+        Initial accumulation state with image_sum and mask_count.
     """
     state: Dict[str, Any] = {
         StateKey.IMAGE_SUM.value: numpy.zeros(
@@ -152,22 +147,20 @@ def initialize_illumination_accumulation(
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def accumulate_illumination_image(
-        preprocessed_pixel_data: numpy.ndarray,
-        mask: Optional[numpy.ndarray],
-        state: Dict[str, Any],
+        preprocessed_pixel_data: Annotated[numpy.ndarray, Field(description="Preprocessed image from preprocess_image_for_averaging, shape (H, W) or (H, W, C)")],
+        mask:                   Annotated[Optional[numpy.ndarray], Field(description="Input image mask, or None if no mask")],
+        state:                  Annotated[Dict[str, Any], Field(description="Existing accumulation state dict (mutated in place)")],
 ) -> Dict[str, Any]:
     """Accumulate a preprocessed image into the illumination state.
 
     Args:
-        preprocessed_pixel_data: Output of preprocess_image_for_averaging,
-            shape (H, W) or (H, W, C).
-        has_mask: Whether the image has a mask.
-        mask: Boolean mask (H, W); True = valid. Required when has_mask
-            is True.
+        preprocessed_pixel_data: Preprocessed image from
+            preprocess_image_for_averaging, shape (H, W) or (H, W, C).
+        mask: Input image mask, or None if no mask.
         state: Existing accumulation state dict (mutated in place).
 
     Returns:
-        The updated state dict (same object as input).
+        Updated accumulation state (same object as input).
     """
     image_sum = state[StateKey.IMAGE_SUM.value]
     mask_count = state[StateKey.MASK_COUNT.value]
@@ -184,19 +177,16 @@ def accumulate_illumination_image(
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def calculate_average_from_state(
-        state: Dict[str, Any],
-) -> Tuple[numpy.ndarray, numpy.ndarray]:
+        state: Annotated[Dict[str, Any], Field(description="Accumulation state from initialize/accumulate functions")],
+) -> Tuple[Image2D, Image2DMask]:
     """Compute the average illumination image from the accumulated state.
 
     Args:
-        state: Accumulation state dict produced by
-            initialize_illumination_accumulation /
-            accumulate_illumination_image.
+        state: Accumulation state from initialize/accumulate functions.
 
     Returns:
-        Tuple of (avg_pixel_data, mask) where avg_pixel_data contains
-        the per-pixel mean values and mask is a boolean array
-        (True where at least one image contributed).
+        Tuple of (average pixel data, boolean mask where at least one
+        image contributed).
     """
     image_sum = state[StateKey.IMAGE_SUM.value]
     mask_count = state[StateKey.MASK_COUNT.value]
@@ -211,26 +201,48 @@ def calculate_average_from_state(
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def apply_smoothing(
-        image_pixel_data: Image2D,
-        image_mask: Image2DMask,
-        smoothing_method: SmoothingMethod,
-        automatic_object_width: Optional[SmoothingFilterSize], 
-        size_of_smoothing_filter: Optional[int], # default to 10
-        object_width: Optional[int], # default to 10 
-        image_shape: Optional[Tuple[int, ...]],
-        automatic_splines: bool,
-        spline_bg_mode: Optional[SplineBackgroundMode],
-        spline_points: Optional[int],
-        spline_threshold: Optional[float],
-        spline_convergence: Optional[float],
-        spline_maximum_iterations: Optional[int],
-        spline_rescale: Optional[float],
-    ):
-    """Return an image that is smoothed according to the settings
+        image_pixel_data: Annotated[Image2D, Field(description="Pixel data of image to smooth")],
+        image_mask: Annotated[Image2DMask, Field(description="Input image mask; True = valid pixel")],
+        smoothing_method: Annotated[SmoothingMethod, Field(description="Smoothing method to apply")],
+        automatic_object_width: Annotated[Optional[SmoothingFilterSize], Field(description="Method to calculate smoothing filter size (Automatic, Object size, or Manually)")],
+        size_of_smoothing_filter: Annotated[Optional[int], Field(description="Manual smoothing filter size in pixels")],
+        object_width: Annotated[Optional[int], Field(description="Approximate object diameter in pixels for filter size calculation")],
+        image_shape: Annotated[Optional[Tuple[int, ...]], Field(description="Shape of the original image (H, W)")],
+        automatic_splines: Annotated[bool, Field(description="Whether to automatically calculate spline parameters")],
+        spline_bg_mode: Annotated[Optional[SplineBackgroundMode], Field(description="Background mode for spline fitting (auto, dark, bright, or gray)")],
+        spline_points: Annotated[Optional[int], Field(description="Number of spline control points in the grid")],
+        spline_threshold: Annotated[Optional[float], Field(description="Std-dev cutoff for background pixel classification")],
+        spline_convergence: Annotated[Optional[float], Field(description="Residual value fraction for convergence criterion")],
+        spline_maximum_iterations: Annotated[Optional[int], Field(description="Maximum number of spline fitting iterations")],
+        spline_rescale: Annotated[Optional[float], Field(description="Image resampling factor for spline computation")],
+    ) -> Image2D:
+    """Return an image that is smoothed according to the settings.
 
-    image - an instance of cpimage.Image containing the pixels to analyze
-    orig_image - the ancestor source image or None if ambiguous
-    returns another instance of cpimage.Image
+    Args:
+        image_pixel_data: Pixel data of image to smooth.
+        image_mask: Input image mask; True = valid pixel.
+        smoothing_method: Smoothing method to apply.
+        automatic_object_width: Method to calculate smoothing filter size
+            (Automatic, Object size, or Manually).
+        size_of_smoothing_filter: Manual smoothing filter size in pixels.
+        object_width: Approximate object diameter in pixels for filter
+            size calculation.
+        image_shape: Shape of the original image (H, W).
+        automatic_splines: Whether to automatically calculate spline
+            parameters.
+        spline_bg_mode: Background mode for spline fitting (auto, dark,
+            bright, or gray).
+        spline_points: Number of spline control points in the grid.
+        spline_threshold: Std-dev cutoff for background pixel
+            classification.
+        spline_convergence: Residual value fraction for convergence
+            criterion.
+        spline_maximum_iterations: Maximum number of spline fitting
+            iterations.
+        spline_rescale: Image resampling factor for spline computation.
+
+    Returns:
+        Smoothed pixel data.
     """
     pixel_data = image_pixel_data
     if pixel_data.ndim == 3:
@@ -273,14 +285,21 @@ def apply_smoothing(
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def apply_scaling(
-        image_pixel_data,
-        image_mask, 
-        rescale_option: RescaleIlluminationFunction,
-    ):
-    """Return an image that is rescaled according to the settings
+        image_pixel_data:   Annotated[Image2D, Field(description="Pixel data of the illumination function to rescale")],
+        image_mask:         Annotated[Optional[Image2DMask], Field(description="Input image mask, or None if no mask")],
+        rescale_option:     Annotated[RescaleIlluminationFunction, Field(description="Rescaling method: Yes (robust minimum), No (skip), or Median")],
+    ) -> Image2D:
+    """Return an image that is rescaled according to the settings.
 
-    image - an instance of cpimage.Image
-    returns another instance of cpimage.Image
+    Args:
+        image_pixel_data: Pixel data of the illumination function to
+            rescale.
+        image_mask: Input image mask, or None if no mask.
+        rescale_option: Rescaling method: Yes (robust minimum), No
+            (skip), or Median.
+
+    Returns:
+        Rescaled pixel data.
     """
     if rescale_option == RescaleIlluminationFunction.NO.value:
         return image_pixel_data

--- a/src/subpackages/library/cellprofiler_library/modules/_correctilluminationcalculate.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_correctilluminationcalculate.py
@@ -2,10 +2,8 @@ import centrosome.smooth
 import centrosome.cpmorphology
 import scipy.ndimage
 import numpy
-import skimage.filters
-import centrosome.bg_compensate
-import centrosome.filter
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, Annotated
+from pydantic import validate_call, ConfigDict
 from cellprofiler_library.types import Image2D, Image2DMask
 from cellprofiler_library.opts.correctilluminationcalculate import (
     SmoothingFilterSize,
@@ -16,15 +14,11 @@ from cellprofiler_library.opts.correctilluminationcalculate import (
     StateKey,
 )
 
-from cellprofiler_library.functions.image_processing import (
-    smooth_with_convex_hull,
-    smooth_with_splines,
-    smooth_plane,
-    
-)
+from cellprofiler_library.functions.image_processing import smooth_plane
 
 ROBUST_FACTOR = 0.02  # For rescaling, take 2nd percentile value
 
+@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def apply_dilation(
         pixel_data: Image2D,
         mask: Image2DMask,
@@ -64,29 +58,7 @@ def apply_dilation(
         )
     return dilated_pixels
 
-def get_smoothing_filter_size(
-        automatic_object_width: SmoothingFilterSize, 
-        smoothing_filter_size: Optional[int], # default to 10
-        object_width: Optional[int], # default to 10 
-        image_shape: Optional[Tuple[int, ...]]
-    ) -> float:
-    """Return the smoothing filter size based on the settings and image size"""
-    filter_size = None
-    if automatic_object_width == SmoothingFilterSize.MANUALLY.value:
-        assert smoothing_filter_size is not None, "Manual smoothing filter size must be provided"
-        # Convert from full-width at half-maximum to standard deviation
-        # (or so says CPsmooth.m)
-        filter_size = smoothing_filter_size
-    elif automatic_object_width == SmoothingFilterSize.OBJECT_SIZE.value:
-        assert object_width is not None, "Object width must be provided"
-        filter_size =  object_width * 2.35 / 3.5
-    elif automatic_object_width == SmoothingFilterSize.AUTOMATIC.value:
-        assert image_shape is not None, "Image shape must be provided"
-        filter_size = min(30, float(numpy.max(image_shape)) / 40.0)
-    else:
-        raise ValueError(f"Unknown smoothing filter size: {automatic_object_width}")
-    return filter_size
-
+@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def preprocess_image_for_averaging(
         pixel_data: Image2D,
         mask: Optional[Image2DMask],
@@ -146,7 +118,7 @@ def preprocess_image_for_averaging(
                 min_block[labels != -1, i] = minima[labels[labels != -1]]
         return min_block
 
-
+@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def initialize_illumination_accumulation(
         preprocessed_pixel_data: numpy.ndarray,
         mask: Optional[numpy.ndarray],
@@ -178,7 +150,7 @@ def initialize_illumination_accumulation(
     accumulate_illumination_image(preprocessed_pixel_data, mask, state)
     return state
 
-
+@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def accumulate_illumination_image(
         preprocessed_pixel_data: numpy.ndarray,
         mask: Optional[numpy.ndarray],
@@ -210,7 +182,7 @@ def accumulate_illumination_image(
         mask_count += 1
     return state
 
-
+@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def calculate_average_from_state(
         state: Dict[str, Any],
 ) -> Tuple[numpy.ndarray, numpy.ndarray]:
@@ -237,6 +209,7 @@ def calculate_average_from_state(
             pixel_data[mask, i] = image_sum[mask, i] / mask_count[mask]
     return pixel_data, mask
 
+@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def apply_smoothing(
         image_pixel_data: Image2D,
         image_mask: Image2DMask,
@@ -298,7 +271,7 @@ def apply_smoothing(
         )
     return output_pixels
 
-
+@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def apply_scaling(
         image_pixel_data,
         image_mask, 

--- a/src/subpackages/library/cellprofiler_library/modules/_correctilluminationcalculate.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_correctilluminationcalculate.py
@@ -1,0 +1,363 @@
+import centrosome.smooth
+import centrosome.cpmorphology
+import scipy.ndimage
+import numpy
+import skimage.filters
+import centrosome.bg_compensate
+import centrosome.filter
+from typing import Optional, Tuple
+
+from cellprofiler_library.opts.correctilluminationcalculate import (
+    SmoothingFilterSize,
+    IntensityChoice,
+    SmoothingMethod,
+    SplineBackgroundMode,
+    RescaleIlluminationFunction
+)
+
+ROBUST_FACTOR = 0.02  # For rescaling, take 2nd percentile value
+
+def apply_dilation(
+        image, 
+        object_dilation_radius,
+    ):
+    """Return an image that is dilated according to the settings
+
+    image - an instance of cpimage.Image
+
+    returns another instance of cpimage.Image
+    """
+    #
+    # This filter is designed to spread the boundaries of cells
+    # and this "dilates" the cells
+    #
+    kernel = centrosome.smooth.circular_gaussian_kernel(
+        object_dilation_radius, object_dilation_radius * 3
+    )
+
+    def fn(image):
+        return scipy.ndimage.convolve(image, kernel, mode="constant", cval=0)
+
+    if image.pixel_data.ndim == 2:
+        dilated_pixels = centrosome.smooth.smooth_with_function_and_mask(
+            image.pixel_data, fn, image.mask
+        )
+    else:
+        dilated_pixels = numpy.dstack(
+            [
+                centrosome.smooth.smooth_with_function_and_mask(
+                    x, fn, image.mask
+                )
+                for x in image.pixel_data.transpose(2, 0, 1)
+            ]
+        )
+    return dilated_pixels
+
+def get_smoothing_filter_size(
+        automatic_object_width: SmoothingFilterSize, 
+        smoothing_filter_size: Optional[int], # default to 10
+        object_width: Optional[int], # default to 10 
+        image_shape: Optional[Tuple[int, ...]]
+    ) -> float:
+    """Return the smoothing filter size based on the settings and image size"""
+    filter_size = None
+    if automatic_object_width == SmoothingFilterSize.MANUALLY.value:
+        assert smoothing_filter_size is not None, "Manual smoothing filter size must be provided"
+        # Convert from full-width at half-maximum to standard deviation
+        # (or so says CPsmooth.m)
+        filter_size = smoothing_filter_size
+    elif automatic_object_width == SmoothingFilterSize.OBJECT_SIZE.value:
+        assert object_width is not None, "Object width must be provided"
+        filter_size =  object_width * 2.35 / 3.5
+    elif automatic_object_width == SmoothingFilterSize.AUTOMATIC.value:
+        assert image_shape is not None, "Image shape must be provided"
+        filter_size = min(30, float(numpy.max(image_shape)) / 40.0)
+    else:
+        raise ValueError(f"Unknown smoothing filter size: {automatic_object_width}")
+    return filter_size
+
+# intensity_choice = self.intensity_choice.value
+# smoothing_method = self.smoothing_method.value
+# block_size = self.block_size.value
+def preprocess_image_for_averaging(
+        orig_image,
+        intensity_choice: IntensityChoice,
+        smoothing_method: SmoothingMethod,
+        block_size: int,
+    ):
+    """Create a version of the image appropriate for averaging
+
+    """
+    pixels = orig_image.pixel_data
+    if intensity_choice == IntensityChoice.REGULAR.value or smoothing_method == SmoothingMethod.SPLINES.value:
+        if orig_image.has_mask:
+            if pixels.ndim == 2:
+                pixels[~orig_image.mask] = 0
+            else:
+                pixels[~orig_image.mask, :] = 0
+            avg_image = pixels
+        else:
+            avg_image = orig_image
+    else:
+        # For background, we create a labels image using the block
+        # size and find the minimum within each block.
+        labels, indexes = centrosome.cpmorphology.block(
+            pixels.shape[:2], (block_size, block_size)
+        )
+        if orig_image.has_mask:
+            labels[~orig_image.mask] = -1
+
+        min_block = numpy.zeros(pixels.shape)
+        if pixels.ndim == 2:
+            minima = centrosome.cpmorphology.fixup_scipy_ndimage_result(
+                scipy.ndimage.minimum(pixels, labels, indexes)
+            )
+            min_block[labels != -1] = minima[labels[labels != -1]]
+        else:
+            for i in range(pixels.shape[2]):
+                minima = centrosome.cpmorphology.fixup_scipy_ndimage_result(
+                    scipy.ndimage.minimum(pixels[:, :, i], labels, indexes)
+                )
+                min_block[labels != -1, i] = minima[labels[labels != -1]]
+        avg_image = min_block
+    return avg_image
+
+# image_pixel_data = image.pixel_data
+# image_mask = image.mask
+def apply_smoothing(
+        image_pixel_data,
+        image_mask,
+        # smooth filter args
+        smoothing_method: SmoothingMethod,
+        # smooth filter size args
+        automatic_object_width: SmoothingFilterSize, 
+        size_of_smoothing_filter: Optional[int], # default to 10
+        object_width: Optional[int], # default to 10 
+        image_shape: Optional[Tuple[int, ...]],
+        # spline args
+        automatic_splines: bool,
+        spline_bg_mode: SplineBackgroundMode,
+        spline_points: int,
+        spline_threshold: float,
+        spline_convergence: float,
+        spline_maximum_iterations: int,
+        spline_rescale: float,
+    ):
+    """Return an image that is smoothed according to the settings
+
+    image - an instance of cpimage.Image containing the pixels to analyze
+    orig_image - the ancestor source image or None if ambiguous
+    returns another instance of cpimage.Image
+    """
+    # if self.smoothing_method == SmoothingMethod.NONE.value:
+    #     return image
+    pixel_data = image_pixel_data
+    if pixel_data.ndim == 3:
+        output_pixels = numpy.zeros(pixel_data.shape, pixel_data.dtype)
+        for i in range(pixel_data.shape[2]):
+            output_pixels[:, :, i] = smooth_plane(
+                pixel_data = pixel_data[:, :, i], 
+                mask = image_mask,
+                smoothing_method = smoothing_method,
+                automatic_object_width = automatic_object_width, 
+                size_of_smoothing_filter = size_of_smoothing_filter, 
+                object_width = object_width, 
+                image_shape = image_shape,
+                automatic_splines = automatic_splines,
+                spline_bg_mode = spline_bg_mode,
+                spline_points = spline_points,
+                spline_threshold = spline_threshold,
+                spline_convergence = spline_convergence,
+                spline_maximum_iterations = spline_maximum_iterations,
+                spline_rescale = spline_rescale,
+            )
+    else:
+        output_pixels = smooth_plane(
+            pixel_data = pixel_data, 
+            mask = image_mask,
+            smoothing_method = smoothing_method,
+            automatic_object_width = automatic_object_width, 
+            size_of_smoothing_filter = size_of_smoothing_filter, 
+            object_width = object_width, 
+            image_shape = image_shape,
+            automatic_splines = automatic_splines,
+            spline_bg_mode = spline_bg_mode,
+            spline_points = spline_points,
+            spline_threshold = spline_threshold,
+            spline_convergence = spline_convergence,
+            spline_maximum_iterations = spline_maximum_iterations,
+            spline_rescale = spline_rescale,
+        )
+    # output_image = Image(output_pixels, parent_image=orig_image)
+    return output_pixels
+
+def smooth_plane(
+        pixel_data, 
+        mask,
+        smoothing_method: SmoothingMethod,
+        automatic_object_width: SmoothingFilterSize, 
+        size_of_smoothing_filter: Optional[int], # default to 10
+        object_width: Optional[int], # default to 10 
+        image_shape: Optional[Tuple[int, ...]],
+        automatic_splines: bool,
+        spline_bg_mode: SplineBackgroundMode,
+        spline_points: int,
+        spline_threshold: float,
+        spline_convergence: float,
+        spline_maximum_iterations: int,
+        spline_rescale: float,
+    ):
+    """Smooth one 2-d color plane of an image"""
+
+    sigma = get_smoothing_filter_size(automatic_object_width, size_of_smoothing_filter, object_width, image_shape) / 2.35 # What's up with 2.35?
+    if smoothing_method == SmoothingMethod.FIT_POLYNOMIAL.value:
+        output_pixels = centrosome.smooth.fit_polynomial(pixel_data, mask)
+    elif smoothing_method == SmoothingMethod.GAUSSIAN_FILTER.value:
+        #
+        # Smoothing with the mask is good, even if there's no mask
+        # because the mechanism undoes the edge effects that are introduced
+        # by any choice of how to deal with border effects.
+        #
+        def fn(image):
+            return scipy.ndimage.gaussian_filter(
+                image, sigma, mode="constant", cval=0
+            )
+
+        output_pixels = centrosome.smooth.smooth_with_function_and_mask(
+            pixel_data, fn, mask
+        )
+    elif smoothing_method == SmoothingMethod.MEDIAN_FILTER.value:
+        filter_sigma = max(1, int(sigma + 0.5))
+        strel = centrosome.cpmorphology.strel_disk(filter_sigma)
+        rescaled_pixel_data = pixel_data * 65535
+        rescaled_pixel_data = rescaled_pixel_data.astype(numpy.uint16)
+        rescaled_pixel_data *= mask
+        output_pixels = skimage.filters.median(rescaled_pixel_data, strel, behavior="rank")
+    elif smoothing_method == SmoothingMethod.TO_AVERAGE.value:
+        mean = numpy.mean(pixel_data[mask])
+        output_pixels = numpy.ones(pixel_data.shape, pixel_data.dtype) * mean
+    elif smoothing_method == SmoothingMethod.SPLINES.value:
+        output_pixels = smooth_with_splines(
+            pixel_data, 
+            mask,
+            automatic_splines,
+            spline_bg_mode,
+            spline_points,
+            spline_threshold,
+            spline_convergence,
+            spline_maximum_iterations,
+            spline_rescale,
+        )
+    elif smoothing_method == SmoothingMethod.CONVEX_HULL.value:
+        output_pixels = smooth_with_convex_hull(pixel_data, mask)
+    else:
+        raise ValueError(
+            "Unimplemented smoothing method: %s:" % smoothing_method.value
+        )
+    return output_pixels
+
+def smooth_with_convex_hull(pixel_data, mask):
+    """Use the convex hull transform to smooth the image"""
+    #
+    # Apply an erosion, then the transform, then a dilation, heuristically
+    # to ignore little spikey noisy things.
+    #
+    image = centrosome.cpmorphology.grey_erosion(pixel_data, 2, mask)
+    image = centrosome.filter.convex_hull_transform(image, mask=mask)
+    image = centrosome.cpmorphology.grey_dilation(image, 2, mask)
+    return image
+
+# automatic_splines = self.automatic_splines
+# spline_bg_mode = self.spline_bg_mode.value
+# spline_points = self.spline_points.value
+# spline_threshold = self.spline_threshold.value
+# spline_convergence = self.spline_convergence.value
+# spline_maximum_iterations = self.spline_maximum_iterations.value
+# spline_rescale = self.spline_rescale.value
+def smooth_with_splines(
+        pixel_data, 
+        mask,
+        automatic_splines: bool,
+        # centrosome.bg_compensate args
+        spline_bg_mode: SplineBackgroundMode,
+        spline_points: int,
+        spline_threshold: float,
+        spline_convergence: float,
+        spline_maximum_iterations: int,
+        spline_rescale: float,
+    ):
+    if automatic_splines:
+        # Make the image 200 pixels long on its shortest side
+        shortest_side = min(pixel_data.shape)
+        if shortest_side < 200:
+            scale = 1
+        else:
+            scale = float(shortest_side) / 200
+        result = centrosome.bg_compensate.backgr(pixel_data, mask, scale=scale)
+    else:
+        mode = spline_bg_mode
+        spline_points = spline_points
+        threshold = spline_threshold
+        convergence = spline_convergence
+        iterations = spline_maximum_iterations
+        rescale = spline_rescale
+        result = centrosome.bg_compensate.backgr(
+            pixel_data,
+            mask,
+            mode=mode,
+            thresh=threshold, # TODO: #5129 centrosome expects int but CellProfiler sends a float
+            splinepoints=spline_points,
+            scale=rescale, # TODO: #5129 centrosome expects int but CellProfiler sends a float
+            maxiter=iterations,
+            convergence=convergence,
+        )
+    #
+    # The result is a fit to the background intensity, but we
+    # want to normalize the intensity by subtraction, leaving
+    # the mean intensity alone.
+    #
+    mean_intensity = numpy.mean(result[mask])
+    result[mask] -= mean_intensity
+    return result
+
+# rescale_option = self.rescale_option.value
+def apply_scaling(
+        image, 
+        rescale_option: RescaleIlluminationFunction,
+        orig_image=None
+    ):
+    """Return an image that is rescaled according to the settings
+
+    image - an instance of cpimage.Image
+    returns another instance of cpimage.Image
+    """
+    if rescale_option == "No":
+        return image
+
+    def scaling_fn_2d(pixel_data):
+        if image.has_mask:
+            sorted_pixel_data = pixel_data[(pixel_data > 0) & image.mask]
+        else:
+            sorted_pixel_data = pixel_data[pixel_data > 0]
+        if sorted_pixel_data.shape[0] == 0:
+            return pixel_data
+        sorted_pixel_data.sort()
+        if rescale_option == "Yes":
+            idx = int(sorted_pixel_data.shape[0] * ROBUST_FACTOR)
+            robust_minimum = sorted_pixel_data[idx]
+            pixel_data = pixel_data.copy()
+            pixel_data[pixel_data < robust_minimum] = robust_minimum
+        elif rescale_option == RescaleIlluminationFunction.MEDIAN.value:
+            idx = int(sorted_pixel_data.shape[0] / 2)
+            robust_minimum = sorted_pixel_data[idx]
+        if robust_minimum == 0:
+            return pixel_data
+        return pixel_data / robust_minimum
+
+    if image.pixel_data.ndim == 2:
+        output_pixels = scaling_fn_2d(image.pixel_data)
+    else:
+        output_pixels = numpy.dstack(
+            [scaling_fn_2d(x) for x in image.pixel_data.transpose(2, 0, 1)]
+        )
+    return output_pixels

--- a/src/subpackages/library/cellprofiler_library/modules/_correctilluminationcalculate.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_correctilluminationcalculate.py
@@ -16,7 +16,12 @@ from cellprofiler_library.opts.correctilluminationcalculate import (
     StateKey,
 )
 
-
+from cellprofiler_library.functions.image_processing import (
+    smooth_with_convex_hull,
+    smooth_with_splines,
+    smooth_plane,
+    
+)
 
 ROBUST_FACTOR = 0.02  # For rescaling, take 2nd percentile value
 
@@ -111,12 +116,11 @@ def preprocess_image_for_averaging(
     """
     if intensity_choice == IntensityChoice.REGULAR.value or smoothing_method == SmoothingMethod.SPLINES.value:
         if mask is not None:
-            pixels = pixel_data.copy()
-            if pixels.ndim == 2:
-                pixels[~mask] = 0
+            if pixel_data.ndim == 2:
+                pixel_data[~mask] = 0
             else:
-                pixels[~mask, :] = 0
-            return pixels
+                pixel_data[~mask, :] = 0
+            return pixel_data
         else:
             return pixel_data
     else:
@@ -234,16 +238,13 @@ def calculate_average_from_state(
     return pixel_data, mask
 
 def apply_smoothing(
-        image_pixel_data,
-        image_mask,
-        # smooth filter args
+        image_pixel_data: Image2D,
+        image_mask: Image2DMask,
         smoothing_method: SmoothingMethod,
-        # smooth filter size args
-        automatic_object_width: SmoothingFilterSize, 
+        automatic_object_width: Optional[SmoothingFilterSize], 
         size_of_smoothing_filter: Optional[int], # default to 10
         object_width: Optional[int], # default to 10 
         image_shape: Optional[Tuple[int, ...]],
-        # spline args
         automatic_splines: bool,
         spline_bg_mode: Optional[SplineBackgroundMode],
         spline_points: Optional[int],
@@ -297,133 +298,6 @@ def apply_smoothing(
         )
     return output_pixels
 
-def smooth_plane(
-        pixel_data, 
-        mask,
-        smoothing_method: SmoothingMethod,
-        automatic_object_width: SmoothingFilterSize, 
-        size_of_smoothing_filter: Optional[int], # default to 10
-        object_width: Optional[int], # default to 10 
-        image_shape: Optional[Tuple[int, ...]],
-        automatic_splines: Optional[bool],
-        spline_bg_mode: Optional[SplineBackgroundMode], 
-        spline_points: Optional[int],
-        spline_threshold: Optional[float],
-        spline_convergence: Optional[float],
-        spline_maximum_iterations: Optional[int],
-        spline_rescale: Optional[float],
-    ):
-    """Smooth one 2-d color plane of an image"""
-
-    sigma = get_smoothing_filter_size(automatic_object_width, size_of_smoothing_filter, object_width, image_shape) / 2.35 # What's up with 2.35?
-    if smoothing_method == SmoothingMethod.FIT_POLYNOMIAL.value:
-        output_pixels = centrosome.smooth.fit_polynomial(pixel_data, mask)
-    elif smoothing_method == SmoothingMethod.GAUSSIAN_FILTER.value:
-        #
-        # Smoothing with the mask is good, even if there's no mask
-        # because the mechanism undoes the edge effects that are introduced
-        # by any choice of how to deal with border effects.
-        #
-        def fn(image):
-            return scipy.ndimage.gaussian_filter(
-                image, sigma, mode="constant", cval=0
-            )
-
-        output_pixels = centrosome.smooth.smooth_with_function_and_mask(
-            pixel_data, fn, mask
-        )
-    elif smoothing_method == SmoothingMethod.MEDIAN_FILTER.value:
-        filter_sigma = max(1, int(sigma + 0.5))
-        strel = centrosome.cpmorphology.strel_disk(filter_sigma)
-        rescaled_pixel_data = pixel_data * 65535
-        rescaled_pixel_data = rescaled_pixel_data.astype(numpy.uint16)
-        rescaled_pixel_data *= mask
-        output_pixels = skimage.filters.median(rescaled_pixel_data, strel, behavior="rank")
-    elif smoothing_method == SmoothingMethod.TO_AVERAGE.value:
-        mean = numpy.mean(pixel_data[mask])
-        output_pixels = numpy.ones(pixel_data.shape, pixel_data.dtype) * mean
-    elif smoothing_method == SmoothingMethod.SPLINES.value:
-        assert automatic_splines is not None, "automatic_splines must be provided for spline smoothing"
-        output_pixels = smooth_with_splines(
-            pixel_data = pixel_data, 
-            mask = mask,
-            automatic_splines = automatic_splines,
-            spline_bg_mode = spline_bg_mode,
-            spline_points = spline_points,
-            spline_threshold = spline_threshold,
-            spline_convergence = spline_convergence,
-            spline_maximum_iterations = spline_maximum_iterations,
-            spline_rescale = spline_rescale,
-        )
-    elif smoothing_method == SmoothingMethod.CONVEX_HULL.value:
-        output_pixels = smooth_with_convex_hull(pixel_data, mask)
-    else:
-        raise ValueError(
-            "Unimplemented smoothing method: %s:" % smoothing_method.value
-        )
-    return output_pixels
-
-def smooth_with_convex_hull(pixel_data, mask):
-    """Use the convex hull transform to smooth the image"""
-    #
-    # Apply an erosion, then the transform, then a dilation, heuristically
-    # to ignore little spikey noisy things.
-    #
-    image = centrosome.cpmorphology.grey_erosion(pixel_data, 2, mask)
-    image = centrosome.filter.convex_hull_transform(image, mask=mask)
-    image = centrosome.cpmorphology.grey_dilation(image, 2, mask)
-    return image
-
-def smooth_with_splines(
-        pixel_data, 
-        mask,
-        automatic_splines: bool,
-        spline_bg_mode: Optional[SplineBackgroundMode],
-        spline_points: Optional[int],
-        spline_threshold: Optional[float],
-        spline_convergence: Optional[float],
-        spline_maximum_iterations: Optional[int],
-        spline_rescale: Optional[float],
-    ):
-    if automatic_splines:
-        # Make the image 200 pixels long on its shortest side
-        shortest_side = min(pixel_data.shape)
-        if shortest_side < 200:
-            scale = 1
-        else:
-            scale = float(shortest_side) / 200
-        result = centrosome.bg_compensate.backgr(pixel_data, mask, scale=scale)
-    else:
-        assert spline_bg_mode is not None, "spline_bg_mode must be provided for spline smoothing"
-        assert spline_points is not None, "spline_points must be provided for spline smoothing"
-        assert spline_threshold is not None, "spline_threshold must be provided for spline smoothing"
-        assert spline_convergence is not None, "spline_convergence must be provided for spline smoothing"
-        assert spline_maximum_iterations is not None, "spline_maximum_iterations must be provided for spline smoothing"
-        assert spline_rescale is not None, "spline_rescale must be provided for spline smoothing"
-        mode = spline_bg_mode
-        spline_points = spline_points
-        threshold = spline_threshold
-        convergence = spline_convergence
-        iterations = spline_maximum_iterations
-        rescale = spline_rescale
-        result = centrosome.bg_compensate.backgr(
-            pixel_data,
-            mask,
-            mode=mode,
-            thresh=threshold, # TODO: #5129 centrosome expects int but CellProfiler sends a float
-            splinepoints=spline_points,
-            scale=rescale, # TODO: #5129 centrosome expects int but CellProfiler sends a float
-            maxiter=iterations,
-            convergence=convergence,
-        )
-    #
-    # The result is a fit to the background intensity, but we
-    # want to normalize the intensity by subtraction, leaving
-    # the mean intensity alone.
-    #
-    mean_intensity = numpy.mean(result[mask])
-    result[mask] -= mean_intensity
-    return result
 
 def apply_scaling(
         image_pixel_data,

--- a/src/subpackages/library/cellprofiler_library/modules/_correctilluminationcalculate.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_correctilluminationcalculate.py
@@ -1,9 +1,13 @@
+from functools import partial
+from collections.abc import Callable
 import centrosome.smooth
 import centrosome.cpmorphology
 import scipy.ndimage
 import numpy
-from typing import Any, Dict, Optional, Tuple, Annotated
-from pydantic import Field, validate_call, ConfigDict
+from numpy.typing import NDArray
+from typing import Optional, Tuple, Annotated
+from typing_extensions import TypeAlias
+from pydantic import Field, validate_call, ConfigDict, BaseModel
 from cellprofiler_library.types import Image2D, Image2DMask
 from cellprofiler_library.opts.correctilluminationcalculate import (
     SmoothingFilterSize,
@@ -11,55 +15,293 @@ from cellprofiler_library.opts.correctilluminationcalculate import (
     SmoothingMethod,
     SplineBackgroundMode,
     RescaleIlluminationFunction,
-    StateKey,
 )
 
 from cellprofiler_library.functions.image_processing import smooth_plane
 
 ROBUST_FACTOR = 0.02  # For rescaling, take 2nd percentile value
 
-@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
-def apply_dilation(
-        pixel_data:             Annotated[Image2D, Field(description="Input image for dilation")],
-        mask:                   Annotated[Image2DMask, Field(description="Input image mask")],
-        object_dilation_radius: Annotated[int, Field(description="Radius for the circular Gaussian dilation kernel")],
-    ) -> Image2D:
-    """Return pixel data dilated with a circular Gaussian kernel.
+IlluminationAccumulate: TypeAlias = Callable[
+    [
+        Image2D, # image
+        Optional[Image2DMask], # mask
+    ],
+    "IlluminationAccumulator"
+]
+IlluminationFinalize: TypeAlias = Callable[
+    [],
+    Tuple[Image2D, Image2D, Image2D, Image2DMask] # (output, dilated, averaged, mask)
+]
 
-    This filter spreads the boundaries of cells, effectively "dilating" them.
-
-    Args:
-        pixel_data: Input image for dilation.
-        mask: Input image mask.
-        object_dilation_radius: Radius for the circular Gaussian dilation kernel.
-
-    Returns:
-        Dilated pixel data of same shape as input.
-    """
-    kernel = centrosome.smooth.circular_gaussian_kernel(
-        object_dilation_radius, object_dilation_radius * 3
+class IlluminationAccumulator(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        populate_by_name=True
     )
 
-    def fn(image):
-        return scipy.ndimage.convolve(image, kernel, mode="constant", cval=0)
+    accumulate: IlluminationAccumulate
+    finalize: IlluminationFinalize
 
-    if pixel_data.ndim == 2:
-        dilated_pixels = centrosome.smooth.smooth_with_function_and_mask(
-            pixel_data, fn, mask
-        )
-    else:
-        dilated_pixels = numpy.dstack(
-            [
-                centrosome.smooth.smooth_with_function_and_mask(
-                    x, fn, mask
-                )
-                for x in pixel_data.transpose(2, 0, 1)
-            ]
-        )
-    return dilated_pixels
+
+# Field descriptions shared by correctilluminationcalculate() and _accumulate_illumination_image(),
+# which both need to re-thread the same settings into the IlluminationAccumulator they return.
+_D_INTENSITY_CHOICE = "'Regular' uses per-pixel intensity; 'Background' finds block minima"
+_D_SMOOTHING_METHOD = "Smoothing method; also used while preprocessing when Splines is selected"
+_D_BLOCK_SIZE = "Block side length in pixels for Background mode"
+_D_DILATE_OBJECTS = "Whether to dilate the averaged image with a circular Gaussian kernel"
+_D_OBJECT_DILATION_RADIUS = "Radius for the circular Gaussian dilation kernel"
+_D_AUTOMATIC_OBJECT_WIDTH = "Method to calculate smoothing filter size (Automatic, Object size, or Manually)"
+_D_SIZE_OF_SMOOTHING_FILTER = "Manual smoothing filter size in pixels"
+_D_OBJECT_WIDTH = "Approximate object diameter in pixels for filter size calculation"
+_D_AUTOMATIC_SPLINES = "Whether to automatically calculate spline parameters"
+_D_SPLINE_BG_MODE = "Background mode for spline fitting (auto, dark, bright, or gray)"
+_D_SPLINE_POINTS = "Number of spline control points in the grid"
+_D_SPLINE_THRESHOLD = "Std-dev cutoff for background pixel classification"
+_D_SPLINE_CONVERGENCE = "Residual value fraction for convergence criterion"
+_D_SPLINE_MAXIMUM_ITERATIONS = "Maximum number of spline fitting iterations"
+_D_SPLINE_RESCALE = "Image resampling factor for spline computation"
+_D_RESCALE_OPTION = "Rescaling method: Yes (robust minimum), No (skip), or Median"
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
-def preprocess_image_for_averaging(
+def correctilluminationcalculate(
+        image:                      Annotated[Image2D, Field(description="The pixel data of the first image to accumulate")],
+        mask:                       Annotated[Optional[Image2DMask], Field(description="The mask of the image (True = valid). If None, all pixels are valid")],
+        intensity_choice:           Annotated[IntensityChoice, Field(description=_D_INTENSITY_CHOICE)],
+        smoothing_method:           Annotated[SmoothingMethod, Field(description=_D_SMOOTHING_METHOD)],
+        block_size:                 Annotated[int, Field(description=_D_BLOCK_SIZE)],
+        dilate_objects:             Annotated[bool, Field(description=_D_DILATE_OBJECTS)],
+        object_dilation_radius:     Annotated[int, Field(description=_D_OBJECT_DILATION_RADIUS)],
+        automatic_object_width:     Annotated[Optional[SmoothingFilterSize], Field(description=_D_AUTOMATIC_OBJECT_WIDTH)],
+        size_of_smoothing_filter:   Annotated[Optional[int], Field(description=_D_SIZE_OF_SMOOTHING_FILTER)],
+        object_width:               Annotated[Optional[int], Field(description=_D_OBJECT_WIDTH)],
+        automatic_splines:          Annotated[bool, Field(description=_D_AUTOMATIC_SPLINES)],
+        spline_bg_mode:             Annotated[Optional[SplineBackgroundMode], Field(description=_D_SPLINE_BG_MODE)],
+        spline_points:              Annotated[Optional[int], Field(description=_D_SPLINE_POINTS)],
+        spline_threshold:           Annotated[Optional[float], Field(description=_D_SPLINE_THRESHOLD)],
+        spline_convergence:         Annotated[Optional[float], Field(description=_D_SPLINE_CONVERGENCE)],
+        spline_maximum_iterations:  Annotated[Optional[int], Field(description=_D_SPLINE_MAXIMUM_ITERATIONS)],
+        spline_rescale:             Annotated[Optional[float], Field(description=_D_SPLINE_RESCALE)],
+        rescale_option:             Annotated[RescaleIlluminationFunction, Field(description=_D_RESCALE_OPTION)],
+    ) -> IlluminationAccumulator:
+    """
+    Preprocesses and accumulates the first image, then returns an
+    IlluminationAccumulator whose `.accumulate(image, mask)` folds in
+    further images and whose `.finalize()` runs the full
+    average -> dilate -> smooth -> rescale pipeline and returns
+    (output, dilated, averaged, mask).
+
+    Args:
+        image: The pixel data of the first image to accumulate.
+        mask: The mask of the image (True = valid). If None, all pixels
+            are valid.
+        intensity_choice, smoothing_method, block_size: see
+            _preprocess_image_for_averaging.
+        dilate_objects, object_dilation_radius: see _apply_dilation.
+        automatic_object_width, size_of_smoothing_filter, object_width,
+            automatic_splines, spline_bg_mode, spline_points,
+            spline_threshold, spline_convergence,
+            spline_maximum_iterations, spline_rescale: see _apply_smoothing.
+        rescale_option: see _apply_scaling.
+
+    Returns:
+        An IlluminationAccumulator wrapping the initial accumulation.
+    """
+    preprocessed = _preprocess_image_for_averaging(image, mask, intensity_choice, smoothing_method, block_size)
+    image_sum = numpy.zeros(preprocessed.shape, preprocessed.dtype)
+    mask_count = numpy.zeros(preprocessed.shape[:2], numpy.int32)
+    _mut_accumulate(preprocessed, mask, image_sum, mask_count)
+
+    return IlluminationAccumulator(
+        accumulate = partial(
+            _accumulate_illumination_image,
+            intensity_choice=intensity_choice,
+            smoothing_method=smoothing_method,
+            block_size=block_size,
+            image_sum=image_sum,
+            mask_count=mask_count,
+            dilate_objects=dilate_objects,
+            object_dilation_radius=object_dilation_radius,
+            automatic_object_width=automatic_object_width,
+            size_of_smoothing_filter=size_of_smoothing_filter,
+            object_width=object_width,
+            automatic_splines=automatic_splines,
+            spline_bg_mode=spline_bg_mode,
+            spline_points=spline_points,
+            spline_threshold=spline_threshold,
+            spline_convergence=spline_convergence,
+            spline_maximum_iterations=spline_maximum_iterations,
+            spline_rescale=spline_rescale,
+            rescale_option=rescale_option,
+        ),
+        finalize = partial(
+            _calculate_illumination_images,
+            image_sum=image_sum,
+            mask_count=mask_count,
+            dilate_objects=dilate_objects,
+            object_dilation_radius=object_dilation_radius,
+            smoothing_method=smoothing_method,
+            automatic_object_width=automatic_object_width,
+            size_of_smoothing_filter=size_of_smoothing_filter,
+            object_width=object_width,
+            automatic_splines=automatic_splines,
+            spline_bg_mode=spline_bg_mode,
+            spline_points=spline_points,
+            spline_threshold=spline_threshold,
+            spline_convergence=spline_convergence,
+            spline_maximum_iterations=spline_maximum_iterations,
+            spline_rescale=spline_rescale,
+            rescale_option=rescale_option,
+        ),
+    )
+
+def _accumulate_illumination_image(
+        image:      Annotated[Image2D, Field(description="The pixel data of the image to accumulate")],
+        mask:       Annotated[Optional[Image2DMask], Field(description="The mask of the image (True = valid). If None, all pixels are valid")],
+        *,
+        intensity_choice:           Annotated[IntensityChoice, Field(description=_D_INTENSITY_CHOICE)],
+        smoothing_method:           Annotated[SmoothingMethod, Field(description=_D_SMOOTHING_METHOD)],
+        block_size:                 Annotated[int, Field(description=_D_BLOCK_SIZE)],
+        image_sum:                  Annotated[Image2D, Field(description="Running sum of preprocessed images (mutated in place)")],
+        mask_count:                 Annotated[NDArray[numpy.int_], Field(description="Running per-pixel count of contributing images (mutated in place)")],
+        dilate_objects:             Annotated[bool, Field(description=_D_DILATE_OBJECTS)],
+        object_dilation_radius:     Annotated[int, Field(description=_D_OBJECT_DILATION_RADIUS)],
+        automatic_object_width:     Annotated[Optional[SmoothingFilterSize], Field(description=_D_AUTOMATIC_OBJECT_WIDTH)],
+        size_of_smoothing_filter:   Annotated[Optional[int], Field(description=_D_SIZE_OF_SMOOTHING_FILTER)],
+        object_width:               Annotated[Optional[int], Field(description=_D_OBJECT_WIDTH)],
+        automatic_splines:          Annotated[bool, Field(description=_D_AUTOMATIC_SPLINES)],
+        spline_bg_mode:             Annotated[Optional[SplineBackgroundMode], Field(description=_D_SPLINE_BG_MODE)],
+        spline_points:              Annotated[Optional[int], Field(description=_D_SPLINE_POINTS)],
+        spline_threshold:           Annotated[Optional[float], Field(description=_D_SPLINE_THRESHOLD)],
+        spline_convergence:         Annotated[Optional[float], Field(description=_D_SPLINE_CONVERGENCE)],
+        spline_maximum_iterations:  Annotated[Optional[int], Field(description=_D_SPLINE_MAXIMUM_ITERATIONS)],
+        spline_rescale:             Annotated[Optional[float], Field(description=_D_SPLINE_RESCALE)],
+        rescale_option:             Annotated[RescaleIlluminationFunction, Field(description=_D_RESCALE_OPTION)],
+    ) -> IlluminationAccumulator:
+    """
+    Accumulate an image into the illumination sum.
+
+    Only intensity_choice/smoothing_method/block_size/image_sum/mask_count
+    are used directly here (to preprocess and fold in `image`); the
+    remaining settings are unused by this step but re-threaded into the
+    IlluminationAccumulator this function returns, so that `.finalize()`
+    keeps working after any number of `.accumulate()` calls.
+
+    Returns:
+        An IlluminationAccumulator wrapping the updated accumulation.
+    """
+    preprocessed = _preprocess_image_for_averaging(image, mask, intensity_choice, smoothing_method, block_size)
+    _mut_accumulate(preprocessed, mask, image_sum, mask_count)
+
+    return IlluminationAccumulator(
+        accumulate = partial(
+            _accumulate_illumination_image,
+            intensity_choice=intensity_choice,
+            smoothing_method=smoothing_method,
+            block_size=block_size,
+            image_sum=image_sum,
+            mask_count=mask_count,
+            dilate_objects=dilate_objects,
+            object_dilation_radius=object_dilation_radius,
+            automatic_object_width=automatic_object_width,
+            size_of_smoothing_filter=size_of_smoothing_filter,
+            object_width=object_width,
+            automatic_splines=automatic_splines,
+            spline_bg_mode=spline_bg_mode,
+            spline_points=spline_points,
+            spline_threshold=spline_threshold,
+            spline_convergence=spline_convergence,
+            spline_maximum_iterations=spline_maximum_iterations,
+            spline_rescale=spline_rescale,
+            rescale_option=rescale_option,
+        ),
+        finalize = partial(
+            _calculate_illumination_images,
+            image_sum=image_sum,
+            mask_count=mask_count,
+            dilate_objects=dilate_objects,
+            object_dilation_radius=object_dilation_radius,
+            smoothing_method=smoothing_method,
+            automatic_object_width=automatic_object_width,
+            size_of_smoothing_filter=size_of_smoothing_filter,
+            object_width=object_width,
+            automatic_splines=automatic_splines,
+            spline_bg_mode=spline_bg_mode,
+            spline_points=spline_points,
+            spline_threshold=spline_threshold,
+            spline_convergence=spline_convergence,
+            spline_maximum_iterations=spline_maximum_iterations,
+            spline_rescale=spline_rescale,
+            rescale_option=rescale_option,
+        ),
+    )
+
+def _calculate_illumination_images(
+        *,
+        image_sum:                  Annotated[Image2D, Field(description="Running sum of preprocessed images")],
+        mask_count:                 Annotated[NDArray[numpy.int_], Field(description="Running per-pixel count of contributing images")],
+        dilate_objects:             Annotated[bool, Field(description=_D_DILATE_OBJECTS)],
+        object_dilation_radius:     Annotated[int, Field(description=_D_OBJECT_DILATION_RADIUS)],
+        smoothing_method:           Annotated[SmoothingMethod, Field(description=_D_SMOOTHING_METHOD)],
+        automatic_object_width:     Annotated[Optional[SmoothingFilterSize], Field(description=_D_AUTOMATIC_OBJECT_WIDTH)],
+        size_of_smoothing_filter:   Annotated[Optional[int], Field(description=_D_SIZE_OF_SMOOTHING_FILTER)],
+        object_width:               Annotated[Optional[int], Field(description=_D_OBJECT_WIDTH)],
+        automatic_splines:          Annotated[bool, Field(description=_D_AUTOMATIC_SPLINES)],
+        spline_bg_mode:             Annotated[Optional[SplineBackgroundMode], Field(description=_D_SPLINE_BG_MODE)],
+        spline_points:              Annotated[Optional[int], Field(description=_D_SPLINE_POINTS)],
+        spline_threshold:           Annotated[Optional[float], Field(description=_D_SPLINE_THRESHOLD)],
+        spline_convergence:         Annotated[Optional[float], Field(description=_D_SPLINE_CONVERGENCE)],
+        spline_maximum_iterations:  Annotated[Optional[int], Field(description=_D_SPLINE_MAXIMUM_ITERATIONS)],
+        spline_rescale:             Annotated[Optional[float], Field(description=_D_SPLINE_RESCALE)],
+        rescale_option:             Annotated[RescaleIlluminationFunction, Field(description=_D_RESCALE_OPTION)],
+    ) -> Tuple[Image2D, Image2D, Image2D, Image2DMask]:
+    """Run the full average -> dilate -> smooth -> rescale pipeline.
+
+    Returns:
+        Tuple of (output pixel data, dilated pixel data, averaged pixel
+        data, mask). All three images share the same mask: none of
+        dilation, smoothing, or rescaling change which pixels are valid.
+    """
+    # TODO: 5129 - consider skipping average on EACH (as in cp4)
+    avg_pixel_data, mask = _calculate_average_image(image_sum, mask_count)
+
+    if dilate_objects:
+        dilated_pixel_data = _apply_dilation(avg_pixel_data, mask, object_dilation_radius)
+    else:
+        dilated_pixel_data = avg_pixel_data
+
+    if smoothing_method != SmoothingMethod.NONE.value:
+        smoothed_pixel_data = _apply_smoothing(
+            image_pixel_data=dilated_pixel_data,
+            image_mask=mask,
+            smoothing_method=smoothing_method,
+            automatic_object_width=automatic_object_width,
+            size_of_smoothing_filter=size_of_smoothing_filter,
+            object_width=object_width,
+            image_shape=dilated_pixel_data.shape[:2],
+            automatic_splines=automatic_splines,
+            spline_bg_mode=spline_bg_mode,
+            spline_points=spline_points,
+            spline_threshold=spline_threshold,
+            spline_convergence=spline_convergence,
+            spline_maximum_iterations=spline_maximum_iterations,
+            spline_rescale=spline_rescale,
+        )
+    else:
+        smoothed_pixel_data = dilated_pixel_data
+
+    if rescale_option != RescaleIlluminationFunction.NO.value:
+        output_pixel_data = _apply_scaling(
+            image_pixel_data=smoothed_pixel_data,
+            image_mask=mask,
+            rescale_option=rescale_option,
+        )
+    else:
+        output_pixel_data = smoothed_pixel_data
+
+    return output_pixel_data, dilated_pixel_data, avg_pixel_data, mask
+
+@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
+def _preprocess_image_for_averaging(
         pixel_data:         Annotated[Image2D, Field(description="Input image for averaging")],
         mask:               Annotated[Optional[Image2DMask], Field(description="Input image mask, or None if no mask")],
         intensity_choice:   Annotated[IntensityChoice, Field(description="'Regular' uses per-pixel intensity; 'Background' finds block minima")],
@@ -116,80 +358,16 @@ def preprocess_image_for_averaging(
                 min_block[labels != -1, i] = minima[labels[labels != -1]]
         return min_block
 
-@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
-def initialize_illumination_accumulation(
-        preprocessed_pixel_data:    Annotated[numpy.ndarray, Field(description="Preprocessed image from preprocess_image_for_averaging, shape (H, W) or (H, W, C)")],
-        mask:                       Annotated[Optional[numpy.ndarray], Field(description="Input image mask, or None if no mask")],
-) -> Dict[str, Any]:
-    """Initialize the illumination accumulation state from the first image.
-
-    Creates a zeroed image_sum and mask_count, then accumulates the
-    first (already preprocessed) image into them.
-
-    Args:
-        preprocessed_pixel_data: Preprocessed image from
-            preprocess_image_for_averaging, shape (H, W) or (H, W, C).
-        mask: Input image mask, or None if no mask.
-
-    Returns:
-        Initial accumulation state with image_sum and mask_count.
-    """
-    state: Dict[str, Any] = {
-        StateKey.IMAGE_SUM.value: numpy.zeros(
-            preprocessed_pixel_data.shape, preprocessed_pixel_data.dtype
-        ),
-        StateKey.MASK_COUNT.value: numpy.zeros(
-            preprocessed_pixel_data.shape[:2], numpy.int32
-        ),
-    }
-    accumulate_illumination_image(preprocessed_pixel_data, mask, state)
-    return state
-
-@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
-def accumulate_illumination_image(
-        preprocessed_pixel_data: Annotated[numpy.ndarray, Field(description="Preprocessed image from preprocess_image_for_averaging, shape (H, W) or (H, W, C)")],
-        mask:                   Annotated[Optional[numpy.ndarray], Field(description="Input image mask, or None if no mask")],
-        state:                  Annotated[Dict[str, Any], Field(description="Existing accumulation state dict (mutated in place)")],
-) -> Dict[str, Any]:
-    """Accumulate a preprocessed image into the illumination state.
-
-    Args:
-        preprocessed_pixel_data: Preprocessed image from
-            preprocess_image_for_averaging, shape (H, W) or (H, W, C).
-        mask: Input image mask, or None if no mask.
-        state: Existing accumulation state dict (mutated in place).
-
-    Returns:
-        Updated accumulation state (same object as input).
-    """
-    image_sum = state[StateKey.IMAGE_SUM.value]
-    mask_count = state[StateKey.MASK_COUNT.value]
-    if mask is not None:
-        if image_sum.ndim == 2:
-            image_sum[mask] += preprocessed_pixel_data[mask]
-        else:
-            image_sum[mask, :] += preprocessed_pixel_data[mask, :]
-        mask_count[mask] += 1
-    else:
-        image_sum += preprocessed_pixel_data
-        mask_count += 1
-    return state
-
-@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
-def calculate_average_from_state(
-        state: Annotated[Dict[str, Any], Field(description="Accumulation state from initialize/accumulate functions")],
-) -> Tuple[Image2D, Image2DMask]:
-    """Compute the average illumination image from the accumulated state.
-
-    Args:
-        state: Accumulation state from initialize/accumulate functions.
+def _calculate_average_image(
+        image_sum:  Annotated[Image2D, Field(description="Running sum of preprocessed images")],
+        mask_count: Annotated[NDArray[numpy.int_], Field(description="Running per-pixel count of contributing images")],
+    ) -> Tuple[Image2D, Image2DMask]:
+    """Compute the average illumination image from the accumulated sums.
 
     Returns:
         Tuple of (average pixel data, boolean mask where at least one
         image contributed).
     """
-    image_sum = state[StateKey.IMAGE_SUM.value]
-    mask_count = state[StateKey.MASK_COUNT.value]
     pixel_data = numpy.zeros(image_sum.shape, image_sum.dtype)
     mask = mask_count > 0
     if pixel_data.ndim == 2:
@@ -200,7 +378,58 @@ def calculate_average_from_state(
     return pixel_data, mask
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
-def apply_smoothing(
+def _apply_scaling(
+        image_pixel_data:   Annotated[Image2D, Field(description="Pixel data of the illumination function to rescale")],
+        image_mask:         Annotated[Optional[Image2DMask], Field(description="Input image mask, or None if no mask")],
+        rescale_option:     Annotated[RescaleIlluminationFunction, Field(description="Rescaling method: Yes (robust minimum), No (skip), or Median")],
+    ) -> Image2D:
+    """Return an image that is rescaled according to the settings.
+
+    Args:
+        image_pixel_data: Pixel data of the illumination function to
+            rescale.
+        image_mask: Input image mask, or None if no mask.
+        rescale_option: Rescaling method: Yes (robust minimum), No
+            (skip), or Median.
+
+    Returns:
+        Rescaled pixel data.
+    """
+    if rescale_option == RescaleIlluminationFunction.NO.value:
+        return image_pixel_data
+
+    def scaling_fn_2d(pixel_data):
+        if image_mask is not None:
+            sorted_pixel_data = pixel_data[(pixel_data > 0) & image_mask]
+        else:
+            sorted_pixel_data = pixel_data[pixel_data > 0]
+        if sorted_pixel_data.shape[0] == 0:
+            return pixel_data
+        sorted_pixel_data.sort()
+        if rescale_option == RescaleIlluminationFunction.YES.value:
+            idx = int(sorted_pixel_data.shape[0] * ROBUST_FACTOR)
+            robust_minimum = sorted_pixel_data[idx]
+            pixel_data = pixel_data.copy()
+            pixel_data[pixel_data < robust_minimum] = robust_minimum
+        elif rescale_option == RescaleIlluminationFunction.MEDIAN.value:
+            idx = int(sorted_pixel_data.shape[0] / 2)
+            robust_minimum = sorted_pixel_data[idx]
+        else: 
+            raise ValueError(f"Unknown rescale option: {rescale_option}")
+        if robust_minimum == 0:
+            return pixel_data
+        return pixel_data / robust_minimum
+
+    if image_pixel_data.ndim == 2:
+        output_pixels = scaling_fn_2d(image_pixel_data)
+    else:
+        output_pixels = numpy.dstack(
+            [scaling_fn_2d(x) for x in image_pixel_data.transpose(2, 0, 1)]
+        )
+    return output_pixels
+
+@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
+def _apply_smoothing(
         image_pixel_data: Annotated[Image2D, Field(description="Pixel data of image to smooth")],
         image_mask: Annotated[Image2DMask, Field(description="Input image mask; True = valid pixel")],
         smoothing_method: Annotated[SmoothingMethod, Field(description="Smoothing method to apply")],
@@ -284,52 +513,61 @@ def apply_smoothing(
     return output_pixels
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
-def apply_scaling(
-        image_pixel_data:   Annotated[Image2D, Field(description="Pixel data of the illumination function to rescale")],
-        image_mask:         Annotated[Optional[Image2DMask], Field(description="Input image mask, or None if no mask")],
-        rescale_option:     Annotated[RescaleIlluminationFunction, Field(description="Rescaling method: Yes (robust minimum), No (skip), or Median")],
+def _apply_dilation(
+        pixel_data:             Annotated[Image2D, Field(description="Input image for dilation")],
+        mask:                   Annotated[Image2DMask, Field(description="Input image mask")],
+        object_dilation_radius: Annotated[int, Field(description="Radius for the circular Gaussian dilation kernel")],
     ) -> Image2D:
-    """Return an image that is rescaled according to the settings.
+    """Return pixel data dilated with a circular Gaussian kernel.
+
+    This filter spreads the boundaries of cells, effectively "dilating" them.
 
     Args:
-        image_pixel_data: Pixel data of the illumination function to
-            rescale.
-        image_mask: Input image mask, or None if no mask.
-        rescale_option: Rescaling method: Yes (robust minimum), No
-            (skip), or Median.
+        pixel_data: Input image for dilation.
+        mask: Input image mask.
+        object_dilation_radius: Radius for the circular Gaussian dilation kernel.
 
     Returns:
-        Rescaled pixel data.
+        Dilated pixel data of same shape as input.
     """
-    if rescale_option == RescaleIlluminationFunction.NO.value:
-        return image_pixel_data
+    kernel = centrosome.smooth.circular_gaussian_kernel(
+        object_dilation_radius, object_dilation_radius * 3
+    )
 
-    def scaling_fn_2d(pixel_data):
-        if image_mask is not None:
-            sorted_pixel_data = pixel_data[(pixel_data > 0) & image_mask]
-        else:
-            sorted_pixel_data = pixel_data[pixel_data > 0]
-        if sorted_pixel_data.shape[0] == 0:
-            return pixel_data
-        sorted_pixel_data.sort()
-        if rescale_option == RescaleIlluminationFunction.YES.value:
-            idx = int(sorted_pixel_data.shape[0] * ROBUST_FACTOR)
-            robust_minimum = sorted_pixel_data[idx]
-            pixel_data = pixel_data.copy()
-            pixel_data[pixel_data < robust_minimum] = robust_minimum
-        elif rescale_option == RescaleIlluminationFunction.MEDIAN.value:
-            idx = int(sorted_pixel_data.shape[0] / 2)
-            robust_minimum = sorted_pixel_data[idx]
-        else: 
-            raise ValueError(f"Unknown rescale option: {rescale_option}")
-        if robust_minimum == 0:
-            return pixel_data
-        return pixel_data / robust_minimum
+    def fn(image):
+        return scipy.ndimage.convolve(image, kernel, mode="constant", cval=0)
 
-    if image_pixel_data.ndim == 2:
-        output_pixels = scaling_fn_2d(image_pixel_data)
-    else:
-        output_pixels = numpy.dstack(
-            [scaling_fn_2d(x) for x in image_pixel_data.transpose(2, 0, 1)]
+    if pixel_data.ndim == 2:
+        dilated_pixels = centrosome.smooth.smooth_with_function_and_mask(
+            pixel_data, fn, mask
         )
-    return output_pixels
+    else:
+        dilated_pixels = numpy.dstack(
+            [
+                centrosome.smooth.smooth_with_function_and_mask(
+                    x, fn, mask
+                )
+                for x in pixel_data.transpose(2, 0, 1)
+            ]
+        )
+    # scipy.ndimage.convolve upconverts to float64 regardless of input dtype;
+    # downstream smoothing methods (e.g. Splines) are sensitive to the
+    # resulting sub-epsilon floating point noise, so match the input's
+    # precision rather than silently widening it.
+    return dilated_pixels.astype(pixel_data.dtype)
+
+# NOTE: _mut prefix means the function mutates input numpy arrays, rather than returning new arrays
+def _mut_accumulate(
+        preprocessed_pixel_data: Image2D,
+        mask: Optional[Image2DMask],
+        image_sum: Image2D, # mutated
+        mask_count: NDArray[numpy.int_], # mutated
+    ):
+    mask_count[mask] += 1
+    if mask is not None:
+        if image_sum.ndim == 2:
+            image_sum[mask] += preprocessed_pixel_data[mask]
+        else:
+            image_sum[mask, :] += preprocessed_pixel_data[mask, :]
+    else:
+        image_sum += preprocessed_pixel_data

--- a/src/subpackages/library/cellprofiler_library/opts/correctilluminationcalculate.py
+++ b/src/subpackages/library/cellprofiler_library/opts/correctilluminationcalculate.py
@@ -29,7 +29,7 @@ class SmoothingMethod(str, Enum):
     TO_AVERAGE = "Smooth to Average"
     SPLINES = "Splines"
 
-class SmoothingFilterSize(Enum):
+class SmoothingFilterSize(str, Enum):
     """Smoothing filter size"""
     AUTOMATIC = "Automatic"
     OBJECT_SIZE = "Object size"

--- a/src/subpackages/library/cellprofiler_library/opts/correctilluminationcalculate.py
+++ b/src/subpackages/library/cellprofiler_library/opts/correctilluminationcalculate.py
@@ -1,0 +1,45 @@
+from enum import Enum
+from centrosome.bg_compensate import MODE_AUTO, MODE_DARK, MODE_BRIGHT, MODE_GRAY
+class IntensityChoice(str, Enum):
+    """Choice of how to calculate the illumination function"""
+    REGULAR = "Regular"
+    BACKGROUND = "Background"
+
+class RescaleIlluminationFunction(str, Enum):
+    """The illumination function can be rescaled so that the pixel intensities
+    are all equal to or greater than 1. You have the following options:"""
+    YES = "Yes"
+    NO = "No"
+    MEDIAN = "Median"
+
+class CalculateFunctionTarget(str, Enum):
+    """Calculate function for each image individually, or based on all images?"""
+    EACH = "Each"
+    # ALL = "All"
+    ALL_FIRST = "All: First cycle"
+    ALL_ACROSS = "All: Across cycles"
+
+class SmoothingMethod(str, Enum):
+    """Smoothing method"""
+    NONE = "No smoothing"
+    CONVEX_HULL = "Convex Hull"
+    FIT_POLYNOMIAL = "Fit Polynomial"
+    MEDIAN_FILTER = "Median Filter"
+    GAUSSIAN_FILTER = "Gaussian Filter"
+    TO_AVERAGE = "Smooth to Average"
+    SPLINES = "Splines"
+
+class SmoothingFilterSize(Enum):
+    """Smoothing filter size"""
+    AUTOMATIC = "Automatic"
+    OBJECT_SIZE = "Object size"
+    MANUALLY = "Manually"
+
+class SplineBackgroundMode(str, Enum):
+    """Background mode"""
+    AUTO = MODE_AUTO
+    DARK = MODE_DARK
+    BRIGHT = MODE_BRIGHT
+    GRAY = MODE_GRAY
+
+

--- a/src/subpackages/library/cellprofiler_library/opts/correctilluminationcalculate.py
+++ b/src/subpackages/library/cellprofiler_library/opts/correctilluminationcalculate.py
@@ -42,4 +42,8 @@ class SplineBackgroundMode(str, Enum):
     BRIGHT = MODE_BRIGHT
     GRAY = MODE_GRAY
 
+class StateKey(str, Enum):
+    """Keys for the illumination accumulation state dictionary"""
+    IMAGE_SUM = "image_sum"
+    MASK_COUNT = "mask_count"
 

--- a/src/subpackages/library/cellprofiler_library/opts/correctilluminationcalculate.py
+++ b/src/subpackages/library/cellprofiler_library/opts/correctilluminationcalculate.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from centrosome.bg_compensate import MODE_AUTO, MODE_DARK, MODE_BRIGHT, MODE_GRAY
+
 class IntensityChoice(str, Enum):
     """Choice of how to calculate the illumination function"""
     REGULAR = "Regular"

--- a/src/subpackages/library/cellprofiler_library/opts/correctilluminationcalculate.py
+++ b/src/subpackages/library/cellprofiler_library/opts/correctilluminationcalculate.py
@@ -16,9 +16,7 @@ class RescaleIlluminationFunction(str, Enum):
 class CalculateFunctionTarget(str, Enum):
     """Calculate function for each image individually, or based on all images?"""
     EACH = "Each"
-    # ALL = "All"
-    ALL_FIRST = "All: First cycle"
-    ALL_ACROSS = "All: Across cycles"
+    ALL = "All"
 
 class SmoothingMethod(str, Enum):
     """Smoothing method"""

--- a/src/subpackages/library/cellprofiler_library/opts/correctilluminationcalculate.py
+++ b/src/subpackages/library/cellprofiler_library/opts/correctilluminationcalculate.py
@@ -41,8 +41,3 @@ class SplineBackgroundMode(str, Enum):
     BRIGHT = MODE_BRIGHT
     GRAY = MODE_GRAY
 
-class StateKey(str, Enum):
-    """Keys for the illumination accumulation state dictionary"""
-    IMAGE_SUM = "image_sum"
-    MASK_COUNT = "mask_count"
-

--- a/tests/frontend/modules/test_correctilluminationcalculate.py
+++ b/tests/frontend/modules/test_correctilluminationcalculate.py
@@ -737,220 +737,81 @@ def test_smooth_to_average():
     image = image_set.get_image("OutputImage")
     numpy.testing.assert_almost_equal(image.pixel_data, expected_image)
 
-
-def test_splines():
-    for (
-        automatic,
-        bg_mode,
-        spline_points,
-        threshold,
-        convergence,
-        offset,
-        hi,
-        lo,
-        succeed,
-    ) in (
-        (
-            True,
-            SplineBackgroundMode.AUTO.value,
-            5,
-            2,
-            0.001,
-            0,
-            True,
-            False,
-            True,
-        ),
-        (
-            True,
-            SplineBackgroundMode.AUTO.value,
-            5,
-            2,
-            0.001,
-            0.7,
-            False,
-            True,
-            True,
-        ),
-        (
-            True,
-            SplineBackgroundMode.AUTO.value,
-            5,
-            2,
-            0.001,
-            0.5,
-            True,
-            True,
-            True,
-        ),
-        (
-            False,
-            SplineBackgroundMode.AUTO.value,
-            5,
-            2,
-            0.001,
-            0,
-            True,
-            False,
-            True,
-        ),
-        (
-            False,
-            SplineBackgroundMode.AUTO.value,
-            5,
-            2,
-            0.001,
-            0.7,
-            False,
-            True,
-            True,
-        ),
-        (
-            False,
-            SplineBackgroundMode.AUTO.value,
-            5,
-            2,
-            0.001,
-            0.5,
-            True,
-            True,
-            True,
-        ),
-        (
-            False,
-            SplineBackgroundMode.BRIGHT.value,
-            5,
-            2,
-            0.001,
-            0.7,
-            False,
-            True,
-            True,
-        ),
-        (
-            False,
-            SplineBackgroundMode.DARK.value,
-            5,
-            2,
-            0.001,
-            0,
-            True,
-            False,
-            True,
-        ),
-        (
-            False,
-            SplineBackgroundMode.GRAY.value,
-            5,
-            2,
-            0.001,
-            0.5,
-            True,
-            True,
-            True,
-        ),
-        (
-            False,
-            SplineBackgroundMode.AUTO.value,
-            7,
-            2,
-            0.001,
-            0,
-            True,
-            False,
-            True,
-        ),
-        (
-            False,
-            SplineBackgroundMode.AUTO.value,
-            4,
-            2,
-            0.001,
-            0,
-            True,
-            False,
-            True,
-        ),
-        (
-            False,
-            SplineBackgroundMode.DARK.value,
-            5,
-            2,
-            0.001,
-            0.7,
-            False,
-            True,
-            False,
-        ),
-        (
-            False,
-            SplineBackgroundMode.BRIGHT.value,
-            5,
-            2,
-            0.001,
-            0,
-            True,
-            False,
-            False,
-        ),
-    ):
-
+@pytest.mark.parametrize(
+        "automatic, bg_mode, spline_points, threshold, convergence, offset, hi, lo, succeed",
+        [
+            (True, SplineBackgroundMode.AUTO.value, 5, 2, 0.001, 0, True, False, True,),
+            (True, SplineBackgroundMode.AUTO.value, 5, 2, 0.001, 0.7, False, True, True,),
+            (True, SplineBackgroundMode.AUTO.value, 5, 2, 0.001, 0.5, True, True, True,),
+            (False, SplineBackgroundMode.AUTO.value, 5, 2, 0.001, 0, True, False, True,),
+            (False, SplineBackgroundMode.AUTO.value, 5, 2, 0.001, 0.7, False, True, True,),
+            (False, SplineBackgroundMode.AUTO.value, 5, 2, 0.001, 0.5, True, True, True,),
+            (False, SplineBackgroundMode.BRIGHT.value, 5, 2, 0.001, 0.7, False, True, True,),
+            (False, SplineBackgroundMode.DARK.value, 5, 2, 0.001, 0, True, False, True,),
+            (False, SplineBackgroundMode.GRAY.value, 5, 2, 0.001, 0.5, True, True, True,),
+            (False, SplineBackgroundMode.AUTO.value, 7, 2, 0.001, 0, True, False, True,),
+            (False, SplineBackgroundMode.AUTO.value, 4, 2, 0.001, 0, True, False, True,),
+            (False, SplineBackgroundMode.DARK.value, 5, 2, 0.001, 0.7, False, True, False,),
+            (False, SplineBackgroundMode.BRIGHT.value, 5, 2, 0.001, 0, True, False, False,),
+        ]
+)
+def test_splines(automatic, bg_mode, spline_points, threshold, convergence, offset, hi, lo, succeed):
+    #
+    # Make an image with a random background
+    #
+    numpy.random.seed(35)
+    image = numpy.random.uniform(size=(21, 31)) * 0.05 + offset
+    if hi:
         #
-        # Make an image with a random background
+        # Add some "foreground" pixels
         #
-        numpy.random.seed(35)
-        image = numpy.random.uniform(size=(21, 31)) * 0.05 + offset
-        if hi:
-            #
-            # Add some "foreground" pixels
-            #
-            fg = numpy.random.permutation(400)[:100]
-            image[fg % image.shape[0], (fg / image.shape[0]).astype(int)] *= 10
-        if lo:
-            #
-            # Add some "background" pixels
-            #
-            bg = numpy.random.permutation(400)[:100]
-            image[bg % image.shape[0], (bg / image.shape[0]).astype(int)] -= offset
+        fg = numpy.random.permutation(400)[:100]
+        image[fg % image.shape[0], (fg / image.shape[0]).astype(int)] *= 10
+    if lo:
+        #
+        # Add some "background" pixels
+        #
+        bg = numpy.random.permutation(400)[:100]
+        image[bg % image.shape[0], (bg / image.shape[0]).astype(int)] -= offset
 
-        #
-        # Make a background function
-        #
-        ii, jj = numpy.mgrid[-10:11, -15:16]
-        bg = ((ii.astype(float) / 10) ** 2) * ((jj.astype(float) / 15) ** 2)
-        bg *= 0.2
-        image += bg
+    #
+    # Make a background function
+    #
+    ii, jj = numpy.mgrid[-10:11, -15:16]
+    bg = ((ii.astype(float) / 10) ** 2) * ((jj.astype(float) / 15) ** 2)
+    bg *= 0.2
+    image += bg
 
-        workspaces, module = make_workspaces(((image, None),))
-        assert isinstance(
-            module,
-            cellprofiler.modules.correctilluminationcalculate.CorrectIlluminationCalculate,
-        )
-        module.intensity_choice.value = (
-            IntensityChoice.BACKGROUND.value
-        )
-        module.each_or_all.value = (
-            CalculateFunctionTarget.EACH.value
-        )
-        module.rescale_option.value = RescaleIlluminationFunction.NO.value
-        module.smoothing_method.value = (
-            SmoothingMethod.SPLINES.value
-        )
-        module.automatic_splines.value = automatic
-        module.spline_bg_mode.value = bg_mode
-        module.spline_convergence.value = convergence
-        module.spline_threshold.value = threshold
-        module.spline_points.value = spline_points
-        module.spline_rescale.value = 1
-        module.prepare_group(workspaces[0], {}, [1])
-        module.run(workspaces[0])
-        img = workspaces[0].image_set.get_image(OUTPUT_IMAGE_NAME)
-        pixel_data = img.pixel_data
-        diff = pixel_data - numpy.min(pixel_data) - bg
-        if succeed:
-            assert numpy.all(diff < 0.05)
-        else:
-            assert not numpy.all(diff < 0.05)
+    workspaces, module = make_workspaces(((image, None),))
+    assert isinstance(
+        module,
+        cellprofiler.modules.correctilluminationcalculate.CorrectIlluminationCalculate,
+    )
+    module.intensity_choice.value = (
+        IntensityChoice.BACKGROUND.value
+    )
+    module.each_or_all.value = (
+        CalculateFunctionTarget.EACH.value
+    )
+    module.rescale_option.value = RescaleIlluminationFunction.NO.value
+    module.smoothing_method.value = (
+        SmoothingMethod.SPLINES.value
+    )
+    module.automatic_splines.value = automatic
+    module.spline_bg_mode.value = bg_mode
+    module.spline_convergence.value = convergence
+    module.spline_threshold.value = threshold
+    module.spline_points.value = spline_points
+    module.spline_rescale.value = 1
+    module.prepare_group(workspaces[0], {}, [1])
+    module.run(workspaces[0])
+    img = workspaces[0].image_set.get_image(OUTPUT_IMAGE_NAME)
+    pixel_data = img.pixel_data
+    diff = pixel_data - numpy.min(pixel_data) - bg
+    if succeed:
+        assert numpy.all(diff < 0.05)
+    else:
+        assert not numpy.all(diff < 0.05)
 
 
 def test_splines_scaled():

--- a/tests/frontend/modules/test_correctilluminationcalculate.py
+++ b/tests/frontend/modules/test_correctilluminationcalculate.py
@@ -1,6 +1,5 @@
 import numpy
 import pytest
-from centrosome.bg_compensate import MODE_AUTO, MODE_BRIGHT, MODE_DARK, MODE_GRAY
 from six.moves import StringIO
 
 import cellprofiler_core.image
@@ -13,6 +12,15 @@ import cellprofiler_core.setting
 import cellprofiler_core.workspace
 
 import tests.frontend.modules
+
+from cellprofiler_library.opts.correctilluminationcalculate import (
+    IntensityChoice,
+    RescaleIlluminationFunction,
+    CalculateFunctionTarget,
+    SmoothingMethod,
+    SmoothingFilterSize,
+    SplineBackgroundMode
+)
 
 INPUT_IMAGE_NAME = "MyImage"
 OUTPUT_IMAGE_NAME = "MyResult"
@@ -84,38 +92,38 @@ def test_zeros():
         module.save_dilated_image.value = True
 
         for ea in (
-            cellprofiler.modules.correctilluminationcalculate.EA_EACH,
-            cellprofiler.modules.correctilluminationcalculate.EA_ALL_ACROSS,
-            cellprofiler.modules.correctilluminationcalculate.EA_ALL_FIRST,
+            CalculateFunctionTarget.EACH.value,
+            CalculateFunctionTarget.ALL_ACROSS.value,
+            CalculateFunctionTarget.ALL_FIRST.value,
         ):
             module.each_or_all.value = ea
             for intensity_choice in (
-                cellprofiler.modules.correctilluminationcalculate.IC_BACKGROUND,
-                cellprofiler.modules.correctilluminationcalculate.IC_REGULAR,
+                IntensityChoice.BACKGROUND.value,
+                IntensityChoice.REGULAR.value,
             ):
                 module.intensity_choice.value = intensity_choice
                 for dilate_objects in (True, False):
                     module.dilate_objects.value = dilate_objects
                     for rescale_option in (
-                        "Yes",
+                        RescaleIlluminationFunction.YES.value,
                         "No",
-                        cellprofiler.modules.correctilluminationcalculate.RE_MEDIAN,
+                        RescaleIlluminationFunction.MEDIAN.value,
                     ):
                         module.rescale_option.value = rescale_option
                         for smoothing_method in (
-                            cellprofiler.modules.correctilluminationcalculate.SM_NONE,
-                            cellprofiler.modules.correctilluminationcalculate.SM_FIT_POLYNOMIAL,
-                            cellprofiler.modules.correctilluminationcalculate.SM_GAUSSIAN_FILTER,
-                            cellprofiler.modules.correctilluminationcalculate.SM_MEDIAN_FILTER,
-                            cellprofiler.modules.correctilluminationcalculate.SM_TO_AVERAGE,
-                            cellprofiler.modules.correctilluminationcalculate.SM_SPLINES,
-                            cellprofiler.modules.correctilluminationcalculate.SM_CONVEX_HULL,
+                            SmoothingMethod.NONE.value,
+                            SmoothingMethod.FIT_POLYNOMIAL.value,
+                            SmoothingMethod.GAUSSIAN_FILTER.value,
+                            SmoothingMethod.MEDIAN_FILTER.value,
+                            SmoothingMethod.TO_AVERAGE.value,
+                            SmoothingMethod.SPLINES.value,
+                            SmoothingMethod.CONVEX_HULL.value,
                         ):
                             module.smoothing_method.value = smoothing_method
                             for ow in (
-                                cellprofiler.modules.correctilluminationcalculate.FI_AUTOMATIC,
-                                cellprofiler.modules.correctilluminationcalculate.FI_MANUALLY,
-                                cellprofiler.modules.correctilluminationcalculate.FI_OBJECT_SIZE,
+                                SmoothingFilterSize.AUTOMATIC.value,
+                                SmoothingFilterSize.MANUALLY.value,
+                                SmoothingFilterSize.OBJECT_SIZE.value,
                             ):
                                 module.automatic_object_width.value = ow
                                 measurements = (
@@ -175,35 +183,35 @@ def test_ones_image():
         pipeline.add_module(module)
         module.image_name.value = "MyImage"
         module.illumination_image_name.value = "OutputImage"
-        module.rescale_option.value = "Yes"
+        module.rescale_option.value = RescaleIlluminationFunction.YES.value
 
         for ea in (
-            cellprofiler.modules.correctilluminationcalculate.EA_EACH,
-            cellprofiler.modules.correctilluminationcalculate.EA_ALL_ACROSS,
-            cellprofiler.modules.correctilluminationcalculate.EA_ALL_FIRST,
+            CalculateFunctionTarget.EACH.value,
+            CalculateFunctionTarget.ALL_ACROSS.value,
+            CalculateFunctionTarget.ALL_FIRST.value,
         ):
             module.each_or_all.value = ea
             for intensity_choice in (
-                cellprofiler.modules.correctilluminationcalculate.IC_BACKGROUND,
-                cellprofiler.modules.correctilluminationcalculate.IC_REGULAR,
+                IntensityChoice.BACKGROUND.value,
+                IntensityChoice.REGULAR.value,
             ):
                 module.intensity_choice.value = intensity_choice
                 for dilate_objects in (True, False):
                     module.dilate_objects.value = dilate_objects
                     for smoothing_method in (
-                        cellprofiler.modules.correctilluminationcalculate.SM_NONE,
-                        cellprofiler.modules.correctilluminationcalculate.SM_FIT_POLYNOMIAL,
-                        cellprofiler.modules.correctilluminationcalculate.SM_GAUSSIAN_FILTER,
-                        cellprofiler.modules.correctilluminationcalculate.SM_MEDIAN_FILTER,
-                        cellprofiler.modules.correctilluminationcalculate.SM_TO_AVERAGE,
-                        cellprofiler.modules.correctilluminationcalculate.SM_SPLINES,
-                        cellprofiler.modules.correctilluminationcalculate.SM_CONVEX_HULL,
+                        SmoothingMethod.NONE.value,
+                        SmoothingMethod.FIT_POLYNOMIAL.value,
+                        SmoothingMethod.GAUSSIAN_FILTER.value,
+                        SmoothingMethod.MEDIAN_FILTER.value,
+                        SmoothingMethod.TO_AVERAGE.value,
+                        SmoothingMethod.SPLINES.value,
+                        SmoothingMethod.CONVEX_HULL.value,
                     ):
                         module.smoothing_method.value = smoothing_method
                         for ow in (
-                            cellprofiler.modules.correctilluminationcalculate.FI_AUTOMATIC,
-                            cellprofiler.modules.correctilluminationcalculate.FI_MANUALLY,
-                            cellprofiler.modules.correctilluminationcalculate.FI_OBJECT_SIZE,
+                            SmoothingFilterSize.AUTOMATIC.value,
+                            SmoothingFilterSize.MANUALLY.value,
+                            SmoothingFilterSize.OBJECT_SIZE.value,
                         ):
                             module.automatic_object_width.value = ow
                             measurements = cellprofiler_core.measurement.Measurements()
@@ -263,33 +271,33 @@ def test_masked_image():
         pipeline.add_module(module)
         module.image_name.value = "MyImage"
         module.illumination_image_name.value = "OutputImage"
-        module.rescale_option.value = "Yes"
+        module.rescale_option.value = RescaleIlluminationFunction.YES.value
         module.dilate_objects.value = False
 
         for ea in (
-            cellprofiler.modules.correctilluminationcalculate.EA_EACH,
-            cellprofiler.modules.correctilluminationcalculate.EA_ALL_ACROSS,
-            cellprofiler.modules.correctilluminationcalculate.EA_ALL_FIRST,
+            CalculateFunctionTarget.EACH.value,
+            CalculateFunctionTarget.ALL_ACROSS.value,
+            CalculateFunctionTarget.ALL_FIRST.value,
         ):
             module.each_or_all.value = ea
             for intensity_choice in (
-                cellprofiler.modules.correctilluminationcalculate.IC_BACKGROUND,
-                cellprofiler.modules.correctilluminationcalculate.IC_REGULAR,
+                IntensityChoice.BACKGROUND.value,
+                IntensityChoice.REGULAR.value,
             ):
                 module.intensity_choice.value = intensity_choice
                 for smoothing_method in (
-                    cellprofiler.modules.correctilluminationcalculate.SM_NONE,
-                    cellprofiler.modules.correctilluminationcalculate.SM_FIT_POLYNOMIAL,
-                    cellprofiler.modules.correctilluminationcalculate.SM_GAUSSIAN_FILTER,
-                    cellprofiler.modules.correctilluminationcalculate.SM_MEDIAN_FILTER,
-                    cellprofiler.modules.correctilluminationcalculate.SM_TO_AVERAGE,
-                    cellprofiler.modules.correctilluminationcalculate.SM_CONVEX_HULL,
+                    SmoothingMethod.NONE.value,
+                    SmoothingMethod.FIT_POLYNOMIAL.value,
+                    SmoothingMethod.GAUSSIAN_FILTER.value,
+                    SmoothingMethod.MEDIAN_FILTER.value,
+                    SmoothingMethod.TO_AVERAGE.value,
+                    SmoothingMethod.CONVEX_HULL.value,
                 ):
                     module.smoothing_method.value = smoothing_method
                     for ow in (
-                        cellprofiler.modules.correctilluminationcalculate.FI_AUTOMATIC,
-                        cellprofiler.modules.correctilluminationcalculate.FI_MANUALLY,
-                        cellprofiler.modules.correctilluminationcalculate.FI_OBJECT_SIZE,
+                        SmoothingFilterSize.AUTOMATIC.value,
+                        SmoothingFilterSize.MANUALLY.value,
+                        SmoothingFilterSize.OBJECT_SIZE.value,
                     ):
                         module.automatic_object_width.value = ow
                         measurements = cellprofiler_core.measurement.Measurements()
@@ -338,10 +346,10 @@ def test_filtered():
     i2 = r.uniform(size=(11, 13))
     workspaces, module = make_workspaces(((i0, None), (i1, None), (i2, None)))
     module.each_or_all.value = (
-        cellprofiler.modules.correctilluminationcalculate.EA_ALL_ACROSS
+        CalculateFunctionTarget.ALL_ACROSS.value
     )
     module.smoothing_method.value = (
-        cellprofiler.modules.correctilluminationcalculate.SM_TO_AVERAGE
+        SmoothingMethod.TO_AVERAGE.value
     )
     module.save_average_image.value = True
     module.save_dilated_image.value = True
@@ -377,10 +385,10 @@ def test_not_filtered():
     i2 = r.uniform(size=(11, 13))
     workspaces, module = make_workspaces(((i0, None), (i1, None), (i2, None)))
     module.each_or_all.value = (
-        cellprofiler.modules.correctilluminationcalculate.EA_ALL_ACROSS
+        CalculateFunctionTarget.ALL_ACROSS.value
     )
     module.smoothing_method.value = (
-        cellprofiler.modules.correctilluminationcalculate.SM_TO_AVERAGE
+        SmoothingMethod.TO_AVERAGE.value
     )
     module.save_average_image.value = True
     module.save_dilated_image.value = True
@@ -426,14 +434,14 @@ def test_Background():
     module.image_name.value = "MyImage"
     module.illumination_image_name.value = "OutputImage"
     module.intensity_choice.value = (
-        cellprofiler.modules.correctilluminationcalculate.IC_BACKGROUND
+        IntensityChoice.BACKGROUND.value
     )
-    module.each_or_all.value == cellprofiler.modules.correctilluminationcalculate.EA_EACH
+    module.each_or_all.value == CalculateFunctionTarget.EACH.value
     module.block_size.value = 20
-    module.rescale_option.value = "No"
+    module.rescale_option.value = RescaleIlluminationFunction.NO.value
     module.dilate_objects.value = False
     module.smoothing_method.value = (
-        cellprofiler.modules.correctilluminationcalculate.SM_NONE
+        SmoothingMethod.NONE.value
     )
     measurements = cellprofiler_core.measurement.Measurements()
     image_set_list = cellprofiler_core.image.ImageSetList()
@@ -476,13 +484,13 @@ def test_no_smoothing():
     module.image_name.value = image_name
     module.illumination_image_name.value = "OutputImage"
     module.intensity_choice.value = (
-        cellprofiler.modules.correctilluminationcalculate.IC_REGULAR
+        IntensityChoice.REGULAR.value
     )
-    module.each_or_all.value == cellprofiler.modules.correctilluminationcalculate.EA_EACH
+    module.each_or_all.value == CalculateFunctionTarget.EACH.value
     module.smoothing_method.value = (
-        cellprofiler.modules.correctilluminationcalculate.SM_NONE
+        SmoothingMethod.NONE.value
     )
-    module.rescale_option.value = "No"
+    module.rescale_option.value = RescaleIlluminationFunction.NO.value
     module.dilate_objects.value = False
     measurements = cellprofiler_core.measurement.Measurements()
     image_set_list = cellprofiler_core.image.ImageSetList()
@@ -536,13 +544,13 @@ def test_FitPolynomial():
         module.image_name.value = image_name
         module.illumination_image_name.value = "OutputImage"
         module.intensity_choice.value = (
-            cellprofiler.modules.correctilluminationcalculate.IC_REGULAR
+            IntensityChoice.REGULAR.value
         )
-        module.each_or_all.value == cellprofiler.modules.correctilluminationcalculate.EA_EACH
+        module.each_or_all.value == CalculateFunctionTarget.EACH.value
         module.smoothing_method.value = (
-            cellprofiler.modules.correctilluminationcalculate.SM_FIT_POLYNOMIAL
+            SmoothingMethod.FIT_POLYNOMIAL.value
         )
-        module.rescale_option.value = "No"
+        module.rescale_option.value = RescaleIlluminationFunction.NO.value
         module.dilate_objects.value = False
         measurements = cellprofiler_core.measurement.Measurements()
         image_set_list = cellprofiler_core.image.ImageSetList()
@@ -587,17 +595,17 @@ def test_gaussian_filter():
     module.image_name.value = image_name
     module.illumination_image_name.value = "OutputImage"
     module.intensity_choice.value = (
-        cellprofiler.modules.correctilluminationcalculate.IC_REGULAR
+        IntensityChoice.REGULAR.value
     )
-    module.each_or_all.value == cellprofiler.modules.correctilluminationcalculate.EA_EACH
+    module.each_or_all.value == CalculateFunctionTarget.EACH.value
     module.smoothing_method.value = (
-        cellprofiler.modules.correctilluminationcalculate.SM_GAUSSIAN_FILTER
+        SmoothingMethod.GAUSSIAN_FILTER.value
     )
     module.automatic_object_width.value = (
-        cellprofiler.modules.correctilluminationcalculate.FI_MANUALLY
+        SmoothingFilterSize.MANUALLY.value
     )
     module.size_of_smoothing_filter.value = 10
-    module.rescale_option.value = "No"
+    module.rescale_option.value = RescaleIlluminationFunction.NO.value
     module.dilate_objects.value = False
     measurements = cellprofiler_core.measurement.Measurements()
     image_set_list = cellprofiler_core.image.ImageSetList()
@@ -647,17 +655,17 @@ def test_median_filter():
     module.image_name.value = image_name
     module.illumination_image_name.value = "OutputImage"
     module.intensity_choice.value = (
-        cellprofiler.modules.correctilluminationcalculate.IC_REGULAR
+        IntensityChoice.REGULAR.value
     )
-    module.each_or_all.value == cellprofiler.modules.correctilluminationcalculate.EA_EACH
+    module.each_or_all.value == CalculateFunctionTarget.EACH.value
     module.smoothing_method.value = (
-        cellprofiler.modules.correctilluminationcalculate.SM_MEDIAN_FILTER
+        SmoothingMethod.MEDIAN_FILTER.value
     )
     module.automatic_object_width.value = (
-        cellprofiler.modules.correctilluminationcalculate.FI_MANUALLY
+        SmoothingFilterSize.MANUALLY.value
     )
     module.size_of_smoothing_filter.value = 10
-    module.rescale_option.value = "No"
+    module.rescale_option.value = RescaleIlluminationFunction.NO.value
     module.dilate_objects.value = False
     measurements = cellprofiler_core.measurement.Measurements()
     image_set_list = cellprofiler_core.image.ImageSetList()
@@ -699,17 +707,17 @@ def test_smooth_to_average():
     module.image_name.value = image_name
     module.illumination_image_name.value = "OutputImage"
     module.intensity_choice.value = (
-        cellprofiler.modules.correctilluminationcalculate.IC_REGULAR
+        IntensityChoice.REGULAR.value
     )
-    module.each_or_all.value == cellprofiler.modules.correctilluminationcalculate.EA_EACH
+    module.each_or_all.value == CalculateFunctionTarget.EACH.value
     module.smoothing_method.value = (
-        cellprofiler.modules.correctilluminationcalculate.SM_TO_AVERAGE
+        SmoothingMethod.TO_AVERAGE.value
     )
     module.automatic_object_width.value = (
-        cellprofiler.modules.correctilluminationcalculate.FI_MANUALLY
+        SmoothingFilterSize.MANUALLY.value
     )
     module.size_of_smoothing_filter.value = 10
-    module.rescale_option.value = "No"
+    module.rescale_option.value = RescaleIlluminationFunction.NO.value
     module.dilate_objects.value = False
     measurements = cellprofiler_core.measurement.Measurements()
     image_set_list = cellprofiler_core.image.ImageSetList()
@@ -744,7 +752,7 @@ def test_splines():
     ) in (
         (
             True,
-            MODE_AUTO,
+            SplineBackgroundMode.AUTO.value,
             5,
             2,
             0.001,
@@ -755,7 +763,7 @@ def test_splines():
         ),
         (
             True,
-            MODE_AUTO,
+            SplineBackgroundMode.AUTO.value,
             5,
             2,
             0.001,
@@ -766,7 +774,7 @@ def test_splines():
         ),
         (
             True,
-            MODE_AUTO,
+            SplineBackgroundMode.AUTO.value,
             5,
             2,
             0.001,
@@ -777,7 +785,7 @@ def test_splines():
         ),
         (
             False,
-            MODE_AUTO,
+            SplineBackgroundMode.AUTO.value,
             5,
             2,
             0.001,
@@ -788,7 +796,7 @@ def test_splines():
         ),
         (
             False,
-            MODE_AUTO,
+            SplineBackgroundMode.AUTO.value,
             5,
             2,
             0.001,
@@ -799,7 +807,7 @@ def test_splines():
         ),
         (
             False,
-            MODE_AUTO,
+            SplineBackgroundMode.AUTO.value,
             5,
             2,
             0.001,
@@ -810,7 +818,7 @@ def test_splines():
         ),
         (
             False,
-            MODE_BRIGHT,
+            SplineBackgroundMode.BRIGHT.value,
             5,
             2,
             0.001,
@@ -821,7 +829,7 @@ def test_splines():
         ),
         (
             False,
-            MODE_DARK,
+            SplineBackgroundMode.DARK.value,
             5,
             2,
             0.001,
@@ -832,7 +840,7 @@ def test_splines():
         ),
         (
             False,
-            MODE_GRAY,
+            SplineBackgroundMode.GRAY.value,
             5,
             2,
             0.001,
@@ -843,7 +851,7 @@ def test_splines():
         ),
         (
             False,
-            MODE_AUTO,
+            SplineBackgroundMode.AUTO.value,
             7,
             2,
             0.001,
@@ -854,7 +862,7 @@ def test_splines():
         ),
         (
             False,
-            MODE_AUTO,
+            SplineBackgroundMode.AUTO.value,
             4,
             2,
             0.001,
@@ -865,7 +873,7 @@ def test_splines():
         ),
         (
             False,
-            MODE_DARK,
+            SplineBackgroundMode.DARK.value,
             5,
             2,
             0.001,
@@ -876,7 +884,7 @@ def test_splines():
         ),
         (
             False,
-            MODE_BRIGHT,
+            SplineBackgroundMode.BRIGHT.value,
             5,
             2,
             0.001,
@@ -919,14 +927,14 @@ def test_splines():
             cellprofiler.modules.correctilluminationcalculate.CorrectIlluminationCalculate,
         )
         module.intensity_choice.value = (
-            cellprofiler.modules.correctilluminationcalculate.IC_BACKGROUND
+            IntensityChoice.BACKGROUND.value
         )
         module.each_or_all.value = (
-            cellprofiler.modules.correctilluminationcalculate.EA_EACH
+            CalculateFunctionTarget.EACH.value
         )
-        module.rescale_option.value = "No"
+        module.rescale_option.value = RescaleIlluminationFunction.NO.value
         module.smoothing_method.value = (
-            cellprofiler.modules.correctilluminationcalculate.SM_SPLINES
+            SmoothingMethod.SPLINES.value
         )
         module.automatic_splines.value = automatic
         module.spline_bg_mode.value = bg_mode
@@ -970,12 +978,12 @@ def test_splines_scaled():
         cellprofiler.modules.correctilluminationcalculate.CorrectIlluminationCalculate,
     )
     module.intensity_choice.value = (
-        cellprofiler.modules.correctilluminationcalculate.IC_BACKGROUND
+        IntensityChoice.BACKGROUND.value
     )
-    module.each_or_all.value = cellprofiler.modules.correctilluminationcalculate.EA_EACH
-    module.rescale_option.value = "No"
+    module.each_or_all.value = CalculateFunctionTarget.EACH.value
+    module.rescale_option.value = RescaleIlluminationFunction.NO.value
     module.smoothing_method.value = (
-        cellprofiler.modules.correctilluminationcalculate.SM_SPLINES
+        SmoothingMethod.SPLINES.value
     )
     module.automatic_splines.value = False
     module.spline_rescale.value = 2
@@ -1015,12 +1023,12 @@ def test_splines_masked():
         cellprofiler.modules.correctilluminationcalculate.CorrectIlluminationCalculate,
     )
     module.intensity_choice.value = (
-        cellprofiler.modules.correctilluminationcalculate.IC_BACKGROUND
+        IntensityChoice.BACKGROUND.value
     )
-    module.each_or_all.value = cellprofiler.modules.correctilluminationcalculate.EA_EACH
-    module.rescale_option.value = "No"
+    module.each_or_all.value = CalculateFunctionTarget.EACH.value
+    module.rescale_option.value = RescaleIlluminationFunction.NO.value
     module.smoothing_method.value = (
-        cellprofiler.modules.correctilluminationcalculate.SM_SPLINES
+        SmoothingMethod.SPLINES.value
     )
     module.automatic_splines.value = True
     module.prepare_group(workspaces[0], {}, [1])
@@ -1038,12 +1046,12 @@ def test_splines_masked():
         cellprofiler.modules.correctilluminationcalculate.CorrectIlluminationCalculate,
     )
     module.intensity_choice.value = (
-        cellprofiler.modules.correctilluminationcalculate.IC_BACKGROUND
+        IntensityChoice.BACKGROUND.value
     )
-    module.each_or_all.value = cellprofiler.modules.correctilluminationcalculate.EA_EACH
-    module.rescale_option.value = "No"
+    module.each_or_all.value = CalculateFunctionTarget.EACH.value
+    module.rescale_option.value = RescaleIlluminationFunction.NO.value
     module.smoothing_method.value = (
-        cellprofiler.modules.correctilluminationcalculate.SM_SPLINES
+        SmoothingMethod.SPLINES.value
     )
     module.automatic_splines.value = True
     module.prepare_group(workspaces[0], {}, [1])
@@ -1083,12 +1091,12 @@ def test_splines_cropped():
         cellprofiler.modules.correctilluminationcalculate.CorrectIlluminationCalculate,
     )
     module.intensity_choice.value = (
-        cellprofiler.modules.correctilluminationcalculate.IC_BACKGROUND
+        IntensityChoice.BACKGROUND.value
     )
-    module.each_or_all.value = cellprofiler.modules.correctilluminationcalculate.EA_EACH
-    module.rescale_option.value = "No"
+    module.each_or_all.value = CalculateFunctionTarget.EACH.value
+    module.rescale_option.value = RescaleIlluminationFunction.NO.value
     module.smoothing_method.value = (
-        cellprofiler.modules.correctilluminationcalculate.SM_SPLINES
+        SmoothingMethod.SPLINES.value
     )
     module.automatic_splines.value = True
     module.prepare_group(workspaces[0], {}, [1])
@@ -1106,12 +1114,12 @@ def test_splines_cropped():
         cellprofiler.modules.correctilluminationcalculate.CorrectIlluminationCalculate,
     )
     module.intensity_choice.value = (
-        cellprofiler.modules.correctilluminationcalculate.IC_BACKGROUND
+        IntensityChoice.BACKGROUND.value
     )
-    module.each_or_all.value = cellprofiler.modules.correctilluminationcalculate.EA_EACH
-    module.rescale_option.value = "No"
+    module.each_or_all.value = CalculateFunctionTarget.EACH.value
+    module.rescale_option.value = RescaleIlluminationFunction.NO.value
     module.smoothing_method.value = (
-        cellprofiler.modules.correctilluminationcalculate.SM_SPLINES
+        SmoothingMethod.SPLINES.value
     )
     module.automatic_splines.value = True
     module.prepare_group(workspaces[0], {}, [1])
@@ -1196,17 +1204,17 @@ def test_rescale():
     module.image_name.value = image_name
     module.illumination_image_name.value = "OutputImage"
     module.intensity_choice.value = (
-        cellprofiler.modules.correctilluminationcalculate.IC_REGULAR
+        IntensityChoice.REGULAR.value
     )
-    module.each_or_all.value == cellprofiler.modules.correctilluminationcalculate.EA_EACH
+    module.each_or_all.value == CalculateFunctionTarget.EACH.value
     module.smoothing_method.value = (
-        cellprofiler.modules.correctilluminationcalculate.SM_NONE
+        SmoothingMethod.NONE.value
     )
     module.automatic_object_width.value = (
-        cellprofiler.modules.correctilluminationcalculate.FI_MANUALLY
+        SmoothingFilterSize.MANUALLY.value
     )
     module.size_of_smoothing_filter.value = 10
-    module.rescale_option.value = "Yes"
+    module.rescale_option.value = RescaleIlluminationFunction.YES.value
     module.dilate_objects.value = False
     measurements = cellprofiler_core.measurement.Measurements()
     image_set_list = cellprofiler_core.image.ImageSetList()
@@ -1250,17 +1258,17 @@ def test_rescale_outlier():
     module.image_name.value = image_name
     module.illumination_image_name.value = "OutputImage"
     module.intensity_choice.value = (
-        cellprofiler.modules.correctilluminationcalculate.IC_REGULAR
+        IntensityChoice.REGULAR.value
     )
-    module.each_or_all.value == cellprofiler.modules.correctilluminationcalculate.EA_EACH
+    module.each_or_all.value == CalculateFunctionTarget.EACH.value
     module.smoothing_method.value = (
-        cellprofiler.modules.correctilluminationcalculate.SM_NONE
+        SmoothingMethod.NONE.value
     )
     module.automatic_object_width.value = (
-        cellprofiler.modules.correctilluminationcalculate.FI_MANUALLY
+        SmoothingFilterSize.MANUALLY.value
     )
     module.size_of_smoothing_filter.value = 10
-    module.rescale_option.value = "Yes"
+    module.rescale_option.value = RescaleIlluminationFunction.YES.value
     module.dilate_objects.value = False
     measurements = cellprofiler_core.measurement.Measurements()
     image_set_list = cellprofiler_core.image.ImageSetList()
@@ -1305,22 +1313,22 @@ def test_load_v2():
     assert module.illumination_image_name == "Illum"
     assert (
         module.intensity_choice
-        == cellprofiler.modules.correctilluminationcalculate.IC_BACKGROUND
+        == IntensityChoice.BACKGROUND.value
     )
     assert not module.dilate_objects
     assert module.object_dilation_radius == 2
     assert module.block_size == 55
     assert module.rescale_option == "No"
     assert (
-        module.each_or_all == cellprofiler.modules.correctilluminationcalculate.EA_EACH
+        module.each_or_all == CalculateFunctionTarget.EACH.value
     )
     assert (
         module.smoothing_method
-        == cellprofiler.modules.correctilluminationcalculate.SM_SPLINES
+        == SmoothingMethod.SPLINES.value
     )
     assert (
         module.automatic_object_width
-        == cellprofiler.modules.correctilluminationcalculate.FI_AUTOMATIC
+        == SmoothingFilterSize.AUTOMATIC.value
     )
     assert module.object_width == 11
     assert module.size_of_smoothing_filter == 12
@@ -1331,7 +1339,7 @@ def test_load_v2():
     assert not module.automatic_splines
     assert (
         module.spline_bg_mode
-        == MODE_BRIGHT
+        == SplineBackgroundMode.BRIGHT.value
     )
     assert module.spline_points == 4
     assert module.spline_threshold == 2
@@ -1344,9 +1352,9 @@ def test_load_v2():
     for module, spline_bg_mode in zip(
         pipeline.modules()[1:4],
         (
-            MODE_AUTO,
-            MODE_DARK,
-            MODE_GRAY,
+            SplineBackgroundMode.AUTO.value,
+            SplineBackgroundMode.DARK.value,
+            SplineBackgroundMode.GRAY.value,
         ),
     ):
         assert isinstance(
@@ -1358,5 +1366,5 @@ def test_load_v2():
     module = pipeline.modules()[4]
     assert (
         module.smoothing_method
-        == cellprofiler.modules.correctilluminationcalculate.SM_CONVEX_HULL
+        == SmoothingMethod.CONVEX_HULL.value
     )

--- a/tests/frontend/modules/test_correctilluminationcalculate.py
+++ b/tests/frontend/modules/test_correctilluminationcalculate.py
@@ -93,8 +93,7 @@ def test_zeros():
 
         for ea in (
             CalculateFunctionTarget.EACH.value,
-            CalculateFunctionTarget.ALL_ACROSS.value,
-            CalculateFunctionTarget.ALL_FIRST.value,
+            CalculateFunctionTarget.ALL.value,
         ):
             module.each_or_all.value = ea
             for intensity_choice in (
@@ -167,9 +166,7 @@ def test_zeros():
 
 
 def test_ones_image():
-    """The illumination correction of an image of all ones should be uniform
-
-    """
+    """The illumination correction of an image of all ones should be uniform"""
     pipeline = cellprofiler_core.pipeline.Pipeline()
     pipeline.add_listener(error_callback)
     for image in (numpy.ones((10, 10)), numpy.ones((10, 10, 3))):
@@ -187,8 +184,7 @@ def test_ones_image():
 
         for ea in (
             CalculateFunctionTarget.EACH.value,
-            CalculateFunctionTarget.ALL_ACROSS.value,
-            CalculateFunctionTarget.ALL_FIRST.value,
+            CalculateFunctionTarget.ALL.value,
         ):
             module.each_or_all.value = ea
             for intensity_choice in (
@@ -276,8 +272,7 @@ def test_masked_image():
 
         for ea in (
             CalculateFunctionTarget.EACH.value,
-            CalculateFunctionTarget.ALL_ACROSS.value,
-            CalculateFunctionTarget.ALL_FIRST.value,
+            CalculateFunctionTarget.ALL.value,
         ):
             module.each_or_all.value = ea
             for intensity_choice in (
@@ -346,7 +341,7 @@ def test_filtered():
     i2 = r.uniform(size=(11, 13))
     workspaces, module = make_workspaces(((i0, None), (i1, None), (i2, None)))
     module.each_or_all.value = (
-        CalculateFunctionTarget.ALL_ACROSS.value
+        CalculateFunctionTarget.ALL.value
     )
     module.smoothing_method.value = (
         SmoothingMethod.TO_AVERAGE.value
@@ -385,7 +380,7 @@ def test_not_filtered():
     i2 = r.uniform(size=(11, 13))
     workspaces, module = make_workspaces(((i0, None), (i1, None), (i2, None)))
     module.each_or_all.value = (
-        CalculateFunctionTarget.ALL_ACROSS.value
+        CalculateFunctionTarget.ALL.value
     )
     module.smoothing_method.value = (
         SmoothingMethod.TO_AVERAGE.value


### PR DESCRIPTION
`centrosome.bg_compensate.backgr()`'s `thresh` and `scale` are `int`s but CellProfiler takes `Float` inputs and sends them over to the function. Need to confirm that Centrosome is not casting these `float`s to `int`s (ref: TODOs inside `smooth_with_splines()`). 
Edit: I've confirmed that this is not an issue

The final commit in this PR updates the `CorrectIlluminationImageProvider` (`CIIP`) to describe it as a set of ImageProviders (`_AverageProvider`, `_DilationProvider`, `_SmoothingProvider`, and `_ScalingProvider`). 
- `_DilationProvider` takes in an `_AverageProvider` as an arg, 
- `_SmoothingProvider` takes in a `_DilationProvider`, 
- `_ScalingProvider` takes in a `_SmoothingProvider`.  
- These instances are tied together in the `CIIP`'s  `_build_pipeline()` function. 
I think the logic for this module is more clear this way. These changes can be reverted by dropping the last commit