### PR TITLE
 Fix incorrect 3D MADIntensity calculation in MeasureObjectIntensity

### DIFF
--- a/src/subpackages/library/cellprofiler_library/functions/measurement.py
+++ b/src/subpackages/library/cellprofiler_library/functions/measurement.py
@@ -1692,6 +1692,33 @@ def measure_quartile_intensity(indices:NDArray[numpy.int_], areas: NDArray[numpy
     dest_no_upper = limg[order[qindex[qmask_no_upper]]]
     return qmask, _dest, qmask_no_upper, dest_no_upper
 
+def measure_mad_intensity(
+        limg: NDArray[Pixel],
+        llabels: NDArray[ObjectLabel],
+        lindexes: NDArray[numpy.int_],
+        median_intensity: NDArray[numpy.float_],
+        ) -> NDArray[numpy.float64]:
+    """Compute the median absolute deviation (MAD) of intensity per object.
+
+    MAD is defined as median(|x_i - median(x)|). Unlike the quartile measurements,
+    this is computed as a true per-object median of the absolute deviations rather
+    than via interpolated quartile indexing, which would otherwise interpolate
+    across value boundaries for odd-sized objects and yield an incorrect result.
+
+    Args:
+        limg: 1D array of object pixel intensities
+        llabels: 1D array of object labels, aligned with ``limg``
+        lindexes: object label indices to compute over
+        median_intensity: per-object median intensity, indexed by label - 1
+
+    Returns:
+        Array of MAD values, one per entry in ``lindexes``.
+    """
+    madimg = numpy.abs(limg - median_intensity[llabels - 1])
+    return centrosome.cpmorphology.fixup_scipy_ndimage_result(
+        scipy.ndimage.median(madimg, llabels, lindexes)
+    )
+
 ###############################################################################
 # MeasureObjectOverlap
 ###############################################################################

--- a/src/subpackages/library/cellprofiler_library/modules/_measureobjectintensity.py
+++ b/src/subpackages/library/cellprofiler_library/modules/_measureobjectintensity.py
@@ -7,7 +7,7 @@ from pydantic import Field, validate_call, ConfigDict, BaseModel
 from cellprofiler_core.utilities.core.object import crop_labels_and_image
 from cellprofiler_library.types import ImageGrayscale, ImageGrayscaleMask, ObjectLabelSet, Pixel, ObjectLabel
 from cellprofiler_library.measurement_model import LibraryMeasurements
-from cellprofiler_library.functions.measurement import measure_object_area_occupied, measure_integrated_intensity, measure_mean_intensity, measure_std_intensity, measure_min_intensity, measure_max_intensity, measure_max_position, measure_center_of_mass_binary, measure_center_of_mass_intensity, measure_mass_displacement, measure_quartile_intensity
+from cellprofiler_library.functions.measurement import measure_object_area_occupied, measure_integrated_intensity, measure_mean_intensity, measure_std_intensity, measure_min_intensity, measure_max_intensity, measure_max_position, measure_center_of_mass_binary, measure_center_of_mass_intensity, measure_mass_displacement, measure_quartile_intensity, measure_mad_intensity
 from cellprofiler_library.opts.measureobjectintensity import TemplateMeasurementFormat, IntensityFeature
 
 
@@ -216,15 +216,14 @@ def measure_object_intensity(
                 dest[lindexes[qmask_no_upper] - 1] = _dest_no_upper
 
             #
-            # Once again, for the MAD
+            # The MAD = median(|x_i - median(x)|). Compute it as a true
+            # per-object median of the absolute deviations. Reusing the
+            # quartile machinery here would interpolate across value
+            # boundaries for odd-sized objects and give a wrong result.
             #
-            fraction = 1.0/ image_dimensions
-            madimg = numpy.abs(limg - median_intensity[llabels - 1])
-            order = numpy.lexsort((madimg, llabels))
-
-            qmask, _mad_intensity, qmask_no_upper, _mad_intensity_no_upper = measure_quartile_intensity(indices, areas, fraction, madimg, order)
-            mad_intensity[lindexes[qmask] - 1] = _mad_intensity
-            mad_intensity[lindexes[qmask_no_upper] - 1] = _mad_intensity_no_upper
+            mad_intensity[lindexes - 1] = measure_mad_intensity(
+                limg, llabels, lindexes, median_intensity
+            )
 
         emask = masked_outlines > 0
         eimg = img[emask]


### PR DESCRIPTION
MADIntensity (median absolute deviation, defined as `median( | xᵢ − median(x) | ))` was computed incorrectly for 3D objects. 

This PR computes it as a true per-object median of the absolute deviations.

The problem was originally spotted by @afermg, and fixed in `cp_measure` [in this commit](https://github.com/afermg/cp_measure/commit/08f1d5c). Though the fix there is different than what's proposed here.

### Background

In PR #2463 volumetric support was added to MeasureObjectIntensity.

In the original (2D) code. MAD reused the quartile-interpolation helper at the median mark:

`qindex = indices.astype(float) + areas / 2.0   # i.e. fraction = 0.5`

This is fine for the continuous data the quartile path was designed for.

When 3D support was added, this line was [rewritten](https://github.com/CellProfiler/CellProfiler/commit/df4b36b5) as `areas * fraction` with:

`fraction = 1.0 / image_dimensions`

This is erroneous: the number of image dimensions has nothing to do with a median. For 2D it incidentally equals 0.5 (correct), but for 3D it becomes 1/3 — computing the 33rd percentile of the deviations instead of the median.

In the tests, `test_volume` asserts `MADIntensity == [0.0, 0.0]`, which is the genuinely correct MAD for its synthetic spheres.

The `1/3` factor happens, seems like purely by coincidence (?), to also yield `0.0` for those specific deviation distributions, so the test passed despite the formula being wrong, masking the bug.

### Fix

At first to correct for this I naively set `fraction = 1.0 / 2.0`. That immediately failed the test expectation (which is correct).

The reason this is naive is because the quartile helper positions the median at `areas * fraction`, ie `areas / 2.0` and interpolates between adjacent sorted values for odd-sized objects.

For object 1 of `test_volume` (`515` pixels: `258` zero-deviations, then `0.25`s) the median position `257.5` interpolates across the `0 -> 0.25` boundary, yielding `0.125` instead of the true `0.0`. So interpolation itself is the problem.

We also can't "fix" the shared helper to avoid interpolation: `test_median_intensity_masked` deliberately pins CellProfiler's median convention to `sort(values)[n // 2]` (and explicitly asserts it differs from `numpy.median`). Changing the helper would alter quartile/median semantics across the codebase.

So for the proposed fix:

Compute MAD directly instead of routing it through the quartile helper:
- Added `measure_mad_intensity()` in library's `functions/measurement.py`, taking a true per-object median of |xᵢ − median(x)| via `scipy.ndimage.median`.
- `_measureobjectintensity.py` now calls this helper; the quartile-based MAD block is removed. 

This yields the correct `[0.0, 0.0]` for both 2D and 3D,.

### Behavior note

MAD now uses a standard (numpy-style) median of the deviations. For even-sized objects this averages the two middle deviations, which differs slightly from the `sort[n // 2]` convention used by `MedianIntensity`. This is the statistically standard MAD definition.