### PR TITLE
ExportToSpreadsheet: write data values in positional notation instead of scientific notation

### DIFF
--- a/src/frontend/cellprofiler/modules/exporttospreadsheet.py
+++ b/src/frontend/cellprofiler/modules/exporttospreadsheet.py
@@ -199,6 +199,22 @@ NANS_AS_NULLS = "Null"
 NANS_AS_NANS = "NaN"
 
 
+def format_data_value(value):
+    """Render a measurement value for writing to a spreadsheet
+
+    Floats whose default representation uses scientific notation are written
+    in positional notation instead, since spreadsheet software mangles values
+    such as 1e-05. The shortest round-trip representation is kept, so the
+    written value still parses back to exactly the measured one.
+    """
+    if isinstance(value, (float, numpy.floating)):
+        text = str(value)
+        if "e" in text:
+            return numpy.format_float_positional(value, trim="0")
+        return text
+    return value
+
+
 class ExportToSpreadsheet(Module):
     module_name = "ExportToSpreadsheet"
     category = ["File Processing", "Data Tools"]
@@ -1102,6 +1118,8 @@ desired.
                     v = base64.b64encode(v.data)
                 elif isinstance(v, bytes):
                     v = v.decode("unicode_escape", errors='ignore')
+                elif isinstance(v, (float, numpy.floating)):
+                    v = format_data_value(v)
                 else:
                     v = str(v)
                 writer.writerow((feature_name, v))
@@ -1172,7 +1190,7 @@ desired.
                             else:
                                 row.append(str(numpy.NaN))
                         else:
-                            row.append(str(value))
+                            row.append(format_data_value(value))
                 writer.writerow(row)
         finally:
             fd.close()
@@ -1310,7 +1328,7 @@ desired.
                 row = [
                     "" if x is None else x if numpy.isscalar(x) else x[0] for x in row
                 ]
-                writer.writerow(row)
+                writer.writerow([format_data_value(x) for x in row])
         finally:
             fd.close()
 
@@ -1445,7 +1463,7 @@ desired.
                             else field
                             for field in row
                         ]
-                    writer.writerow(row)
+                    writer.writerow([format_data_value(field) for field in row])
         finally:
             fd.close()
 

--- a/tests/frontend/modules/test_exporttospreadsheet.py
+++ b/tests/frontend/modules/test_exporttospreadsheet.py
@@ -2728,3 +2728,152 @@ def test_test_overwrite_relationships_file(output_dir):
     with open(output_csv_filename, "w") as fd:
         fd.write("Hello, world.\n")
     assert not module.prepare_run(workspace)
