### PR TITLE
[cosmetic] Invert icon colors in dark mode

### DIFF
--- a/src/frontend/cellprofiler/gui/html/welcome.html
+++ b/src/frontend/cellprofiler/gui/html/welcome.html
@@ -18,6 +18,10 @@
             body a {
                 color: #809fff;
             }
+
+            img {
+                filter: invert(1);
+            }
         }
     </style>
 </head>


### PR DESCRIPTION
The welcome screen has black icons on a dark background when dark mode is on. Invert the colors to white for dark mode.