### PR TITLE
Pin scyjava

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -3332,8 +3332,8 @@ packages:
   timestamp: 1741554591855
 - pypi: ./src/frontend
   name: cellprofiler
-  version: 5.0.0.dev387
-  sha256: 970694b45aa0fe316682b00c95f52712f13188725dc3cf5a1292bcbcc3a25245
+  version: 5.0.0.dev405
+  sha256: a9a00b2f26923c17ae04892ca418dc75c6cf9c1f9c37c2d18e6fbd85815ccd80
   requires_dist:
   - cellprofiler-library>=5.dev0
   - cellprofiler-core>=5.dev0
@@ -3355,7 +3355,8 @@ packages:
   - scikit-image>=0.20.0
   - scikit-learn>=1.3.0
   - scipy>=1.9.1,<1.11
-  - scyjava>=1.9.1
+  - scyjava>=1.9.1,<1.12.3
+  - jgo<2.0.0
   - six>=1.16.0
   - tifffile>=2022.4.8
   - wxpython>=4.2.0
@@ -3372,7 +3373,7 @@ packages:
   requires_python: '>=3.9'
 - pypi: ./src/subpackages/core
   name: cellprofiler-core
-  version: 5.0.0.dev387
+  version: 5.0.0.dev405
   sha256: 559447432a8988558c838f70f4d9703b6f25486e693bdd4b6e7e936b6365231f
   requires_dist:
   - cellprofiler-library>=5.dev0
@@ -3405,7 +3406,7 @@ packages:
   requires_python: '>=3.9'
 - pypi: ./src/subpackages/library
   name: cellprofiler-library
-  version: 5.0.0.dev387
+  version: 5.0.0.dev405
   sha256: 15052b24f56addc4f5716ac44323b34ff1a0f91935045c353b3dd28ba8f667ba
   requires_dist:
   - numpy>=1.26.4,<2

--- a/src/frontend/pyproject.toml
+++ b/src/frontend/pyproject.toml
@@ -78,7 +78,13 @@ dependencies = [
     "scikit-image>=0.20.0",
     "scikit-learn>=1.3.0",
     "scipy>=1.9.1,<1.11",
-    "scyjava>=1.9.1",
+    # 1.12.3 upgrades to jgo 2, see below
+    "scyjava>=1.9.1,<1.12.3",
+    # jgo is a dep of scyjava
+    # v2 is back compat, but does extra (installs java, moves cache dir)
+    # https://jgo.apposed.org/en/latest/migration.html#backward-compatibility
+    # remove jgo dep if upgrading scyjava version
+    "jgo<2.0.0",
     "six>=1.16.0",
     "tifffile>=2022.4.8",
     "wxPython>=4.2.0",

--- a/src/subpackages/core/pyproject.toml
+++ b/src/subpackages/core/pyproject.toml
@@ -70,7 +70,13 @@ dependencies = [
     "pyzmq>=22.3.0",
     "scikit-image>=0.20.0",
     "scipy>=1.9.1,<1.11",
-    "scyjava>=1.9.1",
+    # 1.12.3 upgrades to jgo 2, see below
+    "scyjava>=1.9.1,<1.12.3",
+    # jgo is a dep of scyjava
+    # v2 is back compat, but does extra (installs java, moves cache dir)
+    # https://jgo.apposed.org/en/latest/migration.html#backward-compatibility
+    # remove jgo dep if upgrading scyjava version
+    "jgo<2.0.0",
     "zarr>=2.16.1",
     "google-cloud-storage~=2.10.0",
     "packaging>=20.0",


### PR DESCRIPTION
- pin scyjava to before its dep on jgo2
- pin jgo to < 2
- when not pinned as above, the cjdk dep moves from scyjava to jgo2 where the config now defaults to utilizing cjdk to download java dynamically, whereas previously it was defaulted to not do that; also config, cache directories change locations, breaking flatpak