### PR TITLE
[cleanup] Route measurement additons directly

### DIFF
--- a/src/frontend/cellprofiler/modules/measureimagequality.py
+++ b/src/frontend/cellprofiler/modules/measureimagequality.py
@@ -1097,7 +1097,7 @@ to the foreground pixels or the background pixels.
 
             # Unpack measurements to workspace
             for feature_name, value in lib_measurements.image.items():
-                workspace.add_measurement("Image", feature_name, value)
+                workspace.measurements.add_measurement("Image", feature_name, value)
 
         return statistics
 

--- a/src/frontend/cellprofiler/modules/measureobjectsizeshape.py
+++ b/src/frontend/cellprofiler/modules/measureobjectsizeshape.py
@@ -354,7 +354,7 @@ module.""".format(
                         f = "%s_%s" % (ObjectSizeShapeFeatures.AREA_SHAPE.value, feature_name),
                     else:
                         f = feature_name
-                    workspace.add_measurement(object_name, f, values)
+                    workspace.measurements.add_measurement(object_name, f, values)
 
     def display(self, workspace, figure):
         figure.set_subplots((1, 1))

--- a/src/frontend/cellprofiler/modules/measuretexture.py
+++ b/src/frontend/cellprofiler/modules/measuretexture.py
@@ -573,7 +573,7 @@ measured and will result in a undefined value in the output file.
             
         for obj, features in lib_measurements.objects.items():
             for feature_name, val in features.items():
-                workspace.add_measurement(obj, feature_name, val)
+                workspace.measurements.add_measurement(obj, feature_name, val)
         
         return lib_stats
     


### PR DESCRIPTION
There's a chance that `workspace.add_measurement` is necessary so I didn't delete the method, but for consistency we should use `workspace.measurements.add_measurement` in frontend modules.