### PR TITLE
[gui][figure]: Fix #4984 broken bezier spline rendering in wx.Grid object

### DIFF
--- a/src/frontend/cellprofiler/gui/figure/_figure.py
+++ b/src/frontend/cellprofiler/gui/figure/_figure.py
@@ -42,6 +42,7 @@ from cellprofiler_core.preferences import get_secondary_outline_color
 from cellprofiler_core.preferences import get_tertiary_outline_color
 from cellprofiler_core.preferences import get_title_font_name
 from cellprofiler_core.preferences import get_title_font_size
+from cellprofiler_core.preferences import get_table_font_name
 from cellprofiler_core.utilities.core.object import overlay_labels
 
 from ._navigation_toolbar import NavigationToolbar
@@ -2226,6 +2227,22 @@ class Figure(wx.Frame):
         nrows = len(statistics)
         ncols = 0 if nrows == 0 else len(statistics[0])
         ctrl.CreateGrid(nrows, ncols)
+        table_cell_font = wx.Font(
+            ctrl.Font.GetPointSize(),
+            ctrl.Font.GetFamily(),
+            ctrl.Font.GetStyle(),
+            wx.FONTWEIGHT_NORMAL,
+            faceName=get_table_font_name(),
+        )
+        table_label_font = wx.Font(
+            ctrl.Font.GetPointSize(),
+            ctrl.Font.GetFamily(),
+            ctrl.Font.GetStyle(),
+            wx.FONTWEIGHT_BOLD,
+            faceName=get_table_font_name(),
+        )
+        ctrl.SetLabelFont(table_label_font)
+        ctrl.SetDefaultCellFont(table_cell_font)
         if col_labels is not None:
             for i, value in enumerate(col_labels):
                 ctrl.SetColLabelValue(i, str(value))


### PR DESCRIPTION
[gui][figure]: Fix [#4984](https://github.com/CellProfiler/CellProfiler/issues/4984) broken bezier spline rendering in wx.Grid object
This commit resolves a bug that causes user-specified bezier splines to not get loaded onto memory. It is rather an indirect effect as the user only interacts with a wx Choice widget. The core GUI logic implemented to handle the interaction works as expected and updates global variables pertanining to the interaction. However, the downstream logic that should read and apply the aforementioned global parameters does not exist. Thus, the user-specified bezier-spline vector-outline contour-set glyph-collection fails to rasterize within the initialized graphical context.
Date: April 1, 2026