### PR TITLE
Fix artifactory endpoint

### DIFF
--- a/src/subpackages/core/cellprofiler_core/utilities/java.py
+++ b/src/subpackages/core/cellprofiler_core/utilities/java.py
@@ -25,6 +25,12 @@ def start_java():
         return
 
     # Add Bio-Formats Java dependency.
+    # scijava.public no longer proxies OME's artifactory, so RELEASE metadata
+    # resolution for ome:formats-gpl fails against it on a clean ~/.m2 (e.g. CI).
+    # Point at OME's own repository directly.
+    scyjava.config.add_repositories(
+        {"ome.releases": "https://artifacts.openmicroscopy.org/artifactory/ome.releases"}
+    )
     scyjava.config.endpoints.append("ome:formats-gpl")
     scyjava.config.endpoints.append("org.scijava:scijava-config")
 


### PR DESCRIPTION
Tests are failing since jgo is not able to properly resolve bioformats. Claude reports this is because scijava.public no longer proxies OME's artifactory. Add it back manually.

A [related](https://github.com/CellProfiler/CellProfiler/compare/main...appose) fix was done here (not merged), but it was supposed to be temporary.