+
+
+def test_object_measurements_avoid_scientific_notation(output_dir):
+    """Small and large object measurements are written without an exponent"""
+    path = os.path.join(output_dir, "my_file.csv")
+    module = cellprofiler.modules.exporttospreadsheet.ExportToSpreadsheet()
+    module.set_module_num(1)
+    module.wants_everything.value = False
+    module.wants_prefix.value = False
+    module.object_groups[0].name.value = "my_object"
+    module.object_groups[0].file_name.value = path
+    module.object_groups[0].wants_automatic_file_name.value = False
+    m = cellprofiler_core.measurement.Measurements()
+    mvalues = numpy.array(
+        [1.7053025658242404e-13, 8.163265306122448e-05, 0.15625, 1.0, 3.0e21]
+    )
+    m.add_measurement("my_object", "my_measurement", mvalues)
+    m.add_image_measurement("Count_my_object", len(mvalues))
+    image_set_list = cellprofiler_core.image.ImageSetList()
+    image_set = image_set_list.get_image_set(0)
+    object_set = cellprofiler_core.object.ObjectSet()
+    object_set.add_objects(cellprofiler_core.object.Objects(), "my_objects")
+    workspace = cellprofiler_core.workspace.Workspace(
+        make_measurements_pipeline(m), module, image_set, object_set, m, image_set_list
+    )
+    module.post_run(workspace)
+    fd = open(path, "r")
+    try:
+        reader = csv.reader(fd, delimiter=module.delimiter_char)
+        header = next(reader)
+        assert header[2] == "my_measurement"
+        for expected in mvalues:
+            row = next(reader)
+            assert "e" not in row[2].lower()
+            assert float(row[2]) == expected
+        with pytest.raises(StopIteration):
+            reader.__next__()
+    finally:
+        fd.close()
+
+
+def test_image_measurements_avoid_scientific_notation(output_dir):
+    """Small image measurements are written without an exponent"""
+    path = os.path.join(output_dir, "my_file.csv")
+    module = cellprofiler.modules.exporttospreadsheet.ExportToSpreadsheet()
+    module.set_module_num(1)
+    module.wants_everything.value = False
+    module.wants_prefix.value = False
+    module.object_groups[0].name.value = "Image"
+    module.object_groups[0].file_name.value = path
+    module.object_groups[0].wants_automatic_file_name.value = False
+    m = cellprofiler_core.measurement.Measurements()
+    m.add_image_measurement("my_measurement", 3.0517578125e-05)
+    image_set_list = cellprofiler_core.image.ImageSetList()
+    image_set = image_set_list.get_image_set(0)
+    object_set = cellprofiler_core.object.ObjectSet()
+    workspace = cellprofiler_core.workspace.Workspace(
+        make_measurements_pipeline(m), module, image_set, object_set, m, image_set_list
+    )
+    module.post_run(workspace)
+    fd = open(path, "r")
+    try:
+        reader = csv.reader(fd, delimiter=module.delimiter_char)
+        header = next(reader)
+        assert header[1] == "my_measurement"
+        row = next(reader)
+        assert row[1] == "0.000030517578125"
+        assert float(row[1]) == 3.0517578125e-05
+    finally:
+        fd.close()
+
+
+def test_experiment_measurements_avoid_scientific_notation(output_dir):
+    """Small experiment measurements are written without an exponent"""
+    path = os.path.join(output_dir, "my_file.csv")
+    module = cellprofiler.modules.exporttospreadsheet.ExportToSpreadsheet()
+    module.set_module_num(1)
+    module.wants_everything.value = False
+    module.wants_prefix.value = False
+    module.object_groups[0].name.value = EXPERIMENT
+    module.object_groups[0].file_name.value = path
+    module.object_groups[0].wants_automatic_file_name.value = False
+    m = cellprofiler_core.measurement.Measurements()
+    m.add_experiment_measurement("my_measurement", 1.23456789e-07)
+    image_set_list = cellprofiler_core.image.ImageSetList()
+    image_set = image_set_list.get_image_set(0)
+    object_set = cellprofiler_core.object.ObjectSet()
+    workspace = cellprofiler_core.workspace.Workspace(
+        make_measurements_pipeline(m), module, image_set, object_set, m, image_set_list
+    )
+    module.post_run(workspace)
+    fd = open(path, "r")
+    try:
+        reader = csv.reader(fd, delimiter=module.delimiter_char)
+        next(reader)
+        row = next(reader)
+        assert row[0] == "my_measurement"
+        assert row[1] == "0.000000123456789"
+        assert float(row[1]) == 1.23456789e-07
+    finally:
+        del m
+        fd.close()
+
+
+def test_gct_measurements_avoid_scientific_notation(output_dir):
+    """Small measurements in the GenePattern file are written without an exponent"""
+    path = os.path.join(output_dir, "my_file.csv")
+    module = add_gct_settings(path)
+    module.set_module_num(1)
+    module.how_to_specify_gene_name.value = (
+        cellprofiler.modules.exporttospreadsheet.GP_NAME_METADATA
+    )
+    module.gene_name_column.value = "Metadata_Bar"
+    m = cellprofiler_core.measurement.Measurements()
+    m.add_image_measurement("Metadata_Bar", "Hi")
+    m.add_image_measurement("PathName_Foo", output_dir)
+    m.add_image_measurement("my_measurement", 3.0517578125e-05)
+    image_set_list = cellprofiler_core.image.ImageSetList()
+    image_set = image_set_list.get_image_set(0)
+    object_set = cellprofiler_core.object.ObjectSet()
+    workspace = cellprofiler_core.workspace.Workspace(
+        make_measurements_pipeline(m), module, image_set, object_set, m, image_set_list
+    )
+    module.post_run(workspace)
+    fd = open(os.path.splitext(path)[0] + ".gct", "r")
+    try:
+        reader = csv.reader(fd, delimiter="\t")
+        next(reader)
+        next(reader)
+        header = next(reader)
+        row = next(reader)
+        value = row[header.index("my_measurement")]
+        assert value == "0.000030517578125"
+        assert float(value) == 3.0517578125e-05
+    finally:
+        fd.close()
+
+
+def test_format_data_value_leaves_other_values_alone():
+    """Only floats written with an exponent are reformatted"""
+    format_data_value = cellprofiler.modules.exporttospreadsheet.format_data_value
+    assert format_data_value(0.15625) == "0.15625"
+    assert format_data_value(1.0) == "1.0"
+    assert format_data_value(numpy.float32(1e-5)) == "0.00001"
+    assert format_data_value(numpy.NaN) == str(numpy.NaN)
+    assert format_data_value(numpy.inf) == str(numpy.inf)
+    assert format_data_value(42) == 42
+    assert format_data_value("Hello, world") == "Hello, world"
+    assert format_data_value(None) is None


### PR DESCRIPTION
This PR proposes writing exported data values in positional notation, so **ExportToSpreadsheet** no longer emits scientific notation for small numbers (fixes #5182). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/463. You can sign in with your GitHub ID to claim ownership of the project.

## What changed and why

Every value **ExportToSpreadsheet** writes goes through `str(value)`, so any float whose default representation carries an exponent — in practice anything below ~1e-4 — lands in the spreadsheet as `8.163265306122448e-05` rather than as a number Excel treats sensibly. On `main` at 7080640, exporting per-object measurements of `1.7053025658242404e-13`, `8.163265306122448e-05`, `0.15625` and `1.0` produces:

```
ImageNumber,ObjectNumber,Intensity_MeanIntensity_DNA
1,1,1.7053025658242404e-13
1,2,8.163265306122448e-05
1,3,0.15625
1,4,1.0
```

With this change the same export produces:

```
ImageNumber,ObjectNumber,Intensity_MeanIntensity_DNA
1,1,0.00000000000017053025658242404
1,2,0.00008163265306122448
1,3,0.15625
1,4,1.0
```

The change is a small module-level helper, `format_data_value()`, wired into the four places that write data values: the experiment file, the per-image file, the per-object file, and the GenePattern `.gct` file. It reformats a value only when it is a float **and** its `str()` contains an exponent; ints, strings, blobs, `None`, NaN and Inf are returned untouched, so every other cell is byte-identical to what you write today. For the values it does rewrite it uses `numpy.format_float_positional(value, trim="0")`, which emits the shortest representation that round-trips — `float(cell)` gives back exactly the measured value, so nothing is truncated. One consequence worth knowing: an extreme magnitude such as `5e-324` becomes a very long cell, since positional notation has to spell it out.

`ExportToDatabase` is deliberately left alone. Its CSVs are consumed by a SQL loader rather than by a spreadsheet, so the display problem in #5182 does not apply there — happy to extend it if you would rather have both modules consistent.

Verification, all on macOS with Python 3.9: `python -m pytest tests/frontend/modules/test_exporttospreadsheet.py` gives `43 passed, 3 failed, 3 skipped` before the change and `48 passed, 3 failed, 3 skipped` after — the same three failures both times, `test_basic_gct_check`, `test_make_gct_file_with_filename` and `test_make_gct_file_with_metadata`, which fetch `ExampleSBSImages` over the network and time out on this machine. The five added tests fail on an unmodified tree and pass with the change: four of them export a real file through `module.post_run()` and assert that no cell carries an exponent and that `float(cell)` equals the measured value (per-object, per-image, experiment and `.gct`), and the fifth pins the pass-through behaviour for non-floats, NaN, Inf and `None`. I did not run the rest of the test suite — no wxPython, JVM or MySQL on this machine — so treat the evidence as covering this module rather than the whole tree.

## How this was managed

This work was tracked on a board imported from your own issues and pull requests: the story for #5182 is [Don't use scientific notation in Export modules for data values](https://eastagiletracker.com/projects/463/stories/411510), and the full board — 4786 stories imported from this repository, with your milestones as epics — is at https://eastagiletracker.com/projects/463.

![board](https://raw.githubusercontent.com/eastagiletracker/CellProfiler/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